### PR TITLE
Fix - Integers are now outputted to JSON as numbers and not strings.

### DIFF
--- a/output/src/main/java/com/scottlogic/deg/output/writer/json/JsonDataSetWriter.java
+++ b/output/src/main/java/com/scottlogic/deg/output/writer/json/JsonDataSetWriter.java
@@ -72,6 +72,8 @@ class JsonDataSetWriter implements DataSetWriter {
             return null;
         } else if (value instanceof BigDecimal) {
             return value;
+        } else if (value instanceof Integer) {
+            return value;
         } else if (value instanceof String) {
             return value;
         } else if (value instanceof OffsetDateTime) {


### PR DESCRIPTION
### Old
```
[ {
  "field" : "1"
} ]
```
### New
```
[ {
  "field" : 1
} ]
```
### Issue
Resolves #1000
