### PR TITLE
1049 - Update Profile Schema

### DIFF
--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -172,7 +172,19 @@
             "setFromFile"
           ]
         },
-        "value": {}
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/datetime"
+            },
+            {
+              "$ref": "#/definitions/numeric"
+            },
+            {
+              "$ref": "#/definitions/string"
+            }
+          ]
+        }
       },
       "allOf": [
         {


### PR DESCRIPTION
### Description
The 'value' part of a constraint must be a plain string, datetime or number. This gives a better warning message when schema validation is enabled (which it is by default) and the user makes the easy mistake of typing 'value' instead of 'values' for an inSet constraint.

### Changes
Profile (Lines 12-16):
```
{
  "field": "X",
  "is": "inSet",
  "value": [1, 2, 3]
}
```
Old:
```
* Error(s) occurred during schema validation.
File path: docs\GettingStarted\ExampleProfile1.json
For full details try opening the profile in a json schema-enabled IDE.
See https://github.com/finos/datahelix/blob/master/docs/ProfileDeveloperGuide.md#Microsoft-Visual-Studio-Code

* Problem found at line 14
... "is": "inSet", ...
Suggested fix:
- The value must be one of ["ofType", "equalTo", "formattedAs", "matchingRegex", "containingRegex", "ofLength", "longerThan", "shorterThan", "greaterThan", "lessThan", "greaterThanOrEqualTo", "lessThanOrEqualTo", "granularTo", "after", "afterOrAt", "before", "beforeOrAt", "setFromFile"].

```
New:
```
* Error(s) occurred during schema validation.
File path: docs\GettingStarted\ExampleProfile1.json
For full details try opening the profile in a json schema-enabled IDE.
See https://github.com/finos/datahelix/blob/master/docs/ProfileDeveloperGuide.md#Microsoft-Visual-Studio-Code

* Problem found at line 14
... "is": "inSet", ...
Suggested fix:
- The value must be one of ["ofType", "equalTo", "formattedAs", "matchingRegex", "containingRegex", "ofLength", "longerThan", "shorterThan", "greaterThan", "lessThan", "greaterThanOrEqualTo", "lessThanOrEqualTo", "granularTo", "after", "afterOrAt", "before", "beforeOrAt", "setFromFile"].

* Problem found at line 15
... "value": [1, 2, 3] ...
Suggested fix:
- The value must be of object type, but actual type is array.
```
### Additional notes
- I'm unsure about which type of release this should be? 
- Now that schema validation has been enabled (302e0a81504b7b50ecdac9e115787924261ab5b4), I think this is a better approach that the one I suggested in #1124 

### Issue
Resolves #1049 
