### PR TITLE
Profile Validator - In progress

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/Profile.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Profile.java
@@ -1,9 +1,11 @@
 package com.scottlogic.deg.generator;
 
+import com.scottlogic.deg.generator.inputs.visitor.IProfileVisitor;
+
 import java.util.Collection;
 import java.util.List;
 
-public class Profile {
+public class Profile  {
     public final ProfileFields fields;
     public final Collection<Rule> rules;
     public final String description;
@@ -24,5 +26,11 @@ public class Profile {
         this.fields = fields;
         this.rules = rules;
         this.description = description;
+
+
+    }
+
+    public void accept(IProfileVisitor visitor){
+        visitor.visit(rules);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/AndConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/AndConstraint.java
@@ -1,10 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class AndConstraint implements IConstraint
 {
@@ -23,6 +24,11 @@ public class AndConstraint implements IConstraint
         return subConstraints.stream()
             .flatMap(constraint -> constraint.getFields().stream())
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/ConditionalConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/ConditionalConstraint.java
@@ -1,8 +1,12 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,5 +41,10 @@ public class ConditionalConstraint implements IConstraint
         return Stream.of(condition, whenConditionIsTrue, whenConditionIsFalse)
             .flatMap(constraint -> constraint.getFields().stream())
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/ContainsRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/ContainsRegexConstraint.java
@@ -1,12 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ContainsRegexConstraint implements IConstraint {
     public final Field field;
@@ -25,6 +24,11 @@ public class ContainsRegexConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/FormatConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/FormatConstraint.java
@@ -1,9 +1,13 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class FormatConstraint implements IConstraint {
 
@@ -23,6 +27,11 @@ public class FormatConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IConstraint.java
@@ -1,8 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,6 +24,9 @@ public interface IConstraint
 
     Collection<Field> getFields();
 
+
+    List<ValidationAlert> accept(IConstraintValidatorVisitor visitor);
+
     default public IConstraint or(IConstraint... others)
     {
         return new OrConstraint(combine(this, others));
@@ -35,4 +41,6 @@ public interface IConstraint
     {
         return new NotConstraint(this);
     }
+
+
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsAfterConstantDateTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsAfterConstantDateTimeConstraint.java
@@ -1,10 +1,13 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class IsAfterConstantDateTimeConstraint implements IConstraint {
@@ -24,6 +27,11 @@ public class IsAfterConstantDateTimeConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsAfterOrEqualToConstantDateTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsAfterOrEqualToConstantDateTimeConstraint.java
@@ -1,11 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsAfterOrEqualToConstantDateTimeConstraint implements IConstraint {
     public final Field field;
@@ -24,6 +24,11 @@ public class IsAfterOrEqualToConstantDateTimeConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsBeforeConstantDateTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsBeforeConstantDateTimeConstraint.java
@@ -1,10 +1,14 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class IsBeforeConstantDateTimeConstraint implements IConstraint {
@@ -24,6 +28,11 @@ public class IsBeforeConstantDateTimeConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsBeforeOrEqualToConstantDateTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsBeforeOrEqualToConstantDateTimeConstraint.java
@@ -1,11 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsBeforeOrEqualToConstantDateTimeConstraint implements IConstraint {
     public final Field field;
@@ -25,6 +25,12 @@ public class IsBeforeOrEqualToConstantDateTimeConstraint implements IConstraint 
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsEqualToConstantConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsEqualToConstantConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsEqualToConstantConstraint implements IConstraint {
     public final Field field;
@@ -26,6 +26,11 @@ public class IsEqualToConstantConstraint implements IConstraint {
     }
 
     @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
+    @Override
     public boolean equals(Object o){
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -42,4 +47,5 @@ public class IsEqualToConstantConstraint implements IConstraint {
     public String toString() {
         return String.format("`%s` = %s", field.name, requiredValue);
     }
+    
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGranularToConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGranularToConstraint.java
@@ -1,11 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 import com.scottlogic.deg.generator.restrictions.ParsedGranularity;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsGranularToConstraint implements IConstraint {
     public final Field field;
@@ -24,6 +24,11 @@ public class IsGranularToConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGreaterThanConstantConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGreaterThanConstantConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsGreaterThanConstantConstraint implements IConstraint {
     public final Field field;
@@ -23,6 +23,11 @@ public class IsGreaterThanConstantConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGreaterThanOrEqualToConstantConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsGreaterThanOrEqualToConstantConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsGreaterThanOrEqualToConstantConstraint implements IConstraint {
     public final Field field;
@@ -24,6 +24,12 @@ public class IsGreaterThanOrEqualToConstantConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsInSetConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsInSetConstraint.java
@@ -1,11 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class IsInSetConstraint implements IConstraint {
@@ -42,6 +41,12 @@ public class IsInSetConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     public String toString(){
         return String.format(

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsLessThanConstantConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsLessThanConstantConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsLessThanConstantConstraint implements IConstraint {
     public final Field field;
@@ -24,6 +24,12 @@ public class IsLessThanConstantConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsLessThanOrEqualToConstantConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsLessThanOrEqualToConstantConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsLessThanOrEqualToConstantConstraint implements IConstraint {
     public final Field field;
@@ -24,6 +24,12 @@ public class IsLessThanOrEqualToConstantConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsNullConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsNullConstraint.java
@@ -1,11 +1,11 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 import com.scottlogic.deg.generator.restrictions.NullRestrictions;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsNullConstraint implements IConstraint
 {
@@ -30,6 +30,11 @@ public class IsNullConstraint implements IConstraint
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsOfTypeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsOfTypeConstraint.java
@@ -1,9 +1,13 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class IsOfTypeConstraint implements IConstraint {
@@ -29,6 +33,11 @@ public class IsOfTypeConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+       return visitor.visit(this);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsStringLongerThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsStringLongerThanConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsStringLongerThanConstraint implements IConstraint {
     public final Field field;
@@ -23,6 +23,11 @@ public class IsStringLongerThanConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsStringShorterThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/IsStringShorterThanConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class IsStringShorterThanConstraint implements IConstraint {
     public final Field field;
@@ -25,6 +25,12 @@ public class IsStringShorterThanConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/MatchesRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/MatchesRegexConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class MatchesRegexConstraint implements IConstraint {
@@ -25,6 +25,12 @@ public class MatchesRegexConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     @Override
     public boolean equals(Object o){

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/MatchesStandardConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/MatchesStandardConstraint.java
@@ -2,9 +2,13 @@ package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.generation.IStringGenerator;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class MatchesStandardConstraint implements IConstraint {
     public final Field field;
@@ -24,4 +28,10 @@ public class MatchesStandardConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/NotConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/NotConstraint.java
@@ -1,8 +1,12 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 public class NotConstraint implements IConstraint {
@@ -44,6 +48,12 @@ public class NotConstraint implements IConstraint {
     public Collection<Field> getFields() {
         return negatedConstraint.getFields();
     }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
+    }
+
 
     public String toString(){
         return String.format(

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/OrConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/OrConstraint.java
@@ -1,11 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class OrConstraint implements IConstraint {
@@ -32,6 +31,11 @@ public class OrConstraint implements IConstraint {
         return subConstraints.stream()
             .flatMap(constraint -> constraint.getFields().stream())
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/StringHasLengthConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/StringHasLengthConstraint.java
@@ -1,10 +1,10 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 public class StringHasLengthConstraint implements IConstraint {
     public final Field field;
@@ -27,6 +27,11 @@ public class StringHasLengthConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return Collections.singletonList(field);
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/ViolateConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/ViolateConstraint.java
@@ -1,8 +1,12 @@
 package com.scottlogic.deg.generator.constraints;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.inputs.visitor.IConstraintValidatorVisitor;
+import com.scottlogic.deg.generator.inputs.visitor.ValidationAlert;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public class ViolateConstraint implements IConstraint {
     public final IConstraint violatedConstraint;
@@ -19,5 +23,10 @@ public class ViolateConstraint implements IConstraint {
     @Override
     public Collection<Field> getFields() {
         return violatedConstraint.getFields();
+    }
+
+    @Override
+    public List<ValidationAlert> accept(IConstraintValidatorVisitor visitor) {
+        return new ArrayList<>();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/ProfileReader.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/ProfileReader.java
@@ -4,6 +4,7 @@ import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.Rule;
+import com.scottlogic.deg.generator.inputs.visitor.ProfileValidationVisitor;
 import com.scottlogic.deg.schemas.common.ProfileDeserialiser;
 import com.scottlogic.deg.schemas.v3.V3ProfileDTO;
 
@@ -20,7 +21,11 @@ public class ProfileReader {
         byte[] encoded = Files.readAllBytes(filePath);
         String profileJson = new String(encoded, Charset.forName("UTF-8"));
 
-        return this.read(profileJson);
+        Profile profile =  this.read(profileJson);
+
+
+        profile.accept(new ProfileValidationVisitor());
+        return profile;
     }
 
     public Profile read(String profileJson) throws IOException, InvalidProfileException {

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ConstraintRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ConstraintRestrictions.java
@@ -1,0 +1,14 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+class ConstraintRestrictions {
+
+    public final TypeConstraintRestrictions typeConstraintRestrictions;
+    public final TemporalConstraintRestrictions temporalConstraintRestrictions;
+
+    public ConstraintRestrictions(TypeConstraintRestrictions typeConstraintRestrictions,
+                                  TemporalConstraintRestrictions temporalConstraintRestrictions)
+    {
+        this.typeConstraintRestrictions = typeConstraintRestrictions;
+        this.temporalConstraintRestrictions = temporalConstraintRestrictions;
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ConstraintValidationVisitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ConstraintValidationVisitor.java
@@ -1,0 +1,68 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.constraints.IsAfterConstantDateTimeConstraint;
+import com.scottlogic.deg.generator.constraints.IsBeforeConstantDateTimeConstraint;
+import com.scottlogic.deg.generator.constraints.IsOfTypeConstraint;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ConstraintValidationVisitor implements IConstraintValidatorVisitor {
+
+    private Map<String, ConstraintRestrictions> allFieldsState;
+    public ConstraintValidationVisitor() {
+        allFieldsState = new HashMap<>();
+    }
+
+    @Override
+    public List<ValidationAlert> visit(IsOfTypeConstraint constraint) {
+        ConstraintRestrictions state = getFieldState(constraint.field.name);
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        alerts.addAll(state.typeConstraintRestrictions.IsOfType(constraint.field.name, constraint.requiredType));
+
+        return alerts;
+    }
+
+    @Override
+    public List<ValidationAlert> visit(IsAfterConstantDateTimeConstraint constraint) {
+        ConstraintRestrictions state = getFieldState(constraint.field.name);
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        alerts.addAll(state.typeConstraintRestrictions.IsOfType(constraint.field.name, IsOfTypeConstraint.Types.TEMPORAL));
+        alerts.addAll(state.temporalConstraintRestrictions.IsAfter(constraint.field.name, constraint.referenceValue));
+
+
+        return alerts;
+    }
+
+    @Override
+    public List<ValidationAlert> visit(IsBeforeConstantDateTimeConstraint constraint) {
+        ConstraintRestrictions state = getFieldState(constraint.field.name);
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        alerts.addAll(state.typeConstraintRestrictions.IsOfType(constraint.field.name, IsOfTypeConstraint.Types.TEMPORAL));
+        alerts.addAll(state.temporalConstraintRestrictions.IsBefore(constraint.field.name, constraint.referenceValue));
+
+        return alerts;
+    }
+
+    private ConstraintRestrictions getFieldState(String fieldName) {
+        if (allFieldsState.containsKey(fieldName)) {
+            return allFieldsState.get(fieldName);
+        } else {
+            ConstraintRestrictions noRestrictions = new ConstraintRestrictions(
+                new TypeConstraintRestrictions(),
+                new TemporalConstraintRestrictions());
+
+            allFieldsState.put(fieldName, noRestrictions);
+            return noRestrictions;
+        }
+    }
+}
+
+
+
+

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/IConstraintValidatorVisitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/IConstraintValidatorVisitor.java
@@ -1,0 +1,14 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.constraints.IsAfterConstantDateTimeConstraint;
+import com.scottlogic.deg.generator.constraints.IsBeforeConstantDateTimeConstraint;
+import com.scottlogic.deg.generator.constraints.IsOfTypeConstraint;
+
+import java.util.List;
+
+public interface IConstraintValidatorVisitor {
+
+    List<ValidationAlert> visit(IsOfTypeConstraint constraint);
+    List<ValidationAlert> visit(IsAfterConstantDateTimeConstraint constraint);
+    List<ValidationAlert> visit(IsBeforeConstantDateTimeConstraint constraint);
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/IProfileVisitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/IProfileVisitor.java
@@ -1,0 +1,10 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.Rule;
+
+import java.util.Collection;
+
+public interface IProfileVisitor {
+
+    void visit(Collection<Rule> rules);
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ProfileValidationVisitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ProfileValidationVisitor.java
@@ -1,0 +1,44 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.Rule;
+import com.scottlogic.deg.generator.constraints.IConstraint;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProfileValidationVisitor implements IProfileVisitor {
+
+    @Override
+    public void visit(Collection<Rule> rules) {
+        List<IConstraint> constraints = rules.stream()
+            .flatMap(r -> r.constraints.stream())
+            .collect(Collectors.toList());
+
+        ConstraintValidationVisitor constraintValidationVisitor = new ConstraintValidationVisitor();
+
+        List<ValidationAlert> alerts = new ArrayList<>();
+        for(IConstraint constraint : constraints) {
+            alerts.addAll(constraint.accept(constraintValidationVisitor));
+
+        }
+
+        if(alerts.size()>0) {
+            boolean hasErrors = false;
+            for(ValidationAlert alert : alerts) {
+
+                if(alert.getCriticality().equals(ValidationAlert.Criticality.ERROR)){
+                    hasErrors = true;
+                }
+
+                System.out.println(alert.toString());
+            }
+
+            if(hasErrors) {
+                System.out.println("Encountered unrecoverable profile validation errors.");
+                System.exit(1);
+            }
+        }
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/TemporalConstraintRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/TemporalConstraintRestrictions.java
@@ -1,0 +1,57 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+class TemporalConstraintRestrictions {
+
+    public final ValidationAlert.ValidationType ValidationType = ValidationAlert.ValidationType.TEMPORAL;
+
+    private LocalDateTime min;
+    private LocalDateTime max;
+
+    public TemporalConstraintRestrictions(){
+        this.min = LocalDateTime.MIN;
+        this.max = LocalDateTime.MAX;
+    }
+
+    public  List<ValidationAlert> IsAfter(String field, LocalDateTime referenceValue) {
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        if(this.max.compareTo(referenceValue)<0) {
+            alerts.add(new ValidationAlert(
+                ValidationAlert.Criticality.ERROR,
+                String.format("Is after %s is not allowed for this field.", referenceValue.toString()),
+                ValidationType,
+                field ));
+        }
+
+        if(this.min.compareTo(referenceValue)<0) {
+            this.min = referenceValue;
+        }
+
+        return alerts;
+    }
+
+    public  List<ValidationAlert> IsBefore(String field, LocalDateTime referenceValue) {
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        if(this.min.compareTo(referenceValue)>0) {
+            alerts.add(new ValidationAlert(
+                ValidationAlert.Criticality.ERROR,
+                String.format("Is before %s is not allowed for this field.", referenceValue.toString()),
+                ValidationType,
+                field ));
+        }
+
+        if(this.max.compareTo(referenceValue)>0) {
+            this.max = referenceValue;
+        }
+
+        return alerts;
+    }
+
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/TypeConstraintRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/TypeConstraintRestrictions.java
@@ -1,0 +1,38 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+import com.scottlogic.deg.generator.constraints.IsOfTypeConstraint;
+import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+class TypeConstraintRestrictions {
+
+    public final ValidationAlert.ValidationType ValidationType = ValidationAlert.ValidationType.TYPE;
+    private HashSet<IsOfTypeConstraint.Types> allowedTypes;
+
+    public TypeConstraintRestrictions(){
+        this.allowedTypes = new HashSet<>(Arrays.asList(IsOfTypeConstraint.Types.values()));
+    }
+
+    public List<ValidationAlert> IsOfType(String field, IsOfTypeConstraint.Types type) {
+
+        List<ValidationAlert> alerts = new ArrayList<>();
+
+        if (this.allowedTypes.contains(type)) {
+            this.allowedTypes = new HashSet<>(Arrays.asList(type));
+        }
+        else
+        {
+            alerts.add(new ValidationAlert(
+                ValidationAlert.Criticality.ERROR,
+                String.format("Type %s is not allowed for this field.", type.toString()),
+                ValidationType,
+                field ));
+        }
+
+        return alerts;
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ValidationAlert.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/visitor/ValidationAlert.java
@@ -1,0 +1,42 @@
+package com.scottlogic.deg.generator.inputs.visitor;
+
+
+public class ValidationAlert {
+
+    private Criticality criticality;
+    private String message;
+    private ValidationType validationType;
+    private String field;
+
+
+    public ValidationAlert(
+        Criticality criticality,
+        String message,
+        ValidationType validationType,
+        String field){
+
+        this.criticality = criticality;
+        this.message = message;
+        this.validationType = validationType;
+        this.field = field;
+    }
+
+    @Override
+    public String toString(){
+        return String.format("Field %s: %s during %s Validation: %s ", field, criticality.toString(),validationType.toString(), message);
+    }
+
+    public Criticality getCriticality(){
+        return criticality;
+    }
+
+    public enum Criticality {
+        ERROR,
+        WARNING
+    }
+
+    public enum ValidationType {
+        TEMPORAL,
+        TYPE
+    }}
+


### PR DESCRIPTION
Hi, this is still in progress but would love to get your input on how to improve it. 

Currently, it only validates type constraints and isbefore/isafter constraints.

**Example profile to see errors with:**
{
  "schemaVersion" : "v3",
  "fields" : [  {
    "name" : "updated_epoch"
  }],
  "rules" : [ {
    "rule" : "Numeric field updated_epoch rule",
    "constraints" : [ {
      "field" : "updated_epoch",
      "is" : "ofType",
      "value" : "temporal"
    } ,
	 {
      "field" : "updated_epoch",
      "is" : "after",
      "value" : {
	  "date": "2019-09-14T00:00:00.000"
	  }
    } ,
	 {
      "field" : "updated_epoch",
      "is" : "before",
      "value" : {
	  "date": "2017-09-14T00:00:00.000"
	  }
    },
	{
      "field" : "updated_epoch",
      "is" : "ofType",
      "value" : "string"
    } 
     ]
  } ]
}

**Example output:**
Field updated_epoch: ERROR during TEMPORAL Validation: Is before 2017-09-14T00:00 is not allowed for this field. 
Field updated_epoch: ERROR during TYPE Validation: Type STRING is not allowed for this field. 
Encountered unrecoverable profile validation errors.

Process finished with exit code 1


**Summary of workflow:**

The Profile now accepts a IProfileVisitor.
In ProfileReader after we read in the profile (so assuming it can be deserialised correctly), we invoke the Profile accept method with a ProfileValidationVisitor.
The implemntation of the ProfileValidationVisitor is that it creates a ConstraintValidationVisitor and  iterates over all the constraints (which accept a ConstraintValidationVisitor) and collects the validation alerts.
Finally we report the validation alerts and if there was any errors, terminate the process. 
In the ConstriantValidationVisitor, we have a separate method for each constraint type which defines what restrictions need to be applied because of this constraint (e.g. for a type constraint, it is only a type restriction but for example for a temporal constraint (e.g. is after) we need a restriction on the time but also a restriction on the type of the field (as this constraint can only operate on temporal fields). This is so that we can support more complext constraints with several implications.
Finally, we have a ConstraintRestriction class where we keep the restrictions for each field and against which we validate any new constraints.
