### PR TITLE
Add missing license header

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.deg.orchestrator.validator;
 
 import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidatorLeadPony;


### PR DESCRIPTION
### Description
When I created a new file in [this PR](https://github.com/finos/datahelix/pull/1123) I forgot to add the licence header. This PR inserts it.