### PR TITLE
feat(#1165): call set from file using "file" instead of "values"

### DIFF
--- a/docs/user/UserGuide.md
+++ b/docs/user/UserGuide.md
@@ -20,7 +20,6 @@
         2. [inSet](#predicate-inset)
         3. [null](#predicate-null)
         4. [ofType](#predicate-oftype)
-        5. [setFromFile](#predicate-setfromfile)
     3. [Textual constraints](#Textual-constraints)
         1. [matchingRegex](#predicate-matchingregex)
         2. [containingRegex](#predicate-containingregex)
@@ -212,32 +211,10 @@ Is satisfied if `field`'s value is equal to `value`
 
 Is satisfied if `field`'s value is in the set `values`
 
-<div id="predicate-null"></div>
-
-### `null` _(field)_
+Alternatively, sets can be populated from files.
 
 ```javascript
-{ "field": "price", "is": "null" }
-```
-
-Is satisfied if `field` is null or absent.
-
-<div id="predicate-oftype"></div>
-
-### `ofType` _(field, value)_
-
-```javascript
-{ "field": "price", "is": "ofType", "value": "string" }
-```
-
-Is satisfied if `field` is of type represented by `value` (valid options: `decimal`, `integer`, `string`, `datetime`, `ISIN`, `SEDOL`, `CUSIP`, `RIC`, `firstname`, `lastname` or `fullname`)
-
-<div id="predicate-setfromfile"></div>
-
-### `setFromFile` _(field, value)_
-
-```javascript
-{ "field": "country", "is": "setFromFile", "value": "countries.csv" }
+{ "field": "country", "is": "inSet", "file": "countries.csv" }
 ```
 
 Populates a set from the new-line delimited file (with suffix `.csv`), where each line represents a string value to load.
@@ -265,6 +242,26 @@ Scotland, 3
 ```
 
 After loading the set from the file, this constraint behaves identically to the [inSet](#predicate-inset) constraint. This includes its behaviour when negated or violated.
+
+<div id="predicate-null"></div>
+
+### `null` _(field)_
+
+```javascript
+{ "field": "price", "is": "null" }
+```
+
+Is satisfied if `field` is null or absent.
+
+<div id="predicate-oftype"></div>
+
+### `ofType` _(field, value)_
+
+```javascript
+{ "field": "price", "is": "ofType", "value": "string" }
+```
+
+Is satisfied if `field` is of type represented by `value` (valid options: `decimal`, `integer`, `string`, `datetime`, `ISIN`, `SEDOL`, `CUSIP`, `RIC`, `firstname`, `lastname` or `fullname`)
 
 ## Textual constraints
 

--- a/examples/from-file-weighted/profile.json
+++ b/examples/from-file-weighted/profile.json
@@ -22,8 +22,8 @@
       "constraints": [
         {
           "field": "name",
-          "is": "setFromFile",
-          "value": "greek.csv"
+          "is": "inSet",
+          "file": "greek.csv"
         }
       ]
     }

--- a/examples/from-file/profile.json
+++ b/examples/from-file/profile.json
@@ -22,8 +22,8 @@
       "constraints": [
         {
           "field": "name",
-          "is": "setFromFile",
-          "value": "greek.csv"
+          "is": "inSet",
+          "file": "greek.csv"
         }
       ]
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/loadfiletest.profile.json
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/loadfiletest.profile.json
@@ -22,8 +22,8 @@
       "constraints": [
         {
           "field": "foo",
-          "is": "setFromFile",
-          "value": "src/test/java/com/scottlogic/deg/orchestrator/endtoend/testfile.csv"
+          "is": "inSet",
+          "file": "src/test/java/com/scottlogic/deg/orchestrator/endtoend/testfile.csv"
         }
       ]
     }

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/AtomicConstraintTypeReaderMap.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/AtomicConstraintTypeReaderMap.java
@@ -16,30 +16,21 @@
 
 package com.scottlogic.deg.profile.reader;
 
-import com.google.inject.Inject;
-import com.scottlogic.deg.common.ValidationException;
-import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.constraints.atomic.*;
 import com.scottlogic.deg.common.util.Defaults;
-import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedSet;
-import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
-import com.scottlogic.deg.profile.reader.constraintreaders.FromFileReader;
+import com.scottlogic.deg.profile.reader.constraintreaders.SetReader;
 import com.scottlogic.deg.profile.reader.constraintreaders.GranularToReader;
 import com.scottlogic.deg.profile.reader.constraintreaders.OfTypeReader;
-import com.scottlogic.deg.profile.reader.file.CsvInputStreamReader;
 import com.scottlogic.deg.profile.v0_1.AtomicConstraintType;
 
-import java.io.*;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static com.scottlogic.deg.profile.reader.ConstraintReaderHelpers.getValidatedValue;
-import static com.scottlogic.deg.profile.reader.ConstraintReaderHelpers.getValidatedValues;
 import static com.scottlogic.deg.profile.v0_1.AtomicConstraintType.*;
 
 public class AtomicConstraintTypeReaderMap {
@@ -57,7 +48,7 @@ public class AtomicConstraintTypeReaderMap {
 
         map.put(IS_OF_TYPE, new OfTypeReader());
         map.put(IS_GRANULAR_TO, new GranularToReader());
-        map.put(IS_FROM_FILE, new FromFileReader(fromFilePath));
+        map.put(IS_IN_SET, new SetReader(fromFilePath));
 
         map.put(FORMATTED_AS,
             (dto, fields) -> new FormatConstraint(
@@ -68,12 +59,6 @@ public class AtomicConstraintTypeReaderMap {
             (dto, fields) -> new EqualToConstraint(
                 fields.getByName(dto.field),
                 getValidatedValue(dto)));
-
-        map.put(IS_IN_SET,
-            (dto, fields) ->
-                new IsInSetConstraint(
-                    fields.getByName(dto.field),
-                    FrequencyDistributedSet.uniform(getValidatedValues(dto))));
 
         map.put(CONTAINS_REGEX,
             (dto, fields) ->

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/AtomicConstraintType.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/AtomicConstraintType.java
@@ -24,7 +24,6 @@ public enum AtomicConstraintType {
     IS_IN_SET("inSet"),
     IS_NULL("null"),
     IS_OF_TYPE("ofType"),
-    IS_FROM_FILE("setFromFile"),
 
     MATCHES_REGEX("matchingRegex"),
     CONTAINS_REGEX("containingRegex"),

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/ConstraintDTO.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/ConstraintDTO.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Collection;
 
-@JsonPropertyOrder({ "field", "is", "value", "if", "then", "else" })
+@JsonPropertyOrder({ "field", "is", "value", "file", "if", "then", "else" })
 public class ConstraintDTO {
     // the DTO is very permissive, because validation isn't its job.
     // validation rules should be expressed in JSON schemas and DTO -> Model converters
@@ -38,6 +38,8 @@ public class ConstraintDTO {
 
     /** a set of values - eg, used in isInSet */
     public Collection<Object> values;
+
+    public String file;
 
     /** a constraint to negate - this property should only appear alone */
     public ConstraintDTO not;

--- a/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -132,6 +132,9 @@
           "$ref": "#/definitions/inSetConstraint"
         },
         {
+          "$ref": "#/definitions/fromFileConstraint"
+        },
+        {
           "$ref": "#/definitions/notConstraint"
         },
         {
@@ -168,8 +171,7 @@
             "after",
             "afterOrAt",
             "before",
-            "beforeOrAt",
-            "setFromFile"
+            "beforeOrAt"
           ]
         },
         "value": {
@@ -388,22 +390,6 @@
               }
             }
           }
-        },
-        {
-          "if": {
-            "properties": {
-              "is": {
-                "const": "setFromFile"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "value": {
-                "$ref": "#/definitions/string"
-              }
-            }
-          }
         }
       ]
     },
@@ -484,6 +470,22 @@
         },
         "is": {
           "const": "null"
+        }
+      }
+    },
+    "fromFileConstraint": {
+      "type": "object",
+      "required": ["field", "is", "file"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "inSet"
+        },
+        "file": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
### Description
call sets from file using 
{ "field": "country", "is": "inSet", "file": "countries.csv" }

instead of 
{ "field": "country", "is": "setFromFile", "value": "countries.csv" }

### Issue
Resolves #1165 