### PR TITLE
Test case speed up

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AllOf.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AllOf.feature
@@ -28,7 +28,7 @@ Scenario: Running an 'allOf' request that contains a valid nested anyOf request 
              { "field": "foo", "is": "ofLength", "value": 1 },
              { "field": "foo", "is": "ofLength", "value": 2 }
            ]},
-           { "field": "foo", "is": "containingRegex", "value": "[1-9]{1}" }
+           { "field": "foo", "is": "containingRegex", "value": "[1]{1}" }
          ]}
        """
      Then the following data should be included in what is generated:


### PR DESCRIPTION
Just a tiny change to one test case which was taking 30s to run due to the width of data generated. Constrained it a bit and is now down to 3s.