### PR TITLE
Reenable schema validation

### DIFF
--- a/docs/GettingStarted/CreatingAProfile.md
+++ b/docs/GettingStarted/CreatingAProfile.md
@@ -66,7 +66,6 @@ These three sections are combined to form the [complete profile](ExampleProfile1
 * FAQs about constraints can be found [here](../FrequentlyAskedQuestions.md)
 * For a larger profile example see [here](../Schema.md)
 * Sometimes constraints can contradict one another, click [here](../../generator/docs/Contradictions.md) to find out what happens in these cases
-* To ensure your profile is able to generate data the validate option can be turned on, find out more [here](../../generator/docs/ProfileValidation.md)
 
 #
 

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -10,8 +10,8 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `--validate-profile`
-   * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details.
+* `--disable-schema-validation`
+   * Generate without first checking profile validity against the schema. This can be used if you believe the schema is incorrectly rejecting your profile.
 * `-o <output-format>`
    * Output the data in the given format, either CSV (default) or JSON.
    * Note that JSON format requires that all data is held in-memory until all data is known, at which point data will be flushed to disk, this could have an impact on memory and/or IO requirements

--- a/docs/Options/ViolateOptions.md
+++ b/docs/Options/ViolateOptions.md
@@ -12,8 +12,8 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `--validate-profile`
-   * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details.
+* `--disable-schema-validation`
+   * Generate without first checking profile validity against the schema. This can be used if you believe the schema is incorrectly rejecting your profile.
 * `-o <output-format>`
    * Output the data in the given format, either CSV (default) or JSON.
    * Note that JSON format requires that all data is held in-memory until all data is known, at which point data will be flushed to disk, this could have an impact on memory and/or IO requirements

--- a/generator/docs/ProfileValidation.md
+++ b/generator/docs/ProfileValidation.md
@@ -12,7 +12,6 @@ The validation checks currently performed include:
 
     Example: A is a string and granularity constraint is applied - granularity constraint can only operate on decimal fields at the moment.
 
-Profile validation is turned off by default (Uses the noop validator). To enable it please pass in parameter: `--validate-profile=true` or `-v=true`. 
 
 The workflow for the profile validator is that it iterates over all the constraints in the profile and for each field it keeps a running collection of restrictions that must be observed in order for the profile to remain valid. When an invalidating constraint is encountered, a validation alert is raised and the restrictions for this field remain unchanged. All validation alerts for all fields will be reported at the end of the process.
 

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateCommandLine.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateCommandLine.java
@@ -86,9 +86,9 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
     boolean overwriteOutputFiles = false;
 
     @CommandLine.Option(
-        names = { "--enable-schema-validation" },
-        description = "Enables schema validation")
-    boolean enableSchemaValidation = false;
+        names = { "--disable-schema-validation" },
+        description = "Disables schema validation")
+    boolean disableSchemaValidation = false;
 
     @CommandLine.Option(names = {"-t", "--generation-type"},
         description = "Determines the type of data generation performed (${COMPLETION-CANDIDATES})",
@@ -164,8 +164,8 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
     }
 
     @Override
-    public boolean isSchemaValidationEnabled() {
-        return this.enableSchemaValidation;
+    public boolean isSchemaValidationDisabled() {
+        return this.disableSchemaValidation;
     }
 
     @Override

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -92,8 +92,8 @@ public class CucumberGenerationConfigSource implements AllConfigSource, ViolateC
     }
 
     @Override
-    public boolean isSchemaValidationEnabled() {
-        return false;
+    public boolean isSchemaValidationDisabled() {
+        return true;
     }
 
     @Override

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/loadfiletest.profile.json
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/loadfiletest.profile.json
@@ -1,23 +1,30 @@
 {
   "schemaVersion": "0.1",
   "fields": [
-    {"name": "foo"}
+    {
+      "name": "foo"
+    }
   ],
   "rules": [
     {
       "rule": "notnull",
       "constraints": [
-        { "allOf":
-        [
-          { "not": { "field": "foo", "is": "null" } }
-        ]
+        {
+          "not": {
+            "field": "foo",
+            "is": "null"
+          }
         }
       ]
     },
     {
       "rule": "file",
       "constraints": [
-        {"field": "foo", "is": "setFromFile", "value": "src/test/java/com/scottlogic/deg/orchestrator/endtoend/testfile.csv"}
+        {
+          "field": "foo",
+          "is": "setFromFile",
+          "value": "src/test/java/com/scottlogic/deg/orchestrator/endtoend/testfile.csv"
+        }
       ]
     }
   ]

--- a/profile/src/main/java/com/scottlogic/deg/profile/guice/ProfileConfigSource.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/guice/ProfileConfigSource.java
@@ -20,6 +20,6 @@ import java.io.File;
 
 public interface ProfileConfigSource {
     File getProfileFile();
-    boolean isSchemaValidationEnabled();
+    boolean isSchemaValidationDisabled();
     String fromFilePath();
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/guice/ProfileSchemaValidatorProvider.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/guice/ProfileSchemaValidatorProvider.java
@@ -36,7 +36,7 @@ public class ProfileSchemaValidatorProvider implements Provider<ProfileSchemaVal
 
     @Override
     public ProfileSchemaValidator get() {
-        if (!profileConfigSource.isSchemaValidationEnabled()) {
+        if (profileConfigSource.isSchemaValidationDisabled()) {
             return new NoopProfileSchemaValidator();
         }
 


### PR DESCRIPTION
### Description
This PR reverts schema validation to be on by default - this was turned off in [this PR](https://github.com/finos/datahelix/pull/829) due to lack of confidence in the schema. However, with the schema now once again being tested against example profiles (and hopefully people adding to this/updating schema when making changes) it seems like a good idea to make this the default again.

### Changes

- Makes schema validation once again on by default

- Changes `--enable-schema-validation` back to `--disable-schema-validation`

- Updates documentation to make this clear

- Removes references to CLI option `--validate-profile` as this doesn't exist as a valid option

### Additional notes
Still disabled when running generator through cucumber.