### PR TITLE
1087, 1092 add retry limit to reductive walker

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -27,6 +27,7 @@ import com.scottlogic.deg.generator.generation.combinationstrategies.Combination
 import com.scottlogic.deg.generator.generation.databags.*;
 import com.scottlogic.deg.common.output.GeneratedObject;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
+import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
 
 import java.util.stream.Stream;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -27,7 +27,6 @@ import com.scottlogic.deg.generator.generation.combinationstrategies.Combination
 import com.scottlogic.deg.generator.generation.databags.*;
 import com.scottlogic.deg.common.output.GeneratedObject;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
-import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
 
 import java.util.stream.Stream;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
@@ -29,6 +29,7 @@ import com.scottlogic.deg.generator.generation.combinationstrategies.Combination
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
+import com.scottlogic.deg.generator.walker.ReductiveWalkerRetryChecker;
 import com.scottlogic.deg.generator.walker.reductive.IterationVisualiser;
 
 import java.time.OffsetDateTime;
@@ -70,6 +71,7 @@ public class GeneratorModule extends AbstractModule {
         bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);
         bind(DecisionTreeFactory.class).to(MaxStringLengthInjectingDecisionTreeFactory.class);
         bind(FieldValueSourceEvaluator.class).to(StandardFieldValueSourceEvaluator.class);
+        bind(ReductiveWalkerRetryChecker.class).toInstance(new ReductiveWalkerRetryChecker(100));
 
         bind(JavaUtilRandomNumberGenerator.class)
             .toInstance(new JavaUtilRandomNumberGenerator(OffsetDateTime.now().getNano()));

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/GeneratorModule.java
@@ -71,7 +71,7 @@ public class GeneratorModule extends AbstractModule {
         bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);
         bind(DecisionTreeFactory.class).to(MaxStringLengthInjectingDecisionTreeFactory.class);
         bind(FieldValueSourceEvaluator.class).to(StandardFieldValueSourceEvaluator.class);
-        bind(ReductiveWalkerRetryChecker.class).toInstance(new ReductiveWalkerRetryChecker(100));
+        bind(ReductiveWalkerRetryChecker.class).toInstance(new ReductiveWalkerRetryChecker(10000));
 
         bind(JavaUtilRandomNumberGenerator.class)
             .toInstance(new JavaUtilRandomNumberGenerator(OffsetDateTime.now().getNano()));

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/RandomReductiveDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/RandomReductiveDecisionTreeWalker.java
@@ -19,6 +19,7 @@ package com.scottlogic.deg.generator.walker;
 import com.google.inject.Inject;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
+import com.scottlogic.deg.generator.generation.DataGeneratorMonitor;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 
 import java.util.Optional;
@@ -26,10 +27,12 @@ import java.util.stream.Stream;
 
 public class RandomReductiveDecisionTreeWalker implements DecisionTreeWalker {
     private final ReductiveDecisionTreeWalker underlyingWalker;
+    private final DataGeneratorMonitor monitor;
 
     @Inject
-    RandomReductiveDecisionTreeWalker(ReductiveDecisionTreeWalker underlyingWalker) {
+    RandomReductiveDecisionTreeWalker(ReductiveDecisionTreeWalker underlyingWalker, DataGeneratorMonitor monitor) {
         this.underlyingWalker = underlyingWalker;
+        this.monitor = monitor;
     }
 
     @Override
@@ -53,6 +56,10 @@ public class RandomReductiveDecisionTreeWalker implements DecisionTreeWalker {
             return underlyingWalker.walk(tree)
                 .findFirst();
         } catch (RetryLimitReachedException ex) {
+            monitor.addLineToPrintAtEndOfGeneration("");
+            monitor.addLineToPrintAtEndOfGeneration("The retry limit for generating data has been hit.");
+            monitor.addLineToPrintAtEndOfGeneration("This may mean that a lot or all of the profile is contradictory.");
+            monitor.addLineToPrintAtEndOfGeneration("Either fix the profile, or try running the same command again.");
             return Optional.empty();
         }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/RandomReductiveDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/RandomReductiveDecisionTreeWalker.java
@@ -49,7 +49,12 @@ public class RandomReductiveDecisionTreeWalker implements DecisionTreeWalker {
     }
 
     private Optional<DataBag> getFirstRowSpecFromRandomisingIteration(DecisionTree tree) {
-        return underlyingWalker.walk(tree)
-            .findFirst();
+        try {
+            return underlyingWalker.walk(tree)
+                .findFirst();
+        } catch (RetryLimitReachedException ex) {
+            return Optional.empty();
+        }
+
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
@@ -99,7 +99,7 @@ public class ReductiveDecisionTreeWalker implements DecisionTreeWalker {
         if (reducedTree.isContradictory()){
             //yielding an empty stream will cause back-tracking
             this.monitor.unableToStepFurther(reductiveState);
-            retryChecker.setRetryUnsuccessful();
+            retryChecker.retryUnsuccessful();
             return Stream.empty();
         }
 
@@ -110,7 +110,7 @@ public class ReductiveDecisionTreeWalker implements DecisionTreeWalker {
         visualise(reducedTree.get(), newReductiveState);
 
         if (newReductiveState.allFieldsAreFixed()) {
-            retryChecker.setRetrySuccessful();
+            retryChecker.retrySuccessful();
             return Stream.of(newReductiveState.asDataBag());
         }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
@@ -72,7 +72,6 @@ public class ReductiveDecisionTreeWalker implements DecisionTreeWalker {
     }
 
     private Stream<DataBag> fixNextField(ConstraintNode tree, ReductiveState reductiveState, FixFieldStrategy fixFieldStrategy) {
-
         Field fieldToFix = fixFieldStrategy.getNextFieldToFix(reductiveState);
         Set<FieldSpec> nextFieldSpecs = reductiveFieldSpecBuilder.getDecisionFieldSpecs(tree, fieldToFix);
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
@@ -1,0 +1,23 @@
+package com.scottlogic.deg.generator.walker;
+
+class ReductiveWalkerRetryChecker {
+    private int numRetriesSoFar = 0;
+    private boolean guaranteedNotFullyContradictory = false;
+
+    void setRetrySuccessful() {
+        guaranteedNotFullyContradictory = true;
+    }
+
+    void setRetryUnsuccessful() {
+        numRetriesSoFar++;
+        int RETRY_LIMIT = 100;
+        if (numRetriesSoFar > RETRY_LIMIT && !guaranteedNotFullyContradictory) {
+            throw new RetryLimitReachedException();
+        }
+    }
+
+    void reset() {
+        numRetriesSoFar = 0;
+        guaranteedNotFullyContradictory = false;
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
@@ -1,8 +1,13 @@
 package com.scottlogic.deg.generator.walker;
 
-class ReductiveWalkerRetryChecker {
+public class ReductiveWalkerRetryChecker {
     private int numRetriesSoFar = 0;
     private boolean guaranteedNotFullyContradictory = false;
+    private int retryLimit;
+
+    public ReductiveWalkerRetryChecker(int retryLimit) {
+        this.retryLimit = retryLimit;
+    }
 
     void setRetrySuccessful() {
         guaranteedNotFullyContradictory = true;
@@ -10,8 +15,7 @@ class ReductiveWalkerRetryChecker {
 
     void setRetryUnsuccessful() {
         numRetriesSoFar++;
-        int RETRY_LIMIT = 100;
-        if (numRetriesSoFar > RETRY_LIMIT && !guaranteedNotFullyContradictory) {
+        if (numRetriesSoFar > retryLimit && !guaranteedNotFullyContradictory) {
             throw new RetryLimitReachedException();
         }
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
@@ -2,26 +2,26 @@ package com.scottlogic.deg.generator.walker;
 
 public class ReductiveWalkerRetryChecker {
     private int numRetriesSoFar = 0;
-    private boolean guaranteedNotFullyContradictory = false;
+    private boolean successOccurredAtLeastOnce = false;
     private int retryLimit;
 
     public ReductiveWalkerRetryChecker(int retryLimit) {
         this.retryLimit = retryLimit;
     }
 
-    void setRetrySuccessful() {
-        guaranteedNotFullyContradictory = true;
+    void retrySuccessful() {
+        successOccurredAtLeastOnce = true;
     }
 
-    void setRetryUnsuccessful() {
+    void retryUnsuccessful() {
         numRetriesSoFar++;
-        if (numRetriesSoFar > retryLimit && !guaranteedNotFullyContradictory) {
+        if (numRetriesSoFar > retryLimit && !successOccurredAtLeastOnce) {
             throw new RetryLimitReachedException();
         }
     }
 
     void reset() {
         numRetriesSoFar = 0;
-        guaranteedNotFullyContradictory = false;
+        successOccurredAtLeastOnce = false;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
@@ -14,9 +14,11 @@ public class ReductiveWalkerRetryChecker {
     }
 
     void retryUnsuccessful() {
-        numRetriesSoFar++;
-        if (numRetriesSoFar > retryLimit && !successOccurredAtLeastOnce) {
-            throw new RetryLimitReachedException();
+        if (!successOccurredAtLeastOnce) {
+            numRetriesSoFar++;
+            if (numRetriesSoFar > retryLimit) {
+                throw new RetryLimitReachedException();
+            }
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryChecker.java
@@ -2,7 +2,6 @@ package com.scottlogic.deg.generator.walker;
 
 public class ReductiveWalkerRetryChecker {
     private int numRetriesSoFar = 0;
-    private boolean successOccurredAtLeastOnce = false;
     private int retryLimit;
 
     public ReductiveWalkerRetryChecker(int retryLimit) {
@@ -10,20 +9,17 @@ public class ReductiveWalkerRetryChecker {
     }
 
     void retrySuccessful() {
-        successOccurredAtLeastOnce = true;
+        numRetriesSoFar = 0;
     }
 
     void retryUnsuccessful() {
-        if (!successOccurredAtLeastOnce) {
-            numRetriesSoFar++;
-            if (numRetriesSoFar > retryLimit) {
-                throw new RetryLimitReachedException();
-            }
+        numRetriesSoFar++;
+        if (numRetriesSoFar > retryLimit) {
+            throw new RetryLimitReachedException();
         }
     }
 
     void reset() {
         numRetriesSoFar = 0;
-        successOccurredAtLeastOnce = false;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/RetryLimitReachedException.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/RetryLimitReachedException.java
@@ -2,7 +2,7 @@ package com.scottlogic.deg.generator.walker;
 
 public class RetryLimitReachedException extends RuntimeException {
     // This exception must be a RuntimeException to be able to break out of a stream evaluation.
-    RetryLimitReachedException() {
+    public RetryLimitReachedException() {
         super();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/RetryLimitReachedException.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/RetryLimitReachedException.java
@@ -1,0 +1,8 @@
+package com.scottlogic.deg.generator.walker;
+
+public class RetryLimitReachedException extends RuntimeException {
+    // This exception must be a RuntimeException to be able to break out of a stream evaluation.
+    RetryLimitReachedException() {
+        super();
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
@@ -55,7 +55,7 @@ class ReductiveDecisionTreeWalkerTests {
     private FixFieldStrategyFactory fixFieldStrategyFactory;
     private FieldSpecValueGenerator fieldSpecValueGenerator;
     private ReductiveTreePruner treePruner;
-    private ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker();
+    private ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(100);
     private Field field1 = new Field("field1");
     private Field field2 = new Field("field2");
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofMillis;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -95,7 +97,7 @@ class ReductiveDecisionTreeWalkerTests {
         List<DataBag> result = walker.walk(tree).collect(Collectors.toList());
 
         verify(reductiveFieldSpecBuilder).getDecisionFieldSpecs(eq(rootNode), any());
-        assertTrue(result.isEmpty());
+        assertThat(result, empty());
     }
 
     /**
@@ -114,7 +116,7 @@ class ReductiveDecisionTreeWalkerTests {
         List<DataBag> result = walker.walk(tree).collect(Collectors.toList());
 
         verify(reductiveFieldSpecBuilder, times(2)).getDecisionFieldSpecs(eq(rootNode), any());
-        assertTrue(result.isEmpty());
+        assertThat(result, empty());
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalkerTests.java
@@ -18,6 +18,8 @@ package com.scottlogic.deg.generator.walker;
 
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.ProfileFields;
+import com.scottlogic.deg.generator.builders.ConstraintNodeBuilder;
+import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.decisiontree.TreeConstraintNode;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
@@ -26,10 +28,12 @@ import com.scottlogic.deg.generator.generation.FieldSpecValueGenerator;
 import com.scottlogic.deg.generator.generation.NoopDataGeneratorMonitor;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
-import com.scottlogic.deg.generator.walker.reductive.*;
+import com.scottlogic.deg.generator.walker.reductive.Merged;
+import com.scottlogic.deg.generator.walker.reductive.NoOpIterationVisualiser;
+import com.scottlogic.deg.generator.walker.reductive.ReductiveFieldSpecBuilder;
+import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
 import com.scottlogic.deg.generator.walker.reductive.fieldselectionstrategy.FixFieldStrategy;
 import com.scottlogic.deg.generator.walker.reductive.fieldselectionstrategy.FixFieldStrategyFactory;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +41,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -49,6 +54,8 @@ class ReductiveDecisionTreeWalkerTests {
     private FixFieldStrategy fixFieldStrategy;
     private FixFieldStrategyFactory fixFieldStrategyFactory;
     private FieldSpecValueGenerator fieldSpecValueGenerator;
+    private ReductiveTreePruner treePruner;
+    private ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker();
     private Field field1 = new Field("field1");
     private Field field2 = new Field("field2");
 
@@ -57,8 +64,6 @@ class ReductiveDecisionTreeWalkerTests {
         ProfileFields fields = new ProfileFields(Arrays.asList(field1, field2));
         rootNode = new TreeConstraintNode();
         tree = new DecisionTree(rootNode, fields);
-        ReductiveTreePruner treePruner = mock(ReductiveTreePruner.class);
-        when(treePruner.pruneConstraintNode(eq(rootNode), any(), any())).thenReturn(Merged.of(rootNode));
 
         reductiveFieldSpecBuilder = mock(ReductiveFieldSpecBuilder.class);
         fieldSpecValueGenerator = mock(FieldSpecValueGenerator.class);
@@ -66,6 +71,8 @@ class ReductiveDecisionTreeWalkerTests {
         when(fixFieldStrategy.getNextFieldToFix(any())).thenReturn(field1, field2);
         fixFieldStrategyFactory = mock(FixFieldStrategyFactory.class);
         when(fixFieldStrategyFactory.create(any())).thenReturn(fixFieldStrategy);
+        treePruner = mock(ReductiveTreePruner.class);
+        when(treePruner.pruneConstraintNode(eq(rootNode), any(), any())).thenReturn(Merged.of(rootNode));
 
         walker = new ReductiveDecisionTreeWalker(
             new NoOpIterationVisualiser(),
@@ -73,7 +80,8 @@ class ReductiveDecisionTreeWalkerTests {
             new NoopDataGeneratorMonitor(),
             treePruner,
             fieldSpecValueGenerator,
-            fixFieldStrategyFactory
+            fixFieldStrategyFactory,
+            retryChecker
         );
     }
 
@@ -87,7 +95,7 @@ class ReductiveDecisionTreeWalkerTests {
         List<DataBag> result = walker.walk(tree).collect(Collectors.toList());
 
         verify(reductiveFieldSpecBuilder).getDecisionFieldSpecs(eq(rootNode), any());
-        Assert.assertThat(result, empty());
+        assertTrue(result.isEmpty());
     }
 
     /**
@@ -106,6 +114,34 @@ class ReductiveDecisionTreeWalkerTests {
         List<DataBag> result = walker.walk(tree).collect(Collectors.toList());
 
         verify(reductiveFieldSpecBuilder, times(2)).getDecisionFieldSpecs(eq(rootNode), any());
-        Assert.assertThat(result, empty());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void walk_whereFirstFieldCannotBeFixed_throwsException() {
+        ProfileFields fields = new ProfileFields(Arrays.asList(field1, field2));
+        FieldSpec firstFieldSpec = FieldSpec.Empty.withNotNull();
+        FieldSpec secondFieldSpec = FieldSpec.Empty.withNotNull();
+        Set<FieldSpec> fieldSpecs = new HashSet<>();
+        fieldSpecs.add(firstFieldSpec);
+        fieldSpecs.add(secondFieldSpec);
+        ConstraintNode root = ConstraintNodeBuilder.constraintNode()
+            .where(field1).isNull()
+            .where(field1).isNotNull()
+            .build();
+        DecisionTree tree = new DecisionTree(root, fields);
+        DataBagValue dataBagValue = mock(DataBagValue.class);
+        when(fixFieldStrategy.getNextFieldToFix(any())).thenReturn(field1, field2);
+        when(fixFieldStrategyFactory.create(any())).thenReturn(fixFieldStrategy);
+        when(treePruner.pruneConstraintNode(eq(root), any(), any())).thenReturn(Merged.of(root));
+        when(reductiveFieldSpecBuilder.getDecisionFieldSpecs(any(), any())).thenReturn(fieldSpecs);
+        when(treePruner.pruneConstraintNode(eq(root), any(), any())).thenReturn(Merged.contradictory());
+
+        Stream<DataBagValue> infiniteStream = Stream.iterate(dataBagValue, i -> dataBagValue);
+        when(fieldSpecValueGenerator.generate(anySetOf(FieldSpec.class))).thenReturn(infiniteStream);
+
+        assertTimeoutPreemptively(ofMillis(100), () -> {
+            assertThrows(RetryLimitReachedException.class, () -> walker.walk(tree).findFirst());
+        });
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryCheckerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryCheckerTests.java
@@ -11,11 +11,11 @@ class ReductiveWalkerRetryCheckerTests {
         ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
 
         //Act
-        retryChecker.setRetryUnsuccessful();
-        retryChecker.setRetryUnsuccessful();
+        retryChecker.retryUnsuccessful();
+        retryChecker.retryUnsuccessful();
 
         //Assert
-        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+        assertThrows(RetryLimitReachedException.class, retryChecker::retryUnsuccessful);
     }
 
     @Test
@@ -24,12 +24,12 @@ class ReductiveWalkerRetryCheckerTests {
         ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
 
         //Act
-        retryChecker.setRetryUnsuccessful();
-        retryChecker.setRetrySuccessful();
-        retryChecker.setRetryUnsuccessful();
+        retryChecker.retryUnsuccessful();
+        retryChecker.retrySuccessful();
+        retryChecker.retryUnsuccessful();
 
         //Assert
-        assertDoesNotThrow(retryChecker::setRetryUnsuccessful);
+        assertDoesNotThrow(retryChecker::retryUnsuccessful);
     }
 
     @Test
@@ -38,14 +38,14 @@ class ReductiveWalkerRetryCheckerTests {
         ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
 
         //Act
-        retryChecker.setRetryUnsuccessful();
-        retryChecker.setRetryUnsuccessful();
+        retryChecker.retryUnsuccessful();
+        retryChecker.retryUnsuccessful();
         retryChecker.reset();
-        retryChecker.setRetryUnsuccessful();
-        retryChecker.setRetryUnsuccessful();
+        retryChecker.retryUnsuccessful();
+        retryChecker.retryUnsuccessful();
 
         //Assert
-        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+        assertThrows(RetryLimitReachedException.class, retryChecker::retryUnsuccessful);
     }
 
     @Test
@@ -54,12 +54,12 @@ class ReductiveWalkerRetryCheckerTests {
         ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
 
         //Act
-        retryChecker.setRetrySuccessful();
+        retryChecker.retrySuccessful();
         retryChecker.reset();
-        retryChecker.setRetryUnsuccessful();
-        retryChecker.setRetryUnsuccessful();
+        retryChecker.retryUnsuccessful();
+        retryChecker.retryUnsuccessful();
 
         //Assert
-        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+        assertThrows(RetryLimitReachedException.class, retryChecker::retryUnsuccessful);
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryCheckerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/ReductiveWalkerRetryCheckerTests.java
@@ -1,0 +1,65 @@
+package com.scottlogic.deg.generator.walker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReductiveWalkerRetryCheckerTests {
+    @Test
+    public void retryChecker_withRepeatedFailure_throwsException() {
+        //Arrange
+        ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
+
+        //Act
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.setRetryUnsuccessful();
+
+        //Assert
+        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+    }
+
+    @Test
+    public void retryChecker_withRepeatedFailureAfterSuccess_doesNotThrowException() {
+        //Arrange
+        ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
+
+        //Act
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.setRetrySuccessful();
+        retryChecker.setRetryUnsuccessful();
+
+        //Assert
+        assertDoesNotThrow(retryChecker::setRetryUnsuccessful);
+    }
+
+    @Test
+    public void reset_resetsLimit() {
+        //Arrange
+        ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
+
+        //Act
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.reset();
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.setRetryUnsuccessful();
+
+        //Assert
+        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+    }
+
+    @Test
+    public void reset_resetsGuaranteeOfSuccess() {
+        //Arrange
+        ReductiveWalkerRetryChecker retryChecker = new ReductiveWalkerRetryChecker(2);
+
+        //Act
+        retryChecker.setRetrySuccessful();
+        retryChecker.reset();
+        retryChecker.setRetryUnsuccessful();
+        retryChecker.setRetryUnsuccessful();
+
+        //Assert
+        assertThrows(RetryLimitReachedException.class, retryChecker::setRetryUnsuccessful);
+    }
+}

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
@@ -22,6 +22,7 @@ import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.generation.DataGenerator;
 import com.scottlogic.deg.generator.generation.DataGeneratorMonitor;
 import com.scottlogic.deg.common.output.GeneratedObject;
+import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
 import com.scottlogic.deg.output.writer.DataSetWriter;
 import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
@@ -87,6 +88,8 @@ public class GenerateExecute {
                     throw new RuntimeException(e);
                 }
             });
+        } catch (RetryLimitReachedException ignored) {
+
         }
         monitor.endGeneration();
     }

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
@@ -17,18 +17,17 @@
 package com.scottlogic.deg.orchestrator.generate;
 
 import com.google.inject.Inject;
-import com.scottlogic.deg.common.ValidationException;
+import com.scottlogic.deg.common.output.GeneratedObject;
 import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.generation.DataGenerator;
 import com.scottlogic.deg.generator.generation.DataGeneratorMonitor;
-import com.scottlogic.deg.common.output.GeneratedObject;
-import com.scottlogic.deg.output.writer.DataSetWriter;
-import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
-import com.scottlogic.deg.output.outputtarget.SingleDatasetOutputTarget;
-import com.scottlogic.deg.profile.reader.ProfileReader;
+import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
+import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.orchestrator.validator.ConfigValidator;
-import com.scottlogic.deg.generator.validators.ErrorReporter;
+import com.scottlogic.deg.output.outputtarget.SingleDatasetOutputTarget;
+import com.scottlogic.deg.output.writer.DataSetWriter;
+import com.scottlogic.deg.profile.reader.ProfileReader;
 import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidator;
 
 import java.io.IOException;
@@ -87,8 +86,12 @@ public class GenerateExecute {
                     throw new RuntimeException(e);
                 }
             });
-        } catch (RetryLimitReachedException ignored) {
-
+        }
+        catch (RetryLimitReachedException ignored) {
+            monitor.addLineToPrintAtEndOfGeneration("");
+            monitor.addLineToPrintAtEndOfGeneration("The retry limit for generating data has been hit.");
+            monitor.addLineToPrintAtEndOfGeneration("This may mean that a lot or all of the profile is contradictory.");
+            monitor.addLineToPrintAtEndOfGeneration("Either fix the profile, or try running the same command again.");
         }
         monitor.endGeneration();
     }

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
@@ -22,7 +22,6 @@ import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.generation.DataGenerator;
 import com.scottlogic.deg.generator.generation.DataGeneratorMonitor;
 import com.scottlogic.deg.common.output.GeneratedObject;
-import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
 import com.scottlogic.deg.output.writer.DataSetWriter;
 import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
@@ -88,8 +88,6 @@ public class GenerateExecute {
                     throw new RuntimeException(e);
                 }
             });
-        } catch (RetryLimitReachedException ignored) {
-
         }
         monitor.endGeneration();
     }

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateExecute.java
@@ -87,6 +87,8 @@ public class GenerateExecute {
                     throw new RuntimeException(e);
                 }
             });
+        } catch (RetryLimitReachedException ignored) {
+
         }
         monitor.endGeneration();
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/generate/GenerateExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/generate/GenerateExecuteTests.java
@@ -1,0 +1,80 @@
+package com.scottlogic.deg.orchestrator.generate;
+
+import com.scottlogic.deg.common.output.GeneratedObject;
+import com.scottlogic.deg.common.profile.Profile;
+import com.scottlogic.deg.generator.generation.DataGenerator;
+import com.scottlogic.deg.generator.generation.DataGeneratorMonitor;
+import com.scottlogic.deg.generator.generation.databags.DataBag;
+import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
+import com.scottlogic.deg.generator.walker.RetryLimitReachedException;
+import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
+import com.scottlogic.deg.orchestrator.validator.ConfigValidator;
+import com.scottlogic.deg.output.outputtarget.SingleDatasetOutputTarget;
+import com.scottlogic.deg.profile.reader.ProfileReader;
+import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+
+class GenerateExecuteTests {
+    private AllConfigSource configSource;
+    private SingleDatasetOutputTarget singleDatasetOutputTarget;
+    private ConfigValidator configValidator;
+    private ProfileReader profileReader;
+    private DataGenerator dataGenerator;
+    private ProfileValidator profileValidator;
+    private DataGeneratorMonitor monitor;
+    private ProfileSchemaValidator profileSchemaValidator;
+    private GenerateExecute generateExecute;
+    private Profile profile;
+
+    @BeforeEach
+    void setup() {
+        configSource = mock(AllConfigSource.class);
+        singleDatasetOutputTarget = mock(SingleDatasetOutputTarget.class);
+        configValidator = mock(ConfigValidator.class);
+        profileReader = mock(ProfileReader.class);
+        dataGenerator = mock(DataGenerator.class);
+        profileValidator = mock(ProfileValidator.class);
+        monitor = mock(DataGeneratorMonitor.class);
+        profileSchemaValidator = mock(ProfileSchemaValidator.class);
+        profile = mock(Profile.class);
+
+        generateExecute = new GenerateExecute(
+            profileReader,
+            dataGenerator,
+            configSource,
+            singleDatasetOutputTarget,
+            configValidator,
+            profileValidator,
+            profileSchemaValidator,
+            monitor);
+    }
+
+
+    @Test
+    public void execute_onRetryFail_reportsError() throws IOException {
+        when(profileReader.read(any())).thenReturn(profile);
+        File file = mock(File.class);
+        when(configSource.getProfileFile()).thenReturn(file);
+        when(file.toPath()).thenReturn(mock(Path.class));
+        when(dataGenerator.generateData(profile)).thenReturn(
+            Stream.iterate(mock(GeneratedObject.class), dataBag -> {
+                throw new RetryLimitReachedException();
+            }).skip(1));
+
+        generateExecute.execute();
+
+        verify(monitor, atLeastOnce()).addLineToPrintAtEndOfGeneration(anyString());
+    }
+}


### PR DESCRIPTION
### Description
- Added retry limit to the Reductive Walker so it can't get into an infinite loop.

### Additional notes
- This could cause some profiles with partial contradictions to be unable to produce data when they should be able to. There are other alternatives to this approach, e.g. by resolving #1090 or by making a new walker that supersedes the Reductive Walker.
- Currently does not inform user of error, just ends silently. Gives a warning message could be done in a separate PR.

### Issue
Resolves #1087 
Resolves #1092 
Resolves #1139 
Makes #1090 less important.
