### PR TITLE
fix(#1154): Fix RegexStringGenerator numerical overflow bug

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,6 +27,7 @@ repositories {
 }
 
 dependencies {
+    compile 'org.apache.commons:commons-lang3:3.1'
     compile 'com.fasterxml.jackson.core:jackson-core:2.9.6'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.6'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.6'

--- a/common/src/main/java/com/scottlogic/deg/common/util/NumberUtils.java
+++ b/common/src/main/java/com/scottlogic/deg/common/util/NumberUtils.java
@@ -16,10 +16,13 @@
 
 package com.scottlogic.deg.common.util;
 
+import org.apache.commons.lang3.Validate;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.ParsePosition;
+import java.util.function.BiPredicate;
 
 public class NumberUtils {
 
@@ -54,6 +57,23 @@ public class NumberUtils {
 
     public static BigDecimal tryParse(String value) {
         return (BigDecimal) bigDecimalFormatter.parse(value, new ParsePosition(0));
+    }
+
+    /** throws @IllegalArgumentException if a or b less than zero */
+    public static boolean multiplyingNonNegativesIsSafe(long a, long b) {
+        return checkPredicateOnNonNegatives(a, b, (n1, n2) -> n1 == 0 || n2 == 0 || Long.MAX_VALUE / n2 >= n1);
+    }
+
+    /** throws @IllegalArgumentException if a or b less than zero */
+    public static boolean addingNonNegativesIsSafe(long a, long b) {
+        return checkPredicateOnNonNegatives(a, b, (n1, n2) -> n1 == 0 || n2 == 0 || Long.MAX_VALUE - n2 >= n1);
+    }
+
+    /** throws @IllegalArgumentException if a or b less than zero */
+    private static boolean checkPredicateOnNonNegatives(long a, long b, BiPredicate<Long, Long> predicate) {
+        Validate.isTrue(a >= 0, "The value must be >=0: %d", a);
+        Validate.isTrue(b >= 0, "The value must be >=0: %d", b);
+        return predicate.test(a, b);
     }
 
     private static final DecimalFormat bigDecimalFormatter;

--- a/common/src/test/java/com/scottlogic/deg/common/util/NumberUtilsTests.java
+++ b/common/src/test/java/com/scottlogic/deg/common/util/NumberUtilsTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NumberUtilsTests {
+
+    private static long SQRT_MAX = Math.round(Math.sqrt(Long.MAX_VALUE) - 0.5);
+    private static long HALF_MAX = Long.MAX_VALUE / 2;
+
+    @Test
+    void multiplyingNonNegativesIsSafe_negativeParametersFail() {
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.multiplyingNonNegativesIsSafe(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.multiplyingNonNegativesIsSafe(0, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.multiplyingNonNegativesIsSafe(-1, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.multiplyingNonNegativesIsSafe(1, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.multiplyingNonNegativesIsSafe(-1, 1));
+    }
+
+    @Test
+    void multiplyingNonNegativesIsSafe_zeroParameterAlwaysReturnsTrue() {
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(Long.MAX_VALUE, 0));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(0, Long.MAX_VALUE));
+    }
+
+    @Test
+    void multiplyingNonNegativesIsSafe_withinMaxValueResultsReturnTrue() {
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(SQRT_MAX, SQRT_MAX));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(SQRT_MAX, 3));
+
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(1, Long.MAX_VALUE));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(Long.MAX_VALUE, 1));
+
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(HALF_MAX, 2));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(2, HALF_MAX));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(HALF_MAX - 1, 2));
+        assertTrue(NumberUtils.multiplyingNonNegativesIsSafe(2, HALF_MAX - 1));
+    }
+
+    @Test
+    void multiplyingNonNegativesIsSafe_aboveMaxValueResultsReturnFalse() {
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(SQRT_MAX +1, SQRT_MAX +1));
+
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(2, Long.MAX_VALUE));
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(Long.MAX_VALUE, 2));
+
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(HALF_MAX, 3));
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(3, HALF_MAX));
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(HALF_MAX + 1, 2));
+        assertFalse(NumberUtils.multiplyingNonNegativesIsSafe(2, HALF_MAX + 1));
+    }
+
+    @Test
+    void addingNonNegativesIsSafe_negativeParametersFail() {
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.addingNonNegativesIsSafe(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.addingNonNegativesIsSafe(0, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.addingNonNegativesIsSafe(-1, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.addingNonNegativesIsSafe(1, -1));
+        assertThrows(IllegalArgumentException.class, () -> NumberUtils.addingNonNegativesIsSafe(-1, 1));
+    }
+
+    @Test
+    void addingNonNegativesIsSafe_zeroParameterAlwaysReturnsTrue() {
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(Long.MAX_VALUE, 0));
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(0, Long.MAX_VALUE));
+    }
+
+    @Test
+    void addingNonNegativesIsSafe_withinMaxValueResultsReturnTrue() {
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(HALF_MAX, HALF_MAX));
+
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(Long.MAX_VALUE -3, 3));
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(3, Long.MAX_VALUE -3));
+
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(1, Long.MAX_VALUE - 1));
+        assertTrue(NumberUtils.addingNonNegativesIsSafe(Long.MAX_VALUE - 1, 1));
+    }
+
+    @Test
+    void addingNonNegativesIsSafe_aboveMaxValueResultsReturnFalse() {
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(HALF_MAX + 2, HALF_MAX));
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(HALF_MAX, HALF_MAX + 2));
+
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(Long.MAX_VALUE -3, 4));
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(4, Long.MAX_VALUE -3));
+
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(2, Long.MAX_VALUE - 1));
+        assertFalse(NumberUtils.addingNonNegativesIsSafe(Long.MAX_VALUE - 1, 2));
+    }
+}

--- a/generator/build.gradle
+++ b/generator/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile 'com.google.inject:guice:4.1.0'
     compile 'dk.brics.automaton:automaton:1.11-8'
     compile 'org.apache.commons:commons-csv:1.5'
+    compile 'org.apache.commons:commons-lang3:3.1'
     
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testCompile 'junit:junit:4.12'

--- a/generator/build.gradle
+++ b/generator/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compile 'com.google.inject:guice:4.1.0'
     compile 'dk.brics.automaton:automaton:1.11-8'
     compile 'org.apache.commons:commons-csv:1.5'
-    compile 'org.apache.commons:commons-lang3:3.1'
     
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testCompile 'junit:junit:4.12'

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
@@ -220,8 +220,6 @@ public class RegexStringGenerator implements StringGenerator {
             passedStringNbrInChildNode = passedStringNbr;
         }
         for (Node childN : node.getNextNodes()) {
-            // TODO AF delete this commented out old code before merge:
-            // AF passedStringNbrInChildNode += childN.getMatchedStringIdx();
             passedStringNbrInChildNode += Math.min(childN.getMatchedStringIdx(), Long.MAX_VALUE - childN.getMatchedStringIdx());
             if (passedStringNbrInChildNode >= indexOrder) {
                 passedStringNbrInChildNode -= childN.getMatchedStringIdx();
@@ -308,8 +306,6 @@ public class RegexStringGenerator implements StringGenerator {
                 for (Node childNode : nextNodes) {
                     childNode.updateMatchedStringIdx();
                     long childNbrChar = childNode.getMatchedStringIdx();
-                    // TODO AF delete this commented out old code before merge:
-                    // matchedStringIdx += nbrChar * childNbrChar;
                     long newNbrChar = (childNbrChar == 0 || Long.MAX_VALUE / childNbrChar > nbrChar) ? nbrChar * childNbrChar : nbrChar;
                     matchedStringIdx += Math.min(newNbrChar, Long.MAX_VALUE - newNbrChar);
                 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
@@ -104,7 +104,7 @@ public class RegexStringGenerator implements StringGenerator {
         return new RegexStringGenerator(merged, mergedRepresentation);
     }
 
-    public RegexStringGenerator union(RegexStringGenerator otherGenerator) {
+    RegexStringGenerator union(RegexStringGenerator otherGenerator) {
         Automaton b = otherGenerator.automaton;
         Automaton merged = automaton.union(b);
         String mergedRepresentation = unionRepresentation(
@@ -125,11 +125,11 @@ public class RegexStringGenerator implements StringGenerator {
         return String.format("¬(%s)", representation);
     }
 
-    public static String intersectRepresentation(String left, String right) {
+    static String intersectRepresentation(String left, String right) {
         return String.format("(%s ∩ %s)", left, right);
     }
 
-    public static String unionRepresentation(String left, String right) {
+    static String unionRepresentation(String left, String right) {
         return String.format("(%s ∪ %s)", left, right);
     }
 
@@ -220,7 +220,9 @@ public class RegexStringGenerator implements StringGenerator {
             passedStringNbrInChildNode = passedStringNbr;
         }
         for (Node childN : node.getNextNodes()) {
-            passedStringNbrInChildNode += childN.getMatchedStringIdx();
+            // TODO AF delete this commented out old code before merge:
+            // AF passedStringNbrInChildNode += childN.getMatchedStringIdx();
+            passedStringNbrInChildNode += Math.min(childN.getMatchedStringIdx(), Long.MAX_VALUE - childN.getMatchedStringIdx());
             if (passedStringNbrInChildNode >= indexOrder) {
                 passedStringNbrInChildNode -= childN.getMatchedStringIdx();
                 indexOrder -= passedStringNbrInChildNode;
@@ -306,7 +308,10 @@ public class RegexStringGenerator implements StringGenerator {
                 for (Node childNode : nextNodes) {
                     childNode.updateMatchedStringIdx();
                     long childNbrChar = childNode.getMatchedStringIdx();
-                    matchedStringIdx += nbrChar * childNbrChar;
+                    // TODO AF delete this commented out old code before merge:
+                    // matchedStringIdx += nbrChar * childNbrChar;
+                    long newNbrChar = (childNbrChar == 0 || Long.MAX_VALUE / childNbrChar > nbrChar) ? nbrChar * childNbrChar : nbrChar;
+                    matchedStringIdx += Math.min(newNbrChar, Long.MAX_VALUE - newNbrChar);
                 }
             }
             isNbrMatchedStringUpdated = true;
@@ -375,7 +380,7 @@ public class RegexStringGenerator implements StringGenerator {
                     return false;
                 }
                 currentValue = getMatchedString(currentIndex);
-            } while (!StringUtils.isStringValidUtf8(currentValue));
+            } while (currentValue != null && !StringUtils.isStringValidUtf8(currentValue));
             return currentValue != null;
         }
 
@@ -413,10 +418,10 @@ public class RegexStringGenerator implements StringGenerator {
         return Objects.hash(this.automaton, this.getClass());
     }
 
-    public static class UnionCollector {
+    static class UnionCollector {
         private RegexStringGenerator union;
 
-        public void accumulate(RegexStringGenerator another) {
+        void accumulate(RegexStringGenerator another) {
             if (union == null) {
                 union = another;
             } else {
@@ -424,14 +429,14 @@ public class RegexStringGenerator implements StringGenerator {
             }
         }
 
-        public void combine(UnionCollector other) {
+        void combine(UnionCollector other) {
             if (other == null || other.union == null) {
                 return;
             }
             union = union.union(other.union);
         }
 
-        public RegexStringGenerator getUnionGenerator() {
+        RegexStringGenerator getUnionGenerator() {
             return union;
         }
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
@@ -21,6 +21,7 @@ import com.scottlogic.deg.generator.utils.SupplierBasedIterator;
 import dk.brics.automaton.Automaton;
 import dk.brics.automaton.State;
 import dk.brics.automaton.Transition;
+import org.apache.commons.lang3.Validate;
 
 import java.util.*;
 
@@ -220,7 +221,12 @@ public class RegexStringGenerator implements StringGenerator {
             passedStringNbrInChildNode = passedStringNbr;
         }
         for (Node childN : node.getNextNodes()) {
-            passedStringNbrInChildNode += Math.min(childN.getMatchedStringIdx(), Long.MAX_VALUE - childN.getMatchedStringIdx());
+            if (addWouldOverflow(passedStringNbrInChildNode, childN.getMatchedStringIdx())) {
+                passedStringNbrInChildNode = Long.MAX_VALUE;
+            } else {
+                passedStringNbrInChildNode += childN.getMatchedStringIdx();
+            }
+
             if (passedStringNbrInChildNode >= indexOrder) {
                 passedStringNbrInChildNode -= childN.getMatchedStringIdx();
                 indexOrder -= passedStringNbrInChildNode;
@@ -306,8 +312,12 @@ public class RegexStringGenerator implements StringGenerator {
                 for (Node childNode : nextNodes) {
                     childNode.updateMatchedStringIdx();
                     long childNbrChar = childNode.getMatchedStringIdx();
-                    long newNbrChar = (childNbrChar == 0 || Long.MAX_VALUE / childNbrChar > nbrChar) ? nbrChar * childNbrChar : nbrChar;
-                    matchedStringIdx += Math.min(newNbrChar, Long.MAX_VALUE - newNbrChar);
+
+                    if(multiplyWouldOverflow(nbrChar, childNbrChar) || addWouldOverflow(matchedStringIdx, nbrChar * childNbrChar)) {
+                        matchedStringIdx = Long.MAX_VALUE;
+                    } else {
+                        matchedStringIdx += nbrChar * childNbrChar;
+                    }
                 }
             }
             isNbrMatchedStringUpdated = true;
@@ -332,6 +342,8 @@ public class RegexStringGenerator implements StringGenerator {
         void setMaxChar(char maxChar) {
             this.maxChar = maxChar;
         }
+
+
     }
 
     private class FiniteStringAutomatonIterator implements Iterator<String> {
@@ -413,6 +425,19 @@ public class RegexStringGenerator implements StringGenerator {
     public int hashCode() {
         return Objects.hash(this.automaton, this.getClass());
     }
+    /** throws @IllegalArgumentException if a or b less than zero */
+    private static boolean multiplyWouldOverflow(long a, long b) {
+        Validate.isTrue(a >= 0, "The value must be >=0: %d", a);
+        Validate.isTrue(b >= 0, "The value must be >=0: %d", b);
+        return a > 0 && b > 0 && Long.MAX_VALUE / b < a;
+    }
+
+    /** throws @IllegalArgumentException if a or b less than zero */
+    private static boolean addWouldOverflow(long a, long b) {
+        Validate.isTrue(a >= 0, "The value must be >=0: %d", a);
+        Validate.isTrue(b >= 0, "The value must be >=0: %d", b);
+        return a > 0 && b > 0 && (Long.MAX_VALUE - b < a);
+    }
 
     static class UnionCollector {
         private RegexStringGenerator union;
@@ -436,5 +461,6 @@ public class RegexStringGenerator implements StringGenerator {
             return union;
         }
     }
+
 }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/string/RegexStringGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/string/RegexStringGeneratorTests.java
@@ -26,13 +26,14 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.scottlogic.deg.generator.helpers.StringGeneratorHelper.assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RegexStringGeneratorTests {
+class RegexStringGeneratorTests {
     @Test
     void shouldFullStringMatchAnchoredString() {
         givenRegex("^test$");
@@ -273,7 +274,47 @@ public class RegexStringGeneratorTests {
         }
     }
 
-    private final boolean doesStringContainSurrogates(String testString) {
+    @Test
+    void generateAllShouldGenerateLetterStringsOfLength12() {
+        RegexStringGenerator generator = new RegexStringGenerator("[a-z]{12}", true);
+        generator.generateAllValues();
+
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 12, 12);
+    }
+
+    @Test
+    void generateAllShouldGenerateLatinCharacterStringsOfLength10() {
+        RegexStringGenerator generator = new RegexStringGenerator("[\u0020-\u007E]{10}", true);
+        generator.generateAllValues();
+
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 10, 10);
+    }
+
+    @Test
+    void generateAllShouldGenerateLatinCharacterStringsOfLength12() {
+        RegexStringGenerator generator = new RegexStringGenerator("[\u0020-\u007E]{12}", true);
+        generator.generateAllValues();
+
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 12, 12);
+    }
+
+    @Test
+    void generateAllShouldGenerateNonNullCharacterStringsOfLength12() {
+        RegexStringGenerator generator = new RegexStringGenerator("[\u0001-\uFFFF]{12}", true);
+        generator.generateAllValues();
+
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 12, 12);
+    }
+
+    @Test
+    void generateAllShouldGenerateStringsOfLength12() {
+        RegexStringGenerator generator = new RegexStringGenerator(".{12}", true);
+        generator.generateAllValues();
+
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 12, 12);
+    }
+
+    private boolean doesStringContainSurrogates(String testString) {
         for (char c : testString.toCharArray()) {
             if (Character.isSurrogate(c)) {
                 return true;

--- a/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.generator.helpers;
+
+import com.scottlogic.deg.generator.generation.string.StringGenerator;
+import org.junit.Assert;
+
+import java.util.Iterator;
+
+import static org.hamcrest.Matchers.*;
+
+public enum StringGeneratorHelper {
+    ;
+
+    StringGeneratorHelper() {
+    }
+
+    public static void assertGeneratorCannotGenerateAnyStrings(StringGenerator generator) {
+        Iterator<String> stringValueIterator = generator.generateAllValues().iterator();
+
+        // TODO AF remove once fixed #1154 bug - useful for testing this bug
+        int i = 0;
+        while (stringValueIterator.hasNext() && i < 15) {
+            System.out.println("" + i + ": '" + stringValueIterator.next() + "'");
+            ++i;
+        }
+
+        Assert.assertThat(stringValueIterator.hasNext(), is(false));
+    }
+
+    public static void assertGeneratorCanGenerateAtLeastOneString(StringGenerator generator) {
+        Iterator<String> stringValueIterator = generator.generateAllValues().iterator();
+        Assert.assertThat(stringValueIterator.hasNext(), is(true));
+    }
+
+    public static void assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(StringGenerator generator, int minLength, int maxLength) {
+        Iterator<String> stringValueIterator = generator.generateAllValues().iterator();
+        Assert.assertThat(stringValueIterator.hasNext(), is(true));
+        String value = stringValueIterator.next();
+
+        // TODO AF remove once fixed #1154 bug - useful for testing this bug
+        System.out.println("'" + value + "'");
+        int i = 1;
+        while (stringValueIterator.hasNext() && i < 100) {
+            String next = stringValueIterator.next();
+            System.out.println("" + i + ": '" + next + "'");
+            ++i;
+        }
+
+        Assert.assertThat(value.length(), greaterThanOrEqualTo(minLength));
+        Assert.assertThat(value.length(), lessThanOrEqualTo(maxLength));
+    }
+
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
@@ -31,14 +31,6 @@ public enum StringGeneratorHelper {
 
     public static void assertGeneratorCannotGenerateAnyStrings(StringGenerator generator) {
         Iterator<String> stringValueIterator = generator.generateAllValues().iterator();
-
-        // TODO AF remove once fixed #1154 bug - useful for testing this bug
-        int i = 0;
-        while (stringValueIterator.hasNext() && i < 15) {
-            System.out.println("" + i + ": '" + stringValueIterator.next() + "'");
-            ++i;
-        }
-
         Assert.assertThat(stringValueIterator.hasNext(), is(false));
     }
 
@@ -51,15 +43,6 @@ public enum StringGeneratorHelper {
         Iterator<String> stringValueIterator = generator.generateAllValues().iterator();
         Assert.assertThat(stringValueIterator.hasNext(), is(true));
         String value = stringValueIterator.next();
-
-        // TODO AF remove once fixed #1154 bug - useful for testing this bug
-        System.out.println("'" + value + "'");
-        int i = 1;
-        while (stringValueIterator.hasNext() && i < 100) {
-            String next = stringValueIterator.next();
-            System.out.println("" + i + ": '" + next + "'");
-            ++i;
-        }
 
         Assert.assertThat(value.length(), greaterThanOrEqualTo(minLength));
         Assert.assertThat(value.length(), lessThanOrEqualTo(maxLength));

--- a/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/helpers/StringGeneratorHelper.java
@@ -23,10 +23,9 @@ import java.util.Iterator;
 
 import static org.hamcrest.Matchers.*;
 
-public enum StringGeneratorHelper {
-    ;
+public class StringGeneratorHelper {
 
-    StringGeneratorHelper() {
+    private StringGeneratorHelper() {
     }
 
     public static void assertGeneratorCannotGenerateAnyStrings(StringGenerator generator) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
@@ -323,12 +323,9 @@ class TextualRestrictionsTests {
 
     @Test
     void createGenerator_withContradictingOfLengthAndContainingRegexConstraint_shouldCreateNoStrings() {
-        StringRestrictions restrictions = containsRegex("[a-z]{102}", false)
-            .intersect(ofLength(100, false)).restrictions;
-
-        StringGenerator generator = restrictions.createGenerator();
-
-        assertGeneratorCannotGenerateAnyStrings(generator);
+        MergeResult<StringRestrictions> intersect = containsRegex("[a-z]{102}", false)
+            .intersect(ofLength(100, false));
+        Assert.assertThat(intersect, equalTo(MergeResult.unsuccessful()));
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
@@ -323,7 +323,7 @@ class TextualRestrictionsTests {
 
     @Test
     void createGenerator_withContradictingOfLengthAndContainingRegexConstraint_shouldCreateNoStrings() {
-        StringRestrictions restrictions = containsRegex("[a-z]{0,9}", false)
+        StringRestrictions restrictions = containsRegex("[a-z]{102}", false)
             .intersect(ofLength(100, false)).restrictions;
 
         StringGenerator generator = restrictions.createGenerator();


### PR DESCRIPTION
### Description
Prevent RegexStringGenerator getting numerical overflow for matchedStringIdx and make sure tests still pass.  Not attempting to analyse or rewrite the class - can do that as separate bit of work if we think we need to.

### Changes
Changes all within RegexStringGenerator
I added some tests to RegexStringGeneratorTest of which some failed until i did this change
I also fixed up an erroneous test in TextualRestrictionsTest so its a valid test
I added a StringGeneratorHelper.  Its only used in one test but can be used in more - which will do in ticket #1075 

### Additional notes
This is not an attempt to understand and improve a class I don't understand very well.  If we get more issues then we can do this in which case we should speak to Mark H to see if he cna shed some light on what the class is meant to do.

### Issue
Related to #1075 which revealed this bug