### PR TITLE
Changed Exception message when "value" is provided instead of "values" - Solved Issue #1049

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/If.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/If.feature
@@ -396,7 +396,7 @@ Feature: Values can be specified by using if, then and else constraints
         "else": { "field": "bar", "is": "equalTo", "value": "c" }
       }
       """
-    Then the profile is invalid because "Field \[bar\]: Couldn't recognise 'values' property, it must not contain 'null'"
+    Then the profile is invalid because "Field \[bar\]: Requires a 'values' property but instead a 'value' property has been added."
     And no data is created
 
   Scenario: Running an if request that contains a contradictory inSet constraint within its else statement should be successful

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
@@ -44,7 +44,7 @@ public class ConstraintReaderHelpers {
     public static Set<Object> getValidatedValues(ConstraintDTO dto) {
         if (dto.values == null) {
             throw new InvalidProfileException(String.format(
-                    "Field[%s]: Requires a \"values\" property but instead a \"value\" property has been added.",
+                    "Field[%s]: Requires a 'values' property but instead a 'value' property has been added.",
                     dto.field));
         }
 

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
@@ -44,8 +44,9 @@ public class ConstraintReaderHelpers {
     public static Set<Object> getValidatedValues(ConstraintDTO dto) {
         if (dto.values == null) {
             throw new InvalidProfileException(String.format(
-                    "Field[%s]: Requires a 'values' property but instead a 'value' property has been added.",
-                    dto.field));
+                "Field [%s]: Requires a 'values' property but instead a 'value' property has been added.",
+                    dto.field
+            ));
         }
 
         Set<Object> mappedValues = new HashSet<>();

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReaderHelpers.java
@@ -43,10 +43,17 @@ public class ConstraintReaderHelpers {
 
     public static Set<Object> getValidatedValues(ConstraintDTO dto) {
         if (dto.values == null) {
-            throw new InvalidProfileException(String.format(
-                "Field [%s]: Couldn't recognise 'values' property, it must not contain 'null'",
-                dto.field
-            ));
+            if(dto.value != null) {
+                throw new InvalidProfileException(String.format(
+                    "Field[%s]: Requires a \"values\" property but instead a \"value\" property has been added.",
+                    dto.field
+                ));
+            } else {
+                throw new InvalidProfileException(String.format(
+                    "Field [%s]: Couldn't recognise 'values' property, it must not contain 'null'",
+                    dto.field
+                ));
+            }
         }
 
         Set<Object> mappedValues = new HashSet<>();


### PR DESCRIPTION
Provided a more meaningful exception message.

### Description
Changed Exception message when "value" is provided instead of "values"

### Changes
In ConstraintReaderHelper.java, I added a new condition to check if `values` is `null` but `value` is `not null` then show a clear message showing that `value` instead of `values` field is provided. If  both are `null` then show the already shown generic message that `values` is `null` while it should should not be.

In If.feature, The test case output message was edited to match the above output message.

There is nothing to be updated in documentation as only an error message string has been changed.

### Additional notes
No Additional Notes

### Issue
Resolves #1049
