### PR TITLE
Example profile validation tests

### DIFF
--- a/examples/from-file/profile.json
+++ b/examples/from-file/profile.json
@@ -10,14 +10,10 @@
       "rule": "notnull",
       "constraints": [
         {
-          "allOf": [
-            {
-              "not": {
-                "field": "name",
-                "is": "null"
-              }
-            }
-          ]
+          "not": {
+            "field": "name",
+            "is": "null"
+          }
         }
       ]
     },

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
@@ -1,0 +1,34 @@
+package com.scottlogic.deg.orchestrator.validator;
+
+import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidatorLeadPony;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ProfileValidationTests {
+
+        @TestFactory
+        Collection<DynamicTest> shouldAllValidateWithoutErrors() throws IOException {
+            Collection<DynamicTest> dynamicTests = new ArrayList<>();
+
+            File[] directoriesArray =
+                Paths.get("..", "examples")
+                    .toFile()
+                    .listFiles(File::isDirectory);
+            for (File dir : directoriesArray) {
+                File profileFile = Paths.get(dir.getCanonicalPath(), "profile.json").toFile();
+
+                DynamicTest test = DynamicTest.dynamicTest(dir.getName(), () -> {
+                    new ProfileSchemaValidatorLeadPony().validateProfile(profileFile);
+                });
+
+                dynamicTests.add(test);
+            }
+            return dynamicTests;
+        }
+    }

--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -218,7 +218,7 @@
           "then": {
             "properties": {
               "value": {
-                "enum": ["decimal", "integer", "string", "datetime"]
+                "enum": ["decimal", "integer", "string", "datetime","ISIN","SEDOL","CUSIP","RIC"]
               }
             }
           }

--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -218,7 +218,7 @@
           "then": {
             "properties": {
               "value": {
-                "enum": ["decimal", "integer", "string", "datetime","ISIN","SEDOL","CUSIP","RIC"]
+                "enum": ["decimal", "integer", "string", "datetime","ISIN","SEDOL","CUSIP","RIC","firstname","lastname","fullname"]
               }
             }
           }

--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -168,7 +168,8 @@
             "after",
             "afterOrAt",
             "before",
-            "beforeOrAt"
+            "beforeOrAt",
+            "setFromFile"
           ]
         },
         "value": {}
@@ -372,6 +373,22 @@
             "properties": {
               "value": {
                 "$ref": "#/definitions/numeric"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "setFromFile"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/string"
               }
             }
           }

--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -154,7 +154,6 @@
           "enum": [
             "ofType",
             "equalTo",
-            "aValid",
             "formattedAs",
             "matchingRegex",
             "containingRegex",
@@ -373,23 +372,6 @@
             "properties": {
               "value": {
                 "$ref": "#/definitions/numeric"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "is": {
-                "const": "aValid"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "value": {
-                "const": "ISIN",
-                "default": "ISIN"
               }
             }
           }

--- a/profile/src/test/resources/test-profiles/valid/simple-anyof-allof.json
+++ b/profile/src/test/resources/test-profiles/valid/simple-anyof-allof.json
@@ -26,7 +26,7 @@
             },
             {
               "field": "field1",
-              "is": "aValid",
+              "is": "ofType",
               "value": "ISIN"
             }
           ]

--- a/profile/src/test/resources/test-profiles/valid/simple-data-constraints-nested-2level.json
+++ b/profile/src/test/resources/test-profiles/valid/simple-data-constraints-nested-2level.json
@@ -30,7 +30,7 @@
                 },
                 {
                   "field": "field1",
-                  "is": "aValid",
+                  "is": "ofType",
                   "value": "ISIN"
                 },
                 {
@@ -88,7 +88,7 @@
                 },
                 {
                   "field": "field1",
-                  "is": "aValid",
+                  "is": "ofType",
                   "value": "ISIN"
                 },
                 {
@@ -166,7 +166,7 @@
                 },
                 {
                   "field": "field1",
-                  "is": "aValid",
+                  "is": "ofType",
                   "value": "ISIN"
                 },
                 {
@@ -224,7 +224,7 @@
                 },
                 {
                   "field": "field1",
-                  "is": "aValid",
+                  "is": "ofType",
                   "value": "ISIN"
                 },
                 {

--- a/profile/src/test/resources/test-profiles/valid/simple-data-constraints-nested-7level.json
+++ b/profile/src/test/resources/test-profiles/valid/simple-data-constraints-nested-7level.json
@@ -34,7 +34,7 @@
                       "anyOf": [
                         {
                           "field": "field1",
-                          "is": "aValid",
+                          "is": "ofType",
                           "value": "ISIN"
                         },
                         {
@@ -86,7 +86,7 @@
                                         },
                                         {
                                           "field": "field1",
-                                          "is": "aValid",
+                                          "is": "ofType",
                                           "value": "ISIN"
                                         },
                                         {
@@ -144,7 +144,7 @@
                                         },
                                         {
                                           "field": "field1",
-                                          "is": "aValid",
+                                          "is": "ofType",
                                           "value": "ISIN"
                                         },
                                         {
@@ -206,7 +206,7 @@
                                 },
                                 {
                                   "field": "field1",
-                                  "is": "aValid",
+                                  "is": "ofType",
                                   "value": "ISIN"
                                 },
                                 {
@@ -264,7 +264,7 @@
                                 },
                                 {
                                   "field": "field1",
-                                  "is": "aValid",
+                                  "is": "ofType",
                                   "value": "ISIN"
                                 },
                                 {

--- a/profile/src/test/resources/test-profiles/valid/simple-data-constraints.json
+++ b/profile/src/test/resources/test-profiles/valid/simple-data-constraints.json
@@ -26,7 +26,7 @@
         },
         {
           "field": "field1",
-          "is": "aValid",
+          "is": "ofType",
           "value": "ISIN"
         },
         {

--- a/profile/src/test/resources/test-profiles/valid/simple-not.json
+++ b/profile/src/test/resources/test-profiles/valid/simple-not.json
@@ -40,14 +40,14 @@
         {
           "not": {
             "field": "field1",
-            "is": "aValid",
+            "is": "ofType",
             "value": "ISIN"
           }
         },
         {
           "not": {
             "field": "field1",
-            "is": "aValid",
+            "is": "ofType",
             "value": "ISIN"
           }
         },


### PR DESCRIPTION
### Description
This PR adds a test which checks the example profiles against the schema. This could help us to ensure we keep the schema updated and do not break backwards compatability. At present the schema is not always updated to keep up with new syntax. 

Unlike the old tests this does not run the generator - just the schema validator. This should ensure these tests remain fast and focused. 

### Changes

- New DynamicTest collection of tests added which tests all example profiles.

- Schema updated - `aVaild` removed as acceptable syntax, name/financial code types added, `setFromFile` added

- Small edit to `from-file` example as it had an allOf containing only one constraint which the schema does not see as valid

### Issue
Resolves #1031 
