### PR TITLE
feat(#1192): filter out malformed isins instead of changing them

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/ChecksummedCodeStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/ChecksummedCodeStringGenerator.java
@@ -140,7 +140,9 @@ public abstract class ChecksummedCodeStringGenerator implements StringGenerator 
                 generateAllInvalidRegexStrings(),
                 generateAllInvalidCheckDigitStrings());
         }
-        return wrapIterableWithProjectionAndFilter(regexGenerator.generateAllValues());
+        return new FilteringIterable<>(
+            regexGenerator.generateAllValues(),
+            (x) -> x.equals(fixCheckDigit(x)));
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/IsinStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/IsinStringGenerator.java
@@ -146,7 +146,9 @@ public class IsinStringGenerator implements StringGenerator {
                     generateAllInvalidCheckDigitIsins()));
         }
         final List<Iterable<String>> countryCodeIterables = getAllCountryIsinGeneratorsAsStream()
-            .map(generator -> wrapIterableWithProjectionAndFilter(generator.generateAllValues()))
+            .map(generator -> new FilteringIterable<>(
+                generator.generateAllValues(),
+                (x) -> x.equals(replaceCheckDigit(x))))
             .collect(Collectors.toList());
         return new ConcatenatingIterable<>(countryCodeIterables);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/ProjectingIterable.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/ProjectingIterable.java
@@ -60,7 +60,8 @@ public class ProjectingIterable<TFrom, TTo> implements Iterable<TTo>
 
         @Override
         public TTo next() {
-            return this.converter.apply(this.sourceIterator.next());
+            TFrom next = sourceIterator.next();
+            return converter.apply(next);
         }
     }
 }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/OfTypeFinancialCodes.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/OfTypeFinancialCodes.feature
@@ -13,6 +13,17 @@ Feature: User can specify that a field must be a financial code type
       | null           |
       | "GB0002634946" |
 
+  Scenario: Sequential isins are generated uniquely
+    Given foo is of type "ISIN"
+    And foo is anything but null
+    And the generator can generate at most 4 rows
+    Then the following data should be generated:
+      | foo            |
+      | "GB0000000009" |
+      | "GB0000000116" |
+      | "GB0000000223" |
+      | "GB0000000330" |
+
   Scenario: An ofType constraint with the value "isin" fails with an invalid profile error message
     Given foo is of type "isin"
     Then the profile is invalid because "Profile is invalid: no constraints known for \"is\": \"ofType\", \"value\": \"isin\""


### PR DESCRIPTION
### Description
isin's aren't unique in full sequential

### Changes
currently generates all possible isins, then modifies ones with bad checksums to have the correct checksum. this causes lots of duplication

now it filters out the bad isins, which is inneficient

future work should be to change how isins are generated

### Issue
Resolves #1192 