### PR TITLE
Merge types correctly

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
@@ -17,6 +17,7 @@
 package com.scottlogic.deg.generator.restrictions;
 
 import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
+import com.scottlogic.deg.generator.utils.SetUtils;
 
 import java.util.*;
 
@@ -69,14 +70,12 @@ public class DataTypeRestrictions implements TypeRestrictions {
         if (other == ALL_TYPES_PERMITTED)
             return this;
 
-        ArrayList<IsOfTypeConstraint.Types> allowedTypes = new ArrayList<>(this.allowedTypes);
-        allowedTypes.retainAll(other.getAllowedTypes());
+        Set<IsOfTypeConstraint.Types> intersection = SetUtils.intersect(allowedTypes, other.getAllowedTypes());
 
-        if (allowedTypes.isEmpty())
+        if (intersection.isEmpty())
             return null;
 
-
-        return new DataTypeRestrictions(allowedTypes);
+        return new DataTypeRestrictions(intersection);
     }
 
     public Set<IsOfTypeConstraint.Types> getAllowedTypes() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/TypeRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/TypeRestrictionsMerger.java
@@ -28,7 +28,7 @@ public class TypeRestrictionsMerger {
         final TypeRestrictions merged = left.intersect(right);
 
         if (merged == null) {
-            return new MergeResult<>(DataTypeRestrictions.NO_TYPES_PERMITTED);
+            return MergeResult.unsuccessful();
         }
 
         return new MergeResult<>(merged);


### PR DESCRIPTION
### Description
When no types are allowed, make a fieldSpec that can only be null

### Changes
returns unsuccessful merge when types merge is unsuccessful
calls correct intersect method when merging

### Additional notes
Further changes will be made in another PR to update tests and refactor type restrictions

### Issue
Resolves #1121
