### PR TITLE
improve JsonProfileReader

### DIFF
--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
@@ -39,11 +39,11 @@ import java.util.stream.Collectors;
  * It returns a Profile object for consumption by a generator
  */
 public class JsonProfileReader implements ProfileReader {
-    ConstraintReaderMap readerMap;
+    private final MainConstraintReader mainConstraintReader;
 
     @Inject
-    public JsonProfileReader(ConstraintReaderMap mappings) {
-        readerMap = mappings;
+    public JsonProfileReader(MainConstraintReader mainConstraintReader) {
+        this.mainConstraintReader = mainConstraintReader;
     }
 
     public Profile read(Path filePath) throws IOException {
@@ -71,8 +71,6 @@ public class JsonProfileReader implements ProfileReader {
                 .map(fDto -> new Field(fDto.name))
                 .collect(Collectors.toList()));
 
-        ConstraintReader constraintReader = new MainConstraintReader(readerMap);
-
         Collection<Rule> rules = mapDtos(
             profileDto.rules,
             r -> {
@@ -86,7 +84,7 @@ public class JsonProfileReader implements ProfileReader {
                         r.constraints,
                         dto -> {
                             try {
-                                return constraintReader.apply(
+                                return mainConstraintReader.apply(
                                     dto,
                                     profileFields,
                                     Collections.singleton(constraintRule));

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -48,17 +48,18 @@ import static org.hamcrest.core.IsNull.nullValue;
 public class JsonProfileReaderTests {
     private String json;
     private Profile profile;
-    private ConstraintReaderMap readerMap;
+    private MainConstraintReader mainConstraintReader;
 
     @BeforeEach
     public void Setup() {
         this.json = null;
         this.profile = null;
-        readerMap = new BaseConstraintReaderMap(Stream.of(
+        ConstraintReaderMap readerMap = new BaseConstraintReaderMap(Stream.of(
             new CoreAtomicTypesConstraintReaderSource(null),
             new FinancialTypesConstraintReaderSource(),
             new PersonalDataTypesConstraintReaderSource()
         ));
+        mainConstraintReader = new MainConstraintReader(readerMap);
     }
 
     private void givenJson(String json) {
@@ -67,7 +68,7 @@ public class JsonProfileReaderTests {
 
     private Profile getResultingProfile() throws IOException {
         if (this.profile == null) {
-            JsonProfileReader objectUnderTest = new JsonProfileReader(readerMap);
+            JsonProfileReader objectUnderTest = new JsonProfileReader(mainConstraintReader);
             this.profile = objectUnderTest.read(this.json);
         }
 


### PR DESCRIPTION
### Description
have JsonProfileReader explicity take in the mainConstraintReader rather than access it indirectly

this makes it clearer where the entry point to the constraint reading is.