### PR TITLE
User gets error message if their profile has a partial or full contradiction.

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/NodeMarking.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/NodeMarking.java
@@ -17,6 +17,6 @@
 package com.scottlogic.deg.generator.decisiontree;
 
 public enum NodeMarking {
-    STATICALLY_CONTRADICTORY,
+    CONTRADICTORY,
     VIOLATED
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/visualisation/DecisionTreeVisualisationWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/visualisation/DecisionTreeVisualisationWriter.java
@@ -214,7 +214,7 @@ class NodeVisualiser {
             return "[color=\"green\"]";
         }
 
-        if (node.hasMarking(NodeMarking.STATICALLY_CONTRADICTORY)) {
+        if (node.hasMarking(NodeMarking.CONTRADICTORY)) {
             return "[color=\"red\"]";
         }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DataGeneratorMonitor.java
@@ -22,4 +22,5 @@ public interface DataGeneratorMonitor {
     default void generationStarting() {}
     default void rowEmitted(GeneratedObject row) {}
     default void endGeneration() {}
+    void addLineToPrintAtEndOfGeneration(String line);
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -27,6 +27,7 @@ import com.scottlogic.deg.generator.decisiontree.treepartitioning.TreePartitione
 import com.scottlogic.deg.generator.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.deg.generator.generation.databags.*;
 import com.scottlogic.deg.common.output.GeneratedObject;
+import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
 
 import java.util.stream.Stream;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -22,6 +22,7 @@ import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeOptimiser;
+import com.scottlogic.deg.generator.decisiontree.TreeDecisionNode;
 import com.scottlogic.deg.generator.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.deg.generator.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.deg.generator.generation.databags.*;
@@ -65,7 +66,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
         monitor.generationStarting();
         DecisionTree decisionTree = decisionTreeGenerator.analyse(profile);
 
-        decisionTree = upfrontTreePruner.runUpfrontPrune(decisionTree);
+        decisionTree = upfrontTreePruner.runUpfrontPrune(decisionTree, monitor);
         if (decisionTree.getRootNode() == null) {
             return Stream.empty();
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -22,12 +22,10 @@ import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeOptimiser;
-import com.scottlogic.deg.generator.decisiontree.TreeDecisionNode;
 import com.scottlogic.deg.generator.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.deg.generator.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.deg.generator.generation.databags.*;
 import com.scottlogic.deg.common.output.GeneratedObject;
-import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
 
 import java.util.stream.Stream;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 
 public class MessagePrintingDataGeneratorMonitor extends ReductiveDataGeneratorMonitor {
     public MessagePrintingDataGeneratorMonitor(PrintWriter writer) {
-        this.writer = writer;
+        super(writer);
     }
 
     private void println(String message) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class MessagePrintingDataGeneratorMonitor implements ReductiveDataGeneratorMonitor {
-    private final PrintWriter writer;
-
+public class MessagePrintingDataGeneratorMonitor extends ReductiveDataGeneratorMonitor {
     public MessagePrintingDataGeneratorMonitor(PrintWriter writer) {
         this.writer = writer;
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
@@ -16,6 +16,6 @@
 
 package com.scottlogic.deg.generator.generation;
 
-public class NoopDataGeneratorMonitor implements ReductiveDataGeneratorMonitor {
+public class NoopDataGeneratorMonitor extends ReductiveDataGeneratorMonitor {
     // don't override any of the default no-op implementations from the interface
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
@@ -16,6 +16,11 @@
 
 package com.scottlogic.deg.generator.generation;
 
+import java.io.PrintWriter;
+
 public class NoopDataGeneratorMonitor extends ReductiveDataGeneratorMonitor {
+    public NoopDataGeneratorMonitor() {
+        super(new PrintWriter(System.err));
+    }
     // don't override any of the default no-op implementations from the interface
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
@@ -16,21 +16,26 @@
 
 package com.scottlogic.deg.generator.generation;
 
+import com.google.inject.Inject;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
-import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public abstract class ReductiveDataGeneratorMonitor implements DataGeneratorMonitor {
-    protected PrintWriter writer;
+    final PrintWriter writer;
 
     private List<String> linesToPrintAtEndOfGeneration = new ArrayList<>();
+
+    @Inject
+    ReductiveDataGeneratorMonitor(PrintWriter writer) {
+        this.writer = writer;
+    }
+
     public void endGeneration() {
         linesToPrintAtEndOfGeneration.forEach(writer::println);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
@@ -21,11 +21,25 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-public interface ReductiveDataGeneratorMonitor extends DataGeneratorMonitor {
-    default void fieldFixedToValue(Field field, Object current) {}
-    default void unableToStepFurther(ReductiveState reductiveState) {}
-    default void noValuesForField(ReductiveState reductiveState, Field field) {}
-    default void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField) {}
+public abstract class ReductiveDataGeneratorMonitor implements DataGeneratorMonitor {
+    protected PrintWriter writer;
+
+    private List<String> linesToPrintAtEndOfGeneration = new ArrayList<>();
+    public void endGeneration() {
+        linesToPrintAtEndOfGeneration.forEach(writer::println);
+    }
+
+    public void addLineToPrintAtEndOfGeneration(String line) {
+        linesToPrintAtEndOfGeneration.add(line);
+    }
+    public void fieldFixedToValue(Field field, Object current) {}
+    public void unableToStepFurther(ReductiveState reductiveState) {}
+    public void noValuesForField(ReductiveState reductiveState, Field field) {}
+    public void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField) {}
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
@@ -23,25 +23,19 @@ import com.scottlogic.deg.generator.decisiontree.DecisionNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.decisiontree.NodeMarking;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
-import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.fieldspecs.FieldSpecMerger;
-import com.scottlogic.deg.generator.fieldspecs.RowSpecMerger;
-import com.scottlogic.deg.generator.reducer.ConstraintReducer;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
-import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
+import com.scottlogic.deg.generator.validators.ContradictionDecisionTreeValidator;
 import com.scottlogic.deg.generator.walker.reductive.Merged;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
 
-import java.lang.ref.ReferenceQueue;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class UpfrontTreePruner {
     private ReductiveTreePruner treePruner;
-    private StaticContradictionDecisionTreeValidator validator;
+    private ContradictionDecisionTreeValidator validator;
     @Inject
-    public UpfrontTreePruner(ReductiveTreePruner treePruner, StaticContradictionDecisionTreeValidator validator) {
+    public UpfrontTreePruner(ReductiveTreePruner treePruner, ContradictionDecisionTreeValidator validator) {
         this.treePruner = treePruner;
         this.validator = validator;
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
@@ -51,12 +51,14 @@ public class UpfrontTreePruner {
         DecisionTree markedTree = validator.markContradictions(tree);
 
         if (prunedNode.isContradictory()) {
-            monitor.addLineToPrintAtEndOfGeneration("The provided profile is wholly contradictory.");
-            monitor.addLineToPrintAtEndOfGeneration("No data can be generated.");
+            monitor.addLineToPrintAtEndOfGeneration("");
+            monitor.addLineToPrintAtEndOfGeneration("The provided profile is wholly contradictory!");
+            monitor.addLineToPrintAtEndOfGeneration("No data can be generated!");
             return new DecisionTree(null, tree.getFields());
 
         } else if (isPartiallyContradictory(markedTree.getRootNode())) {
-            monitor.addLineToPrintAtEndOfGeneration("The provided profile is partially contradictory.");
+            monitor.addLineToPrintAtEndOfGeneration("");
+            monitor.addLineToPrintAtEndOfGeneration("The provided profile is partially contradictory!");
             monitor.addLineToPrintAtEndOfGeneration("Run the visualise command for more information.");
             return new DecisionTree(prunedNode.get(), tree.getFields());
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
+public class VelocityMonitor extends ReductiveDataGeneratorMonitor {
     private static final BigDecimal millisecondsInSecond = BigDecimal.valueOf(1_000);
     private static final BigDecimal nanoSecondsInMillisecond = BigDecimal.valueOf(1_000_000);
 
@@ -38,8 +38,6 @@ public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
     private Timer timer;
     private DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private long previousVelocity = 0;
-
-    private final PrintWriter writer;
 
     @Inject
     public VelocityMonitor(PrintWriter writer) {
@@ -103,6 +101,8 @@ public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
         println(
             "\nGeneration finished at: %s",
             timeFormatter.format(finished));
+
+        super.endGeneration();
     }
 
     private void reportVelocity(long rowsSinceLastSample) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
@@ -41,7 +41,7 @@ public class VelocityMonitor extends ReductiveDataGeneratorMonitor {
 
     @Inject
     public VelocityMonitor(PrintWriter writer) {
-        this.writer = writer;
+        super(writer);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
@@ -19,21 +19,18 @@ package com.scottlogic.deg.generator.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import com.scottlogic.deg.generator.config.detail.DataGenerationType;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeOptimiser;
 import com.scottlogic.deg.generator.decisiontree.MaxStringLengthInjectingDecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.deg.generator.generation.*;
-import com.scottlogic.deg.generator.config.detail.DataGenerationType;
 import com.scottlogic.deg.generator.generation.combinationstrategies.CombinationStrategy;
-import com.scottlogic.deg.generator.generation.databags.RowSpecDataBagGenerator;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
 import com.scottlogic.deg.generator.walker.reductive.IterationVisualiser;
 
-import java.io.PrintWriter;
-import java.nio.file.Path;
 import java.time.OffsetDateTime;
 
 /**

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
@@ -24,15 +24,12 @@ import java.io.PrintWriter;
 
 public class MonitorProvider implements Provider<ReductiveDataGeneratorMonitor>  {
     private GenerationConfigSource commandLine;
-    private NoopDataGeneratorMonitor noopDataGeneratorMonitor;
 
     @Inject
     MonitorProvider(
-        GenerationConfigSource commandLine,
-        NoopDataGeneratorMonitor noopDataGeneratorMonitor) {
+        GenerationConfigSource commandLine) {
 
         this.commandLine = commandLine;
-        this.noopDataGeneratorMonitor = noopDataGeneratorMonitor;
     }
 
     @Override
@@ -43,7 +40,7 @@ public class MonitorProvider implements Provider<ReductiveDataGeneratorMonitor> 
                     new PrintWriter(System.err, true));
 
             case QUIET:
-                return this.noopDataGeneratorMonitor;
+                return new NoopDataGeneratorMonitor();
 
             default:
                 return new VelocityMonitor(

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
@@ -29,12 +29,12 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class StaticContradictionDecisionTreeValidator {
+public class ContradictionDecisionTreeValidator {
     private final RowSpecMerger rowSpecMerger;
     private final ConstraintReducer constraintReducer;
 
     @Inject
-    public StaticContradictionDecisionTreeValidator(RowSpecMerger rowSpecMerger, ConstraintReducer constraintReducer){
+    public ContradictionDecisionTreeValidator(RowSpecMerger rowSpecMerger, ConstraintReducer constraintReducer){
         this.rowSpecMerger = rowSpecMerger;
         this.constraintReducer = constraintReducer;
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
@@ -61,4 +61,12 @@ public class AtomicConstraintBuilder {
         constraintNodeBuilder.constraints.add(isNotNullConstraint);
         return constraintNodeBuilder;
     }
+
+    public ConstraintNodeBuilder isSelfContradictory() {
+        IsNullConstraint isNullConstraint = new IsNullConstraint(field, Collections.emptySet());
+        AtomicConstraint isNotNullConstraint = new IsNullConstraint(field, Collections.emptySet()).negate();
+        constraintNodeBuilder.constraints.add(isNullConstraint);
+        constraintNodeBuilder.constraints.add(isNotNullConstraint);
+        return constraintNodeBuilder;
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
@@ -63,8 +63,8 @@ public class AtomicConstraintBuilder {
     }
 
     public ConstraintNodeBuilder isSelfContradictory() {
-        IsNullConstraint isNullConstraint = new IsNullConstraint(field, Collections.emptySet());
-        AtomicConstraint isNotNullConstraint = new IsNullConstraint(field, Collections.emptySet()).negate();
+        IsNullConstraint isNullConstraint = new IsNullConstraint(field);
+        AtomicConstraint isNotNullConstraint = new IsNullConstraint(field).negate();
         constraintNodeBuilder.constraints.add(isNullConstraint);
         constraintNodeBuilder.constraints.add(isNotNullConstraint);
         return constraintNodeBuilder;

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/ConstraintNodeBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/ConstraintNodeBuilder.java
@@ -18,23 +18,23 @@ package com.scottlogic.deg.generator.builders;
 
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.constraints.atomic.AtomicConstraint;
-import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
-import com.scottlogic.deg.generator.decisiontree.DecisionNode;
-import com.scottlogic.deg.generator.decisiontree.TreeConstraintNode;
-import com.scottlogic.deg.generator.decisiontree.TreeDecisionNode;
+import com.scottlogic.deg.generator.decisiontree.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ConstraintNodeBuilder {
     protected List<AtomicConstraint> constraints = new ArrayList<>();
     private List<DecisionNode> decisionNodes = new ArrayList<>();
+    private Set<NodeMarking> markings = new HashSet<>();
 
     protected ConstraintNodeBuilder() {
     }
 
     public ConstraintNode build() {
-        return new TreeConstraintNode(constraints, decisionNodes);
+        return applyNodeMarkings(markings, new TreeConstraintNode(constraints, decisionNodes));
     }
 
     public static ConstraintNodeBuilder constraintNode() {
@@ -52,5 +52,18 @@ public class ConstraintNodeBuilder {
         }
         decisionNodes.add(new TreeDecisionNode(nodes));
         return this;
+    }
+
+    public ConstraintNodeBuilder markNode(NodeMarking marking) {
+        this.markings.add(marking);
+        return this;
+    }
+
+    private ConstraintNode applyNodeMarkings(Set<NodeMarking> markings, ConstraintNode unmarkedNode) {
+        ConstraintNode currentNode = unmarkedNode;
+        for (NodeMarking marking : markings) {
+            currentNode = currentNode.markNode(marking);
+        }
+        return currentNode;
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
@@ -92,7 +92,7 @@ public class DecisionTreeDataGeneratorTests {
             //Arrange
             DecisionTree outputTree = Mockito.mock(DecisionTree.class);
             Mockito.when(outputTree.getRootNode()).thenReturn(null);
-            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree)).thenReturn(outputTree);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree, Mockito.mock(DataGeneratorMonitor.class))).thenReturn(outputTree);
 
             //Act
             Stream<GeneratedObject> actual = generator.generateData(profile);
@@ -106,7 +106,7 @@ public class DecisionTreeDataGeneratorTests {
             //Arrange
             DecisionTree outputTree = Mockito.mock(DecisionTree.class);
             Mockito.when(outputTree.getRootNode()).thenReturn(rootNode);
-            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree)).thenReturn(outputTree);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree, Mockito.mock(DataGeneratorMonitor.class))).thenReturn(outputTree);
 
             //Act
             Stream<GeneratedObject> actual = generator.generateData(profile);

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 
 public class DecisionTreeDataGeneratorTests {
     private DecisionTreeDataGenerator generator;
@@ -92,7 +93,7 @@ public class DecisionTreeDataGeneratorTests {
             //Arrange
             DecisionTree outputTree = Mockito.mock(DecisionTree.class);
             Mockito.when(outputTree.getRootNode()).thenReturn(null);
-            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree, Mockito.mock(DataGeneratorMonitor.class))).thenReturn(outputTree);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(eq(tree), any())).thenReturn(outputTree);
 
             //Act
             Stream<GeneratedObject> actual = generator.generateData(profile);
@@ -106,7 +107,7 @@ public class DecisionTreeDataGeneratorTests {
             //Arrange
             DecisionTree outputTree = Mockito.mock(DecisionTree.class);
             Mockito.when(outputTree.getRootNode()).thenReturn(rootNode);
-            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree, Mockito.mock(DataGeneratorMonitor.class))).thenReturn(outputTree);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(eq(tree), any())).thenReturn(outputTree);
 
             //Act
             Stream<GeneratedObject> actual = generator.generateData(profile);

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
@@ -26,10 +26,9 @@ import com.scottlogic.deg.generator.decisiontree.TreeConstraintNode;
 import com.scottlogic.deg.generator.fieldspecs.*;
 import com.scottlogic.deg.generator.reducer.ConstraintReducer;
 import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
-import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
+import com.scottlogic.deg.generator.validators.ContradictionDecisionTreeValidator;
 import com.scottlogic.deg.generator.walker.reductive.Merged;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.mockito.Mockito;
@@ -47,7 +46,7 @@ class UpfrontTreePrunerTests {
     class unit_tests {
 
         private ReductiveTreePruner reductiveTreePruner = Mockito.mock(ReductiveTreePruner.class);
-        private StaticContradictionDecisionTreeValidator contradictionValidator = Mockito.mock(StaticContradictionDecisionTreeValidator.class);
+        private ContradictionDecisionTreeValidator contradictionValidator = Mockito.mock(ContradictionDecisionTreeValidator.class);
         private UpfrontTreePruner upfrontTreePruner = new UpfrontTreePruner(reductiveTreePruner, contradictionValidator);
         private Field fieldA = new Field("A");
         private Field fieldB = new Field("B");
@@ -134,7 +133,7 @@ class UpfrontTreePrunerTests {
             new FieldSpecMerger(),
             constraintReducer,
             new FieldSpecHelper());
-        private StaticContradictionDecisionTreeValidator validator = new StaticContradictionDecisionTreeValidator(
+        private ContradictionDecisionTreeValidator validator = new ContradictionDecisionTreeValidator(
             new RowSpecMerger(
                 new FieldSpecMerger()),
             constraintReducer);

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/VelocityMonitorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/VelocityMonitorTests.java
@@ -1,0 +1,36 @@
+package com.scottlogic.deg.generator.generation;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+
+public class VelocityMonitorTests {
+    @Test
+    public void endGeneration_printsAllSavedMessages() {
+        //Arrange
+        PrintWriter mockWriter = Mockito.mock(PrintWriter.class);
+        VelocityMonitor monitor = new VelocityMonitor(mockWriter);
+        String firstString = "First St-- HELP I'M TRAPPED IN A PRINT STREAM FACTORY --ring.";
+        String secondString = "Second String";
+        List<String> expectedStrings = Arrays.asList(firstString, secondString);
+
+        //Act
+        monitor.generationStarting();
+        monitor.addLineToPrintAtEndOfGeneration(firstString);
+        monitor.addLineToPrintAtEndOfGeneration(secondString);
+        monitor.endGeneration();
+
+        //Assert
+        ArgumentCaptor<String> args = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockWriter, times(5)).println(args.capture());
+        assertEquals(expectedStrings, args.getAllValues().subList(3, 5));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/VelocityMonitorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/VelocityMonitorTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.deg.generator.generation;
 
 import org.junit.jupiter.api.Test;

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/visualise/VisualiseExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/visualise/VisualiseExecute.java
@@ -90,7 +90,6 @@ public class VisualiseExecute {
 
         StaticContradictionDecisionTreeValidator treeValidator =
             new StaticContradictionDecisionTreeValidator(
-                profile.getFields(),
                 new RowSpecMerger(fieldSpecMerger),
                 new ConstraintReducer(fieldSpecFactory, fieldSpecMerger));
 

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/visualise/VisualiseExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/visualise/VisualiseExecute.java
@@ -17,7 +17,6 @@
 package com.scottlogic.deg.orchestrator.visualise;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
@@ -29,8 +28,7 @@ import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.output.OutputPath;
 import com.scottlogic.deg.profile.reader.ProfileReader;
 import com.scottlogic.deg.generator.reducer.ConstraintReducer;
-import com.scottlogic.deg.generator.validators.ErrorReporter;
-import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
+import com.scottlogic.deg.generator.validators.ContradictionDecisionTreeValidator;
 import com.scottlogic.deg.orchestrator.validator.VisualisationConfigValidator;
 import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidator;
 
@@ -88,8 +86,8 @@ public class VisualiseExecute {
         final String profileBaseName = configSource.getProfileFile().getName()
             .replaceFirst("\\.[^.]+$", "");
 
-        StaticContradictionDecisionTreeValidator treeValidator =
-            new StaticContradictionDecisionTreeValidator(
+        ContradictionDecisionTreeValidator treeValidator =
+            new ContradictionDecisionTreeValidator(
                 new RowSpecMerger(fieldSpecMerger),
                 new ConstraintReducer(fieldSpecFactory, fieldSpecMerger));
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
@@ -17,19 +17,20 @@
 package com.scottlogic.deg.orchestrator.cucumber.testframework.utils;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.name.Names;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
 import com.scottlogic.deg.generator.generation.DataGenerator;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.generation.NoopDataGeneratorMonitor;
+import com.scottlogic.deg.generator.generation.ReductiveDataGeneratorMonitor;
 import com.scottlogic.deg.generator.inputs.validation.MultipleProfileValidator;
+import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
+import com.scottlogic.deg.generator.inputs.validation.TypingRequiredPerFieldValidator;
+import com.scottlogic.deg.generator.validators.ErrorReporter;
+import com.scottlogic.deg.orchestrator.validator.ConfigValidator;
+import com.scottlogic.deg.output.manifest.ManifestWriter;
 import com.scottlogic.deg.output.outputtarget.OutputTargetFactory;
 import com.scottlogic.deg.output.outputtarget.SingleDatasetOutputTarget;
 import com.scottlogic.deg.profile.reader.ProfileReader;
-import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
-import com.scottlogic.deg.generator.inputs.validation.TypingRequiredPerFieldValidator;
-import com.scottlogic.deg.output.manifest.ManifestWriter;
-import com.scottlogic.deg.orchestrator.validator.ConfigValidator;
-import com.scottlogic.deg.generator.validators.ErrorReporter;
 
 import java.util.stream.Stream;
 
@@ -66,6 +67,7 @@ public class CucumberTestModule extends AbstractModule {
         bind(ConfigValidator.class).toInstance(mock(ConfigValidator.class));
         bind(ManifestWriter.class).toInstance(mock(ManifestWriter.class));
         bind(SingleDatasetOutputTarget.class).toInstance(new InMemoryOutputTarget(testState));
+        bind(ReductiveDataGeneratorMonitor.class).to(NoopDataGeneratorMonitor.class);
 
         OutputTargetFactory mockOutputTargetFactory = mock(OutputTargetFactory.class);
         when(mockOutputTargetFactory.create(any())).thenReturn(new InMemoryOutputTarget(testState));


### PR DESCRIPTION
### Description
Full contradictions reported to the user like this:
![image](https://user-images.githubusercontent.com/15249483/60528503-76bfb180-9cec-11e9-8916-6e5cb106fb57.png)

Partial contradictions reported to the user like this:
![image](https://user-images.githubusercontent.com/15249483/60528460-64457800-9cec-11e9-937e-201025b0c804.png)

### Changes
- UpfrontTreePruner updated to use the contradiction checking used in the visualiser to report contradictions.
- Helper function added to monitors to allow easier printing after generation.
- Added unit and integration tests.
- Removed the reference to static contradictions, because all contradictions should be picked up.

### Issue
Meets basic requirements of #896
Meets basic requirements of #383 
