### PR TITLE
Fix - Contradiction Reporting

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -145,6 +145,13 @@ public class FieldSpec {
         return getTypeRestrictions() == null || getTypeRestrictions().isTypeAllowed(type);
     }
 
+    public boolean isContradictory() {
+        return
+            !isNullable() &&
+            getTypeRestrictions() != null &&
+            getTypeRestrictions().getAllowedTypes().isEmpty();
+    }
+
     @Override
     public String toString() {
         if (whitelist != null) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -42,6 +42,9 @@ public class FieldSpecMerger {
      * Returning an empty Optional conveys that the fields were unmergeable.
      */
     public Optional<FieldSpec> merge(FieldSpec left, FieldSpec right) {
+        if (left.isContradictory() || right.isContradictory()) {
+            return Optional.empty();
+        }
         if (hasSet(left) && hasSet(right)) {
             return mergeSets(left, right);
         }

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/AtomicConstraintBuilder.java
@@ -20,6 +20,7 @@ import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.common.profile.constraints.atomic.IsInSetConstraint;
 import com.scottlogic.deg.common.profile.constraints.atomic.IsNullConstraint;
+import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -67,6 +68,18 @@ public class AtomicConstraintBuilder {
         AtomicConstraint isNotNullConstraint = new IsNullConstraint(field).negate();
         constraintNodeBuilder.constraints.add(isNullConstraint);
         constraintNodeBuilder.constraints.add(isNotNullConstraint);
+        return constraintNodeBuilder;
+    }
+
+    public ConstraintNodeBuilder isString() {
+        IsOfTypeConstraint typeConstraint = new IsOfTypeConstraint(field, IsOfTypeConstraint.Types.STRING);
+        constraintNodeBuilder.constraints.add(typeConstraint);
+        return constraintNodeBuilder;
+    }
+
+    public ConstraintNodeBuilder isNumeric() {
+        IsOfTypeConstraint typeConstraint = new IsOfTypeConstraint(field, IsOfTypeConstraint.Types.NUMERIC);
+        constraintNodeBuilder.constraints.add(typeConstraint);
         return constraintNodeBuilder;
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/ConstraintNodeBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/ConstraintNodeBuilder.java
@@ -19,6 +19,7 @@ package com.scottlogic.deg.generator.builders;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.decisiontree.*;
+import com.scottlogic.deg.generator.restrictions.TypeRestrictions;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMergerTests.java
@@ -1,0 +1,75 @@
+package com.scottlogic.deg.generator.fieldspecs;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FieldSpecMergerTests {
+    private FieldSpecMerger merger = new FieldSpecMerger();
+
+    @Test
+    void merge_withContradictingLeftFieldSpec_returnsContradiction() {
+        //Arrange
+        FieldSpec contradictingFieldSpec = Mockito.mock(FieldSpec.class);
+        FieldSpec unContradictingFieldSpec = Mockito.mock(FieldSpec.class);
+
+        Mockito.when(contradictingFieldSpec.isContradictory()).thenReturn(true);
+        Mockito.when(unContradictingFieldSpec.isContradictory()).thenReturn(false);
+
+        Mockito.when(unContradictingFieldSpec.getWhitelist()).thenReturn(null);
+        Mockito.when(contradictingFieldSpec.getWhitelist()).thenReturn(null);
+
+        //Act
+        Optional<FieldSpec> actual = merger.merge(contradictingFieldSpec, unContradictingFieldSpec);
+
+        //Assert
+        assertFalse(actual.isPresent());
+    }
+
+    @Test
+    void merge_withContradictingRightFieldSpec_returnsContradiction() {
+        //Arrange
+        FieldSpec contradictingFieldSpec = Mockito.mock(FieldSpec.class);
+        FieldSpec unContradictingFieldSpec = Mockito.mock(FieldSpec.class);
+
+        Mockito.when(contradictingFieldSpec.isContradictory()).thenReturn(true);
+        Mockito.when(unContradictingFieldSpec.isContradictory()).thenReturn(false);
+
+        Mockito.when(unContradictingFieldSpec.getWhitelist()).thenReturn(null);
+        Mockito.when(contradictingFieldSpec.getWhitelist()).thenReturn(null);
+
+        //Act
+        Optional<FieldSpec> actual = merger.merge(unContradictingFieldSpec, contradictingFieldSpec);
+
+        //Assert
+        assertFalse(actual.isPresent());
+    }
+
+    @Test
+    void merge_withUnContradictingFieldSpecs_returnsNoContradiction() {
+        //Arrange
+        FieldSpec contradictingFieldSpec = Mockito.mock(FieldSpec.class);
+        FieldSpec unContradictingFieldSpec = Mockito.mock(FieldSpec.class);
+
+        Mockito.when(contradictingFieldSpec.isContradictory()).thenReturn(false);
+        Mockito.when(unContradictingFieldSpec.isContradictory()).thenReturn(false);
+
+        Mockito.when(unContradictingFieldSpec.getWhitelist()).thenReturn(null);
+        Mockito.when(contradictingFieldSpec.getWhitelist()).thenReturn(null);
+
+        //Act
+        Optional<FieldSpec> actual = merger.merge(unContradictingFieldSpec, contradictingFieldSpec);
+
+        //Assert
+        assertTrue(actual.isPresent());
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -37,6 +37,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class FieldSpecTests {
@@ -399,6 +400,24 @@ class FieldSpecTests {
             .withFormatting("format2");
 
         Assert.assertThat(a, not(equalTo(b)));
+    }
+
+    @Test
+    public void isContradictory_whenFieldSpecContradictory_returnsTrue() {
+        FieldSpec fieldSpec = FieldSpec.Empty
+            .withNotNull()
+            .withTypeRestrictions(new NoAllowedTypesRestriction());
+
+        assertTrue(fieldSpec.isContradictory());
+    }
+
+    @Test
+    public void isContradictory_whenFieldSpecNotContradictory_returnsFalse() {
+        FieldSpec fieldSpec = FieldSpec.Empty
+            .withNotNull()
+            .withTypeRestrictions(new DataTypeRestrictions(Arrays.asList(Types.STRING, Types.NUMERIC)));
+
+        assertFalse(fieldSpec.isContradictory());
     }
 
     @ParameterizedTest()

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
@@ -31,6 +31,7 @@ import com.scottlogic.deg.generator.walker.reductive.Merged;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.*;
@@ -169,7 +170,7 @@ class UpfrontTreePrunerTests {
             upfrontTreePruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
 
         }
@@ -194,7 +195,7 @@ class UpfrontTreePrunerTests {
             upfrontTreePruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
 
         }
@@ -356,8 +357,12 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
-                .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
+            ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(monitor, times(3))
+                .addLineToPrintAtEndOfGeneration(errorMessageCaptor.capture());
+
+            List<String> messages = errorMessageCaptor.getAllValues();
+            assertTrue(messages.stream().anyMatch(partialContradictionSubstring::contains));
         }
 
         @Test
@@ -381,8 +386,12 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
-                .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
+            ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(monitor, times(3))
+                .addLineToPrintAtEndOfGeneration(errorMessageCaptor.capture());
+
+            List<String> messages = errorMessageCaptor.getAllValues();
+            assertTrue(messages.stream().anyMatch(partialContradictionSubstring::contains));
         }
 
 
@@ -412,8 +421,12 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
-                .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
+            ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(monitor, times(3))
+                .addLineToPrintAtEndOfGeneration(errorMessageCaptor.capture());
+
+            List<String> messages = errorMessageCaptor.getAllValues();
+            assertTrue(messages.stream().anyMatch(partialContradictionSubstring::contains));
         }
 
 
@@ -449,8 +462,12 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
-                .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
+            ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(monitor, times(3))
+                .addLineToPrintAtEndOfGeneration(errorMessageCaptor.capture());
+
+            List<String> messages = errorMessageCaptor.getAllValues();
+            assertTrue(messages.stream().anyMatch(partialContradictionSubstring::contains));
         }
 
         @Test
@@ -488,8 +505,12 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
-                .addLineToPrintAtEndOfGeneration(contains(partialContradictionSubstring));
+            ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(monitor, times(3))
+                .addLineToPrintAtEndOfGeneration(errorMessageCaptor.capture());
+
+            List<String> messages = errorMessageCaptor.getAllValues();
+            assertTrue(messages.stream().anyMatch(partialContradictionSubstring::contains));
         }
 
         @Test
@@ -511,7 +532,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
 
@@ -539,7 +560,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
 
@@ -569,7 +590,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
 
@@ -600,7 +621,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
 
@@ -630,7 +651,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
 
@@ -660,7 +681,7 @@ class UpfrontTreePrunerTests {
             upfrontPruner.runUpfrontPrune(tree, monitor);
 
             //Assert
-            Mockito.verify(monitor, times(1))
+            Mockito.verify(monitor)
                 .addLineToPrintAtEndOfGeneration(contains(fullContradictionSubstring));
         }
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/ReductiveTreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/ReductiveTreePrunerTests.java
@@ -23,7 +23,9 @@ import com.scottlogic.deg.generator.decisiontree.TreeConstraintNode;
 import com.scottlogic.deg.generator.fieldspecs.*;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import com.scottlogic.deg.generator.reducer.ConstraintReducer;
+import com.scottlogic.deg.generator.restrictions.NoAllowedTypesRestriction;
 import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.TypeRestrictions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -105,6 +107,30 @@ class ReductiveTreePrunerTests {
         Set<Object> inputWhitelist = new HashSet<>(Arrays.asList("c"));
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (inputWhitelist));
+
+        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+
+        //Act
+        Merged<ConstraintNode> actual = treePruner.pruneConstraintNode(tree, field, fieldValue());
+
+        //Assert
+        Merged<Object> expected = Merged.contradictory();
+        assertThat(actual, sameBeanAs(expected));
+    }
+
+    @Test
+    public void pruneConstraintNode_withContradictoryFieldSpec_returnsContradictory() {
+        //Arrange
+        ConstraintNode tree =
+            constraintNode()
+                .where(field).isNotNull()
+                .where(field).isString()
+                .where(field).isNumeric()
+                .build();
+
+        FieldSpec inputFieldSpec = notNull.withTypeRestrictions(new NoAllowedTypesRestriction());
+        Map<Field, FieldSpec> fieldSpecMap = new HashMap<>();
+        fieldSpecMap.put(field, inputFieldSpec);
 
         when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
 


### PR DESCRIPTION
### Description
Added check to `FieldSpecMerger` so it can pick up a contradiction in a `FieldSpec` of the form 'Not null and no allowed types'. This allows this type of contradiction to be reported to the user.

### Issue
Resolves #1121 