### PR TITLE
1075 Change string generation to pick from latin characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ firstName
 
 The generator has successfully created 100 rows of random data. However, in most cases this data will not be terribly useful. It is likely that `firstName` will only allow string values, with this constraint enforced via a database schema for example. If you don't provide any constraints, the generator will output values from the 'universal set', which contains all generatable values (null, any string, any date, any number, etc).
 
-Let's assume you only want to generate string values for the `firstName` field; this can be achieved by adding an `ofType` constraint for the field. With this constraint alone, the generator will output random strings containing characters from the unicode [Basic Multilingual Plane](<https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane>). If you want a more restrictive character set, ths can be achieved by adding `matchingRegex`.
+Let's assume you only want to generate string values for the `firstName` field; this can be achieved by adding an `ofType` constraint for the field. With this constraint alone, the generator will output random strings containing basic latin characters and punctuation. If you want a more restrictive character set, ths can be achieved by adding `matchingRegex`.
 
 ## Adding constraints
 

--- a/docs/developer/KeyDecisions.md
+++ b/docs/developer/KeyDecisions.md
@@ -49,9 +49,9 @@ Should I be able to express the above, and if so what does it mean? Intuitive, w
 
 Both of these approaches seem more or less intuitive in different cases (for example, how should `equalTo` constraints be applied?). To resolve this problem, we currently require datetime expressions to be fully specified down to thousandths of milliseconds.
 
-## How should we generate characters above the Basic Unicode Plane?
+## How should we generate characters outside the basic latin character set?
 
-We currently only support generation of characters represented in range 0000-FFFF.
+We currently only support generation of characters represented in range 002c-007e.
 
 Either we can:
 1) Update the tool to reject any regular expressions that contain characters outside of this range.

--- a/docs/user/UserGuide.md
+++ b/docs/user/UserGuide.md
@@ -124,7 +124,7 @@ Note that granularity concerns which values are valid, not how they're presented
 
 ## Strings
 
-Strings are sequences of unicode characters with a maximum length of 1000 characters. Currently, only characters from the [Basic Multilingual Plane](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane) (Plane 0) are supported.
+Strings are sequences of unicode characters with a maximum length of 1000 characters. Currently, only basic latin characters (unicode 002c - 007e) are supported.
 
 ## DateTime
 

--- a/examples/string/README.md
+++ b/examples/string/README.md
@@ -1,0 +1,1 @@
+This is a simple profile using the "ofType" string constraint.

--- a/examples/string/profile.json
+++ b/examples/string/profile.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "not": {
+            "field": "field1",
+            "is": "null"
+          }
+        },
+        {
+            "field": "field1",
+            "is": "ofType",
+            "value": "string"
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -224,6 +224,8 @@ class AutomatonUtils {
 
         Automaton generatedAutomaton = bricsRegExp.toAutomaton();
         generatedAutomaton.expandSingleton();
+        // NB: AF if want to allow cmd line option to expand to a fuller character set make sure don't
+        // make it unbounded as we don't want to see tabs or back spaces or null (\u0000) unicode chars
         generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007E');
 
         cache.put(regexStr, generatedAutomaton);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -16,10 +16,7 @@
 
 package com.scottlogic.deg.generator.generation.string;
 
-import dk.brics.automaton.Automaton;
-import dk.brics.automaton.RegExp;
-import dk.brics.automaton.State;
-import dk.brics.automaton.Transition;
+import dk.brics.automaton.*;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -209,8 +206,6 @@ class AutomatonUtils {
         return currentBest;
     }
 
-
-
     /**
      * Create an automaton and store its instance in the cache, keyed on the given regex
      * The cache will vary based on &lt;matchFullString&gt;.
@@ -229,6 +224,7 @@ class AutomatonUtils {
 
         Automaton generatedAutomaton = bricsRegExp.toAutomaton();
         generatedAutomaton.expandSingleton();
+        generatedAutomaton =  BasicOperations.intersection(Automaton.makeCharRange('\u002c', '\u007e').repeat(), generatedAutomaton);
 
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -224,7 +224,7 @@ class AutomatonUtils {
 
         Automaton generatedAutomaton = bricsRegExp.toAutomaton();
         generatedAutomaton.expandSingleton();
-        generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u001F', '\u007E');
+        generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007E');
 
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -224,7 +224,7 @@ class AutomatonUtils {
 
         Automaton generatedAutomaton = bricsRegExp.toAutomaton();
         generatedAutomaton.expandSingleton();
-        generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007e');
+        generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u001F', '\u007E');
 
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -224,10 +224,16 @@ class AutomatonUtils {
 
         Automaton generatedAutomaton = bricsRegExp.toAutomaton();
         generatedAutomaton.expandSingleton();
-        generatedAutomaton =  BasicOperations.intersection(Automaton.makeCharRange('\u002c', '\u007e').repeat(), generatedAutomaton);
+        generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007e');
 
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;
+    }
+
+    private static Automaton restrictCharacterSet(Automaton generatedAutomaton, char minChar, char maxChar) {
+        return BasicOperations.intersection(
+            Automaton.makeCharRange(minChar, maxChar).repeat(),
+            generatedAutomaton);
     }
 
     private static String escapeCharacters(String regex) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/string/AutomatonUtilsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/string/AutomatonUtilsTests.java
@@ -17,16 +17,18 @@
 package com.scottlogic.deg.generator.generation.string;
 
 import dk.brics.automaton.Automaton;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AutomatonUtilsTests {
     
@@ -166,6 +168,36 @@ class AutomatonUtilsTests {
         String longestExample = AutomatonUtils.getShortestExample(automaton);
 
         assertThat(longestExample, equalTo(""));
+    }
+
+    @Test
+    public void createAutomaton_withValidString_shouldAcceptValidCharacters(){
+        String validRegex = ".*";
+        Map<String, Automaton> dummyCache = new HashMap<>();
+
+        Automaton automaton = AutomatonUtils.createAutomaton(validRegex, true, dummyCache);
+
+        assertTrue(automaton.run("a"));
+    }
+
+    @Test
+    public void createAutomaton_withValidString_shouldRejectInvalidCharacters(){
+        String validRegex = ".*";
+        Map<String, Automaton> dummyCache = new HashMap<>();
+
+        Automaton automaton = AutomatonUtils.createAutomaton(validRegex, true, dummyCache);
+
+        assertFalse(automaton.run("汉字"));
+    }
+
+    @Test
+    public void createAutomaton_withInValidString_shouldCreateEmptyAutomaton(){
+        String validRegex = "汉字*";
+        Map<String, Automaton> dummyCache = new HashMap<>();
+
+        Automaton automaton = AutomatonUtils.createAutomaton(validRegex, true, dummyCache);
+
+        assertTrue(automaton.isEmpty());
     }
 
     private static Automaton getAutomaton(String regex){

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
@@ -21,12 +21,14 @@ import com.scottlogic.deg.generator.generation.string.IsinStringGenerator;
 import com.scottlogic.deg.generator.generation.string.RegexStringGenerator;
 import com.scottlogic.deg.generator.generation.string.StringGenerator;
 import org.junit.Assert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
+import static com.scottlogic.deg.generator.helpers.StringGeneratorHelper.*;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNull.nullValue;
 
@@ -234,6 +236,22 @@ class TextualRestrictionsTests {
     }
 
     @Test
+    void createGenerator_withContradictingLength10AndMatchingRegexConstraintThatIsShorter_shouldCreateNoStrings() {
+        MergeResult<StringRestrictions> intersect = matchingRegex("[a-z]{5,9}", false)
+            .intersect(ofLength(10, false));
+
+        Assert.assertThat(intersect, equalTo(MergeResult.unsuccessful()));
+    }
+
+    @Test
+    void createGenerator_withContradictingLength15AndMatchingRegexConstraintThatIsShorter_shouldCreateNoStrings() {
+        MergeResult<StringRestrictions> intersect = matchingRegex("[a-z]{5,9}", false)
+            .intersect(ofLength(15, false));
+
+        Assert.assertThat(intersect, equalTo(MergeResult.unsuccessful()));
+    }
+
+    @Test
     void createGenerator_withNonContradictingOfLengthAndMatchingRegexConstraint_shouldCreateStringsMatchingRegexAndOfPrescribedLength() {
         StringRestrictions restrictions = matchingRegex("[a-z]{0,9}", false)
             .intersect(ofLength(5, false)).restrictions;
@@ -329,6 +347,40 @@ class TextualRestrictionsTests {
     }
 
     @Test
+    void createGenerator_OfLength11_shouldCreateStrings() {
+        StringRestrictions restrictions = ofLength(11, false);
+        StringGenerator generator = restrictions.createGenerator();
+
+        Assert.assertThat(generator.toString(), equalTo("/^.{11}$/"));
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 11, 11);
+    }
+
+    @Test
+    void createGenerator_OfLength12_shouldCreateStrings() {
+        StringRestrictions restrictions = ofLength(12, false);
+        StringGenerator generator = restrictions.createGenerator();
+
+        Assert.assertThat(generator.toString(), equalTo("/^.{12}$/"));
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 12, 12);
+    }
+
+    @Test
+    void createGenerator_withContradictingOfLength10AndContainingRegexConstraint_shouldCreateNoStrings() {
+        MergeResult<StringRestrictions> intersect = containsRegex("[a-z]{11,12}", false)
+            .intersect(ofLength(10, false));
+
+        Assert.assertThat(intersect, equalTo(MergeResult.unsuccessful()));
+    }
+
+    @Test
+    void createGenerator_withContradictingOfLength100AndContainingRegexConstraint_shouldCreateNoStrings() {
+        MergeResult<StringRestrictions> intersect = containsRegex("[a-z]{102,103}", false)
+            .intersect(ofLength(100, false));
+
+        Assert.assertThat(intersect, equalTo(MergeResult.unsuccessful()));
+    }
+
+    @Test
     void createGenerator_withMinAndMaxLengthAndContainingRegexConstraint_shouldCreateStringsContainingRegexAndBetweenLengths() {
         StringRestrictions restrictions = containsRegex("[a-z]{0,9}", false)
             .intersect(minLength(3)).restrictions
@@ -337,6 +389,7 @@ class TextualRestrictionsTests {
         StringGenerator generator = restrictions.createGenerator();
 
         Assert.assertThat(generator.toString(), equalTo("(/^.{3,7}$/ ∩ */[a-z]{0,9}/*)"));
+        assertGeneratorCanGenerateAtLeastOneStringWithinLengthBounds(generator, 3, 7);
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
@@ -21,7 +21,6 @@ import com.scottlogic.deg.generator.generation.string.IsinStringGenerator;
 import com.scottlogic.deg.generator.generation.string.RegexStringGenerator;
 import com.scottlogic.deg.generator.generation.string.StringGenerator;
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination-SpecialChars.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination-SpecialChars.feature
@@ -1,0 +1,49 @@
+# (1075) ignoring these tests as only allowing latin character set for now but we will turn them back on when allow them
+@ignore
+Feature: Whilst including non-latin characters, user can create data across multiple fields for all combinations available.
+
+  Background:
+    Given the generation strategy is full
+    And the combination strategy is exhaustive
+
+  Scenario: Running an exhaustive combination strategy with special character (emoji) strings should be successful
+    Given the following fields exist:
+      | foo |
+      | bar |
+    And foo is of type "string"
+    And foo is anything but null
+    And bar is of type "string"
+    And bar is anything but null
+    And foo is in set:
+      | "😐" |
+      | "☻"  |
+    And bar is in set:
+      | "🚍" |
+      | "🚌" |
+    Then the following data should be generated:
+      | foo  | bar  |
+      | "😐" | "🚍" |
+      | "☻"  | "🚍" |
+      | "😐" | "🚌" |
+      | "☻"  | "🚌" |
+
+  Scenario: Running an exhaustive combination strategy with special character (various white spaces) strings should be successful
+    Given the following fields exist:
+      | foo |
+      | bar |
+    And foo is of type "string"
+    And foo is anything but null
+    And bar is of type "string"
+    And bar is anything but null
+    And foo is in set:
+      | " " |
+      | " " |
+    And bar is in set:
+      | " " |
+      | " " |
+    Then the following data should be generated:
+      | foo | bar |
+      | " " | " " |
+      | " " | " " |
+      | " " | " " |
+      | " " | " " |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination.feature
@@ -69,7 +69,7 @@ Feature: User can create data across multiple fields for all combinations availa
       | "0" | "7" |
       | "1" | "7" |
 
-  Scenario: Running an exhaustive combination strategy with special character (emoji) strings should be successful
+  Scenario: Running an exhaustive combination strategy with plain white spaces should be successful
     Given the following fields exist:
       | foo |
       | bar |
@@ -78,38 +78,17 @@ Feature: User can create data across multiple fields for all combinations availa
     And bar is of type "string"
     And bar is anything but null
     And foo is in set:
-      | "😐" |
-      | "☻"  |
+      | " " |
+      | "x" |
     And bar is in set:
-      | "🚍" |
-      | "🚌" |
-    Then the following data should be generated:
-      | foo  | bar  |
-      | "😐" | "🚍" |
-      | "☻"  | "🚍" |
-      | "😐" | "🚌" |
-      | "☻"  | "🚌" |
-
-  Scenario: Running an exhaustive combination strategy with special character (white spaces) strings should be successful
-    Given the following fields exist:
-      | foo |
-      | bar |
-    And foo is of type "string"
-    And foo is anything but null
-    And bar is of type "string"
-    And bar is anything but null
-    And foo is in set:
-      | " " |
-      | " " |
-    And bar is in set:
-      | " " |
+      | "y" |
       | " " |
     Then the following data should be generated:
       | foo | bar |
-      | " " | " " |
-      | " " | " " |
-      | " " | " " |
-      | " " | " " |
+      | " " | "y" |
+      | " " | " " |
+      | "x" | " " |
+      | "x" | "y" |
 
   Scenario: Running an exhaustive combination strategy with valid integer values should be successful
     Given the following fields exist:

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo-SpecialChars.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo-SpecialChars.feature
@@ -1,0 +1,104 @@
+# (1075) ignoring these tests as only allowing latin character set for now but we will turn them back on when allow them
+@ignore
+Feature: Whilst including non-latin characters, user can specify that a value is equalTo a required value
+
+  Background:
+    Given the generation strategy is full
+
+### alone ###
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (standard) should be successful
+    Given there is a field foo
+    And foo is equal to ".,;:/()-+£$%€!?=&#@<>[]{}^*"
+    Then the following data should be generated:
+      | foo                           |
+      | null                          |
+      | ".,;:/()-+£$%€!?=&#@<>[]{}^*" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (like white space strings) should be successful
+    Given there is a field foo
+    And foo is equal to "]	[] [] [] [] [] [] ["
+    Then the following data should be generated:
+      | foo                     |
+      | null                    |
+      | "]	[] [] [] [] [] [] [" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (unicode symbols) should be successful
+    Given there is a field foo
+    And foo is equal to "†ŠŒŽ™¼ǅ©®…¶Σ֎"
+    Then the following data should be generated:
+      | foo             |
+      | null            |
+      | "†ŠŒŽ™¼ǅ©®…¶Σ֎" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (emoji) should be successful
+    Given there is a field foo
+    And foo is equal to "☺☹☻😀😁😂😃😄😅😆😇😈😉😊😋😌🚩🚪🚫🚬🚭🚮🚯🚰"
+    Then the following data should be generated:
+      | foo                                             |
+      | null                                            |
+      | "☺☹☻😀😁😂😃😄😅😆😇😈😉😊😋😌🚩🚪🚫🚬🚭🚮🚯🚰" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (non roman character maps: Chinese / Arabic / Russian) should be successful
+    Given there is a field foo
+    And foo is equal to "传/傳象形字ФХѰѾЦИتشرقصف"
+    Then the following data should be generated:
+      | foo                  |
+      | null                 |
+      | "传/傳象形字ФХѰѾЦИتشرقصف" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (non roman character maps: Chinese / Arabic / Russian) should be successful
+    Given there is a field foo
+    And foo is equal to "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ"
+    Then the following data should be generated:
+      | foo                                                            |
+      | null                                                           |
+      | "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (standard) alongside roman alphanumeric characters should be successful
+    Given there is a field foo
+    And foo is equal to "abcdefghijk.,;:/()-+£$%€!?=&#@<>[]{}^*"
+    Then the following data should be generated:
+      | foo                                      |
+      | null                                     |
+      | "abcdefghijk.,;:/()-+£$%€!?=&#@<>[]{}^*" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (white spaces) alongside roman alphanumeric characters should be successful
+    Given there is a field foo
+    And foo is equal to "abcdefghijk]	[] [] [] [] [] [] ["
+    Then the following data should be generated:
+      | foo                                |
+      | null                               |
+      | "abcdefghijk]	[] [] [] [] [] [] [" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (unicode symbols) alongside roman alphanumeric characters should be successful
+    Given there is a field foo
+    And foo is equal to "abcdefghijk†ŠŒŽ™¼ǅ©®…¶Σ֎"
+    Then the following data should be generated:
+      | foo                        |
+      | null                       |
+      | "abcdefghijk†ŠŒŽ™¼ǅ©®…¶Σ֎" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (emoji) alongside roman alphanumeric characters should be successful
+    Given there is a field foo
+    And foo is equal to "abcdefghijk☺☹☻😀😁😂😃😄😅😆😇😈😉😊😋😌🚩🚪🚫🚬🚭🚮🚯🚰"
+    Then the following data should be generated:
+      | foo                                                        |
+      | null                                                       |
+      | "abcdefghijk☺☹☻😀😁😂😃😄😅😆😇😈😉😊😋😌🚩🚪🚫🚬🚭🚮🚯🚰" |
+
+  Scenario: Running an 'equalTo' request that includes strings with special characters (non roman character maps: Chinese / Arabic / Russian) alongside roman alphanumeric characters should be successful
+    Given there is a field foo
+    And foo is equal to "abcdefghijk传/傳象形字ФХѰѾЦИتشرقصف"
+    Then the following data should be generated:
+      | foo                             |
+      | null                            |
+      | "abcdefghijk传/傳象形字ФХѰѾЦИتشرقصف" |
+
+  Scenario: Running an 'equalTo' request that includes roman numeric strings that include numbers in a currency style should be successful
+    Given there is a field foo
+    And foo is equal to "£1.00"
+    Then the following data should be generated:
+      | foo     |
+      | null    |
+      | "£1.00" |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InSet-SpecialChars.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InSet-SpecialChars.feature
@@ -1,0 +1,84 @@
+# (1075) ignoring these tests as only allowing latin character set for now but we will turn them back on when allow them
+@ignore
+Feature: Whilst including non-latin characters, User can specify that a field value belongs to a set of predetermined options.
+
+  Background:
+    Given the generation strategy is full
+
+### inSet alone ###
+
+  Scenario: Running an 'inSet' request that includes strings with special characters (standard) should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "!£$%^&*()"   |
+      | "{}:@~;'#<>?" |
+    Then the following data should be generated:
+      | foo           |
+      | null          |
+      | "!£$%^&*()"   |
+      | "{}:@~;'#<>?" |
+
+  Scenario: Running an 'inSet' request that includes strings with special characters (white spaces) should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "]	[] [] [] [" |
+      | "] [] [] ["    |
+    Then the following data should be generated:
+      | foo            |
+      | null           |
+      | "]	[] [] [] [" |
+      | "] [] [] ["    |
+
+  Scenario: Running an 'inSet' request that includes strings with special characters (unicode symbols) should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "†ŠŒŽ™¼ǅ©" |
+      | "®…¶Σ֎"    |
+    Then the following data should be generated:
+      | foo        |
+      | null       |
+      | "†ŠŒŽ™¼ǅ©" |
+      | "®…¶Σ֎"    |
+
+  Scenario: Running an 'inSet' request that includes strings with special characters (emoji) should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "🚫⌛⚡🐢"   |
+      | "👟💪😈🔬" |
+    Then the following data should be generated:
+      | foo        |
+      | null       |
+      | "🚫⌛⚡🐢"   |
+      | "👟💪😈🔬" |
+
+  Scenario: Running an 'inSet' request that includes strings with special characters (non roman character maps) should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "Ω" |
+      | "ڦ" |
+      | "আ" |
+      | "⾉" |
+      | "㑹" |
+      | "㾹" |
+    Then the following data should be generated:
+      | foo  |
+      | null |
+      | "Ω"  |
+      | "ڦ"  |
+      | "আ"  |
+      | "⾉"  |
+      | "㑹"  |
+      | "㾹"  |
+
+  Scenario: Running an 'inSet' request that includes roman numeric strings that include numbers with Preceding zeros should be successful
+    Given there is a field foo
+    And foo is in set:
+      | "£1.00"   |
+      | "€5,99"   |
+      | "¥10,000" |
+    Then the following data should be generated:
+      | foo       |
+      | null      |
+      | "£1.00"   |
+      | "€5,99"   |
+      | "¥10,000" |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InSet.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InSet.feature
@@ -70,69 +70,6 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       | "nil"       |
       | "infinity"  |
 
-  Scenario: Running an 'inSet' request that includes strings with special characters (standard) should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "!£$%^&*()"   |
-      | "{}:@~;'#<>?" |
-    Then the following data should be generated:
-      | foo           |
-      | null          |
-      | "!£$%^&*()"   |
-      | "{}:@~;'#<>?" |
-
-  Scenario: Running an 'inSet' request that includes strings with special characters (white spaces) should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "]	[] [] [] [" |
-      | "] [] [] ["    |
-    Then the following data should be generated:
-      | foo            |
-      | null           |
-      | "]	[] [] [] [" |
-      | "] [] [] ["    |
-
-  Scenario: Running an 'inSet' request that includes strings with special characters (unicode symbols) should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "†ŠŒŽ™¼ǅ©" |
-      | "®…¶Σ֎"    |
-    Then the following data should be generated:
-      | foo        |
-      | null       |
-      | "†ŠŒŽ™¼ǅ©" |
-      | "®…¶Σ֎"    |
-
-  Scenario: Running an 'inSet' request that includes strings with special characters (emoji) should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "🚫⌛⚡🐢"   |
-      | "👟💪😈🔬" |
-    Then the following data should be generated:
-      | foo        |
-      | null       |
-      | "🚫⌛⚡🐢"   |
-      | "👟💪😈🔬" |
-
-  Scenario: Running an 'inSet' request that includes strings with special characters (non roman character maps) should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "Ω" |
-      | "ڦ" |
-      | "আ" |
-      | "⾉" |
-      | "㑹" |
-      | "㾹" |
-    Then the following data should be generated:
-      | foo  |
-      | null |
-      | "Ω"  |
-      | "ڦ"  |
-      | "আ"  |
-      | "⾉"  |
-      | "㑹"  |
-      | "㾹"  |
-
   Scenario: Running an 'inSet' request that includes roman numeric strings that include decimal numbers should be successful
     Given there is a field foo
     And foo is in set:
@@ -160,19 +97,6 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       | "55,5"         |
       | "10,000"       |
       | "1,000,000.00" |
-
-  Scenario: Running an 'inSet' request that includes roman numeric strings that include numbers with Preceding zeros should be successful
-    Given there is a field foo
-    And foo is in set:
-      | "£1.00"   |
-      | "€5,99"   |
-      | "¥10,000" |
-    Then the following data should be generated:
-      | foo       |
-      | null      |
-      | "£1.00"   |
-      | "€5,99"   |
-      | "¥10,000" |
 
   Scenario: Running an 'inSet' request that includes roman numeric strings that include negative numbers("-1") should be successful
     Given there is a field foo

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/CharacterSet.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/CharacterSet.feature
@@ -1,0 +1,107 @@
+Feature: Strings will be generated using characters from only latin characters
+
+  Background:
+    Given the generation strategy is full
+    And there is a field foo
+    And foo is of type "string"
+
+  Scenario: Running a 'matchingRegex' request that includes roman alphabet lowercase chars (a-z) only should be successful
+    Given foo is matching regex /./
+    Then the following data should be generated:
+      | foo  |
+      | null |
+      | " "  |
+      | "!"  |
+      | """  |
+      | "#"  |
+      | "$"  |
+      | "%"  |
+      | "&"  |
+      | "'"  |
+      | "("  |
+      | ")"  |
+      | "*"  |
+      | "+"  |
+      | ","  |
+      | "-"  |
+      | "."  |
+      | "/"  |
+      | "0"  |
+      | "1"  |
+      | "2"  |
+      | "3"  |
+      | "4"  |
+      | "5"  |
+      | "6"  |
+      | "7"  |
+      | "8"  |
+      | "9"  |
+      | ":"  |
+      | ";"  |
+      | "<"  |
+      | "="  |
+      | ">"  |
+      | "?"  |
+      | "@"  |
+      | "A"  |
+      | "B"  |
+      | "C"  |
+      | "D"  |
+      | "E"  |
+      | "F"  |
+      | "G"  |
+      | "H"  |
+      | "I"  |
+      | "J"  |
+      | "K"  |
+      | "L"  |
+      | "M"  |
+      | "N"  |
+      | "O"  |
+      | "P"  |
+      | "Q"  |
+      | "R"  |
+      | "S"  |
+      | "T"  |
+      | "U"  |
+      | "V"  |
+      | "W"  |
+      | "X"  |
+      | "Y"  |
+      | "Z"  |
+      | "["  |
+      | "\"  |
+      | "]"  |
+      | "^"  |
+      | "_"  |
+      | "`"  |
+      | "a"  |
+      | "b"  |
+      | "c"  |
+      | "d"  |
+      | "e"  |
+      | "f"  |
+      | "g"  |
+      | "h"  |
+      | "i"  |
+      | "j"  |
+      | "k"  |
+      | "l"  |
+      | "m"  |
+      | "n"  |
+      | "o"  |
+      | "p"  |
+      | "q"  |
+      | "r"  |
+      | "s"  |
+      | "t"  |
+      | "u"  |
+      | "v"  |
+      | "w"  |
+      | "x"  |
+      | "y"  |
+      | "z"  |
+      | "{"  |
+      | "\|"  |
+      | "}"  |
+      | "~"  |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex-SpecialChars.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex-SpecialChars.feature
@@ -1,0 +1,57 @@
+# (1075) ignoring these tests as only allowing latin character set for now but we will turn them back on when allow them
+@ignore
+Feature: Whilst including non-latin characters, user can specify that contains a specified regex
+
+  Background:
+    Given the generation strategy is full
+    And there is a field foo
+    And foo is of type "string"
+
+  Scenario: Running a 'containingRegex' request that includes special characters (non roman character maps: Hiragana) should be successful
+    Given foo is containing regex /[あ-げ]{1}/
+    And foo is of length 1
+    Then the following data should be generated:
+      | foo  |
+      | null |
+      | "あ"  |
+      | "ぃ"  |
+      | "い"  |
+      | "ぅ"  |
+      | "う"  |
+      | "ぇ"  |
+      | "え"  |
+      | "ぉ"  |
+      | "お"  |
+      | "か"  |
+      | "が"  |
+      | "き"  |
+      | "ぎ"  |
+      | "く"  |
+      | "ぐ"  |
+      | "け"  |
+      | "げ"  |
+
+  @ignore #294 As a user I want to be able to configure the characters that can be emitted by the generator
+  Scenario: Running a 'containingRegex' request that includes special characters (emoji) only should be successful
+    Given foo is containing regex /[😁-😘]{1}/
+    And foo is of length 1
+    Then the following data should be generated:
+      | foo  |
+      | null |
+      | "😁" |
+      | "😂" |
+      | "😃" |
+      | "😄" |
+      | "😅" |
+      | "😆" |
+      | "😉" |
+      | "😊" |
+      | "😋" |
+      | "😌" |
+      | "😍" |
+      | "😏" |
+      | "😒" |
+      | "😓" |
+      | "😔" |
+      | "😖" |
+      | "😘" |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex.feature
@@ -109,55 +109,6 @@ Feature: User can specify that contains a specified regex
       | "-"  |
       | "."  |
 
-  Scenario: Running a 'containingRegex' request that includes special characters (non roman character maps: Hiragana) should be successful
-    Given foo is containing regex /[あ-げ]{1}/
-    And foo is of length 1
-    Then the following data should be generated:
-      | foo  |
-      | null |
-      | "あ"  |
-      | "ぃ"  |
-      | "い"  |
-      | "ぅ"  |
-      | "う"  |
-      | "ぇ"  |
-      | "え"  |
-      | "ぉ"  |
-      | "お"  |
-      | "か"  |
-      | "が"  |
-      | "き"  |
-      | "ぎ"  |
-      | "く"  |
-      | "ぐ"  |
-      | "け"  |
-      | "げ"  |
-
-  @ignore #294 As a user I want to be able to configure the characters that can be emitted by the generator
-  Scenario: Running a 'containingRegex' request that includes special characters (emoji) only should be successful
-    Given foo is containing regex /[😁-😘]{1}/
-    And foo is of length 1
-    Then the following data should be generated:
-      | foo  |
-      | null |
-      | "😁" |
-      | "😂" |
-      | "😃" |
-      | "😄" |
-      | "😅" |
-      | "😆" |
-      | "😉" |
-      | "😊" |
-      | "😋" |
-      | "😌" |
-      | "😍" |
-      | "😏" |
-      | "😒" |
-      | "😓" |
-      | "😔" |
-      | "😖" |
-      | "😘" |
-
   Scenario: Running a 'containingRegex' request that includes anchors ^ and $ should be successful
     Given foo is containing regex /^[a-c]{1}$/
     And foo is of length 1

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex-SpecialChars.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex-SpecialChars.feature
@@ -1,0 +1,38 @@
+# (1075) ignoring these tests as only allowing latin character set for now but we will turn them back on when allow them
+@ignore
+Feature: Whilst including non-latin characters, user can specify that a value either matches or contains a specified regex
+
+  Background:
+    Given the generation strategy is full
+    And there is a field foo
+    And foo is of type "string"
+
+  Scenario: Running a 'matchingRegex' request that includes special characters (non roman character maps: Hiragana) should be successful
+    Given foo is matching regex /[あ-げ]{1}/
+    Then the following data should be generated:
+      | foo  |
+      | null |
+      | "あ"  |
+      | "ぃ"  |
+      | "い"  |
+      | "ぅ"  |
+      | "う"  |
+      | "ぇ"  |
+      | "え"  |
+      | "ぉ"  |
+      | "お"  |
+      | "か"  |
+      | "が"  |
+      | "き"  |
+      | "ぎ"  |
+      | "く"  |
+      | "ぐ"  |
+      | "け"  |
+      | "げ"  |
+
+  Scenario: Running a 'matchingRegex' request that includes special characters (emoji) only should be successful
+    Given foo is matching regex /[😁-😘]{1}/
+    Then the following data should be generated:
+      | foo  |
+      | null |
+

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex.feature
@@ -110,23 +110,6 @@ Feature: User can specify that a value either matches or contains a specified re
     Then the following data should be generated:
       | foo  |
       | null |
-      | "あ"  |
-      | "ぃ"  |
-      | "い"  |
-      | "ぅ"  |
-      | "う"  |
-      | "ぇ"  |
-      | "え"  |
-      | "ぉ"  |
-      | "お"  |
-      | "か"  |
-      | "が"  |
-      | "き"  |
-      | "ぎ"  |
-      | "く"  |
-      | "ぐ"  |
-      | "け"  |
-      | "げ"  |
 
   Scenario: Running a 'matchingRegex' request that includes special characters (emoji) only should be successful
     Given foo is matching regex /[😁-😘]{1}/


### PR DESCRIPTION
### Description
Change string generation to pick from latin characters

### Changes
The character set has been restriceted to the range between U+0020 and U+007E.
Documentation and tests have been updated.

### Additional notes
Note that this does not satisfy all acceptance criteria in #1075 specifically there is not command line argument which can toggle the feature.

### Issue
Related to #1075
Had merge issue withoriginal PR #1138 so cherry picked into this PR