### PR TITLE
Centralise and document(ish) CLI commands

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -1,60 +1,15 @@
-## Rule violation
+# Generator
 
-We have a clear idea of how to generate test data that satisfies all rules, but additionally we wish to generate test data which _violates_ rules.  
-i.e. data which mostly complies with the rule, but deliberately fails to meet one constraint/sub-constraint.  
-This helps you test "would my program notice when you submit invalid data".
+A command-line tool for generating data according to [profiles](../docs/Profiles.md).
 
-Each rule has one constraint (multiple constraints may be composed using AND(A, B, ...)).  
-The constraint upon that rule must be one of the following:
+## Command line
 
-```
-a // atomic constraint. supports negation.
-A // any of [OR, AND, atomic constraint]
-OR(A, B, ...)  // exactly one of these constraints applies
-AND(A, B, ...) // all of these constraints apply
-```
+The command line has two commands. Usage instructions for a command can be requested by calling it without arguments - eg, `dg generate`.
 
-So, consider this constraint, which describes "rule #1":
+### `generate`
 
-```
-  Country = US
-OR
-    Country = UK
-  AND
-    x = 5
-```
+Generates data to a specified endpoint.
 
-We can use `😧(X)` to generate ways to violate constraint X.
+### `visualise`
 
-```
-😧(a) = ¬a
-😧(AND(A, B)) = 😧(A), B
-               = A, 😧(B)
-               = 😧(A), 😧(B) // bonus (every possible combination that fails it)
-😧(OR(A, B)) = 😧(A), 😧(B)
-
-// you may not need to implement these, depending on what guarantees you have on your input
-😧(AND(A, B, C)) = 😧(AND(AND(A, B), C))
-😧(OR(A, B, C)) = 😧(OR(OR(A, B), C))
-```
-
-Currently our plan is to ignore the "bonus" solution to the violation of `AND()`, because tests are more useful if they change fewer things.
-
-### If, If/else
-
-```
-  IF (Country == US)
-    City IN ['Boston', 'Super Boston']
-AND
-    Currency = USD
-  IFELSE(Country == US)
-    International = "true"
-```
-
-Keep the precondition true, but violate the consequences.
-
-```
-😧(IF(A, B)) = IF(A, 😧(B))
-😧(IFELSE(A, B, C)) = IFELSE(A, 😧(B), C)
-                    = IFELSE(A, B, 😧(C))
-```
+Generates a [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language))-compliant representation of the decision tree, for manual inspection.

--- a/generator/src/main/java/com/scottlogic/deg/generator/App.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/App.java
@@ -1,0 +1,25 @@
+package com.scottlogic.deg.generator;
+
+import picocli.CommandLine;
+
+import java.util.stream.Collectors;
+
+@CommandLine.Command(name = "dg")
+public class App implements Runnable {
+    private static final CommandLine picoCliCommandLine = new CommandLine(new App())
+        .addSubcommand("generate", new Generate())
+        .addSubcommand("visualise", new Visualise());
+
+    public static void main(String[] args) {
+        picoCliCommandLine.parseWithHandler(
+            new CommandLine.RunLast(), // the base command (ie, this class) is always identified as a possible handler. RunLast picks the most specific handler
+            args);
+    }
+
+    @Override
+    public void run() {
+        String commandListString = picoCliCommandLine.getSubcommands().keySet().stream().sorted().collect(Collectors.joining(", "));
+
+        System.err.println("Valid commands: " + commandListString);
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/Generate.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Generate.java
@@ -8,10 +8,12 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Path;
 
-@CommandLine.Command(description = "Generates data using a profile file.",
-    name = "generate", mixinStandardHelpOptions = true, version = "1.0")
+@CommandLine.Command(
+    name = "generate",
+    description = "Generates data using a profile file.",
+    mixinStandardHelpOptions = true,
+    version = "1.0")
 public class Generate implements Runnable {
-
     @CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
     private File sourceFile;
 
@@ -23,13 +25,8 @@ public class Generate implements Runnable {
         defaultValue = "Interesting")
     private GenerationConfig.DataGenerationType generationType = GenerationConfig.DataGenerationType.Interesting;
 
-    public static void main(String[] args) throws Exception {
-        CommandLine.run(new Generate(), args);
-    }
-
     @Override
     public void run() {
-
         GenerationConfig config = new GenerationConfig(
             generationType,
             new FieldExhaustiveCombinationStrategy());

--- a/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
@@ -10,19 +10,17 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 
-@picocli.CommandLine.Command(description = "Produces a decision tree in DOT format for the specified profile.",
-    name = "visualise", mixinStandardHelpOptions = true, version = "1.0")
+@picocli.CommandLine.Command(
+    name = "visualise",
+    description = "Produces a decision tree in DOT format for the specified profile.",
+    mixinStandardHelpOptions = true,
+    version = "1.0")
 public class Visualise implements Runnable {
-
     @picocli.CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
     private File sourceFile;
 
     @picocli.CommandLine.Parameters(index = "1", description = "The directory into which generated data should be saved.")
     private Path outputDir;
-
-    public static void main(String[] args) throws Exception {
-        picocli.CommandLine.run(new Visualise(), args);
-    }
 
     @Override
     public void run() {


### PR DESCRIPTION
Removed old content of `generator/README.md`, centralised CLI (eg, the program returns to only having one `main` method, so the user has to specify a subcommand on the command line), added really basic docs.