### PR TITLE
1146 smart directory searching

### DIFF
--- a/docs/developer/HowToAddSupportForNewSchemaVersion.md
+++ b/docs/developer/HowToAddSupportForNewSchemaVersion.md
@@ -2,7 +2,6 @@
 
 1. Copy a package in _profile/src/main/resources/profileschema/_ and rename to the new version number.
 1. Change the _schemaVersion_ const from the old version number to the new one.
-1. Change the hardcoded list in _profile/v0_1/SupportedVersionChecker.java_ (future work is to remove the necessity of doing this).
 
 ### Example
 If the file structure currently looks like the below...
@@ -38,12 +37,3 @@ Then change the below (in the new file)...
 },
 ...
 ``` 
-
-Then change the line in SupportedVersionChecker from...
-```
-List<String> supportedSchemaVersions = Arrays.asList("0.1");
-```
-...to:
-```
-List<String> supportedSchemaVersions = Arrays.asList("0.1", "0.2");
-```

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -26,6 +26,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JarExecuteTests {
+    private String errorMessageOnFailure =
+        "Jar test failed. This may have been caused by one of the following:" +
+        "1) You have not built the jar. \n Try running Gradle Build. \n" +
+        "2) System.out is being printed to (which interferes with streaming output) e.g. using 'printStackTrace'.\n" +
+        "3) There is a bug in code conditional on whether it is running inside the JAR, e.g. in SupportedVersionsGetter. \n";
 
     @Test
     void generateSuccessfullyFromJar() throws Exception {
@@ -33,9 +38,7 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertEquals(Arrays.asList("foo", "\"Generation successful\""), collectedOutput,
-            "Jar test failed. This might be because you have not built the jar. \n Try running Gradle Build. \n" +
-            "Alternatively, it may be because System.out is being printed to (which interferes with streaming output) e.g. using 'printStackTrace'. ");
+        assertEquals(Arrays.asList("foo", "\"Generation successful\""), collectedOutput, errorMessageOnFailure);
     }
 
     @Test
@@ -44,9 +47,7 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertEquals(Arrays.asList("foo", "\"Generated successfully from file\""), collectedOutput,
-            "Jar test failed. This might be because you have not built the jar. \n Try running Gradle Build. \n" +
-            "Alternatively, it may be because System.out is being printed to (which interferes with streaming output) e.g. using 'printStackTrace'. ");
+        assertEquals(Arrays.asList("foo", "\"Generated successfully from file\""), collectedOutput, errorMessageOnFailure);
     }
 
     private Process setupProcess(final String profile) throws IOException {

--- a/profile/src/main/java/com/scottlogic/deg/profile/serialisation/SchemaVersionGetter.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/serialisation/SchemaVersionGetter.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class SchemaVersionRetriever {
+public class SchemaVersionGetter {
     public String getSchemaVersionOfJson(Path filePath) throws IOException {
         byte[] encoded = Files.readAllBytes(filePath);
         String profileJson = new String(encoded, StandardCharsets.UTF_8);

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionChecker.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionChecker.java
@@ -28,11 +28,17 @@ import java.util.List;
 public class SupportedVersionChecker implements SchemaVersionValidator {
     private SchemaVersionRetriever schemaVersionRetriever;
     private ProfileConfigSource configSource;
+    private SupportedVersionsGetter supportedVersionsGetter;
 
     @Inject
-    public SupportedVersionChecker(SchemaVersionRetriever schemaVersionRetriever, ProfileConfigSource configSource) {
+    public SupportedVersionChecker(
+        SchemaVersionRetriever schemaVersionRetriever,
+        ProfileConfigSource configSource,
+        SupportedVersionsGetter supportedVersionsGetter
+    ) {
         this.schemaVersionRetriever = schemaVersionRetriever;
         this.configSource = configSource;
+        this.supportedVersionsGetter = supportedVersionsGetter;
     }
 
     public URL getSchemaFile() throws IOException {
@@ -42,8 +48,7 @@ public class SupportedVersionChecker implements SchemaVersionValidator {
     }
 
     private void validateSchemaVersion(String schemaVersion) {
-        // TODO: Change this so the acceptable schema versions are not hardcoded here:
-        List<String> supportedSchemaVersions = Arrays.asList("0.1");
+        List<String> supportedSchemaVersions = supportedVersionsGetter.getSupportedSchemaVersions();
         if (!supportedSchemaVersions.contains(schemaVersion)) {
             String errorMessage = "This version of the generator does not support v" +
                 schemaVersion +

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionChecker.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionChecker.java
@@ -18,31 +18,30 @@ package com.scottlogic.deg.profile.v0_1;
 import com.google.inject.Inject;
 import com.scottlogic.deg.common.ValidationException;
 import com.scottlogic.deg.profile.guice.ProfileConfigSource;
-import com.scottlogic.deg.profile.serialisation.SchemaVersionRetriever;
+import com.scottlogic.deg.profile.serialisation.SchemaVersionGetter;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 
 public class SupportedVersionChecker implements SchemaVersionValidator {
-    private SchemaVersionRetriever schemaVersionRetriever;
+    private SchemaVersionGetter schemaVersionGetter;
     private ProfileConfigSource configSource;
     private SupportedVersionsGetter supportedVersionsGetter;
 
     @Inject
     public SupportedVersionChecker(
-        SchemaVersionRetriever schemaVersionRetriever,
+        SchemaVersionGetter schemaVersionGetter,
         ProfileConfigSource configSource,
         SupportedVersionsGetter supportedVersionsGetter
     ) {
-        this.schemaVersionRetriever = schemaVersionRetriever;
+        this.schemaVersionGetter = schemaVersionGetter;
         this.configSource = configSource;
         this.supportedVersionsGetter = supportedVersionsGetter;
     }
 
     public URL getSchemaFile() throws IOException {
-        String schemaVersion = schemaVersionRetriever.getSchemaVersionOfJson(configSource.getProfileFile().toPath());
+        String schemaVersion = schemaVersionGetter.getSchemaVersionOfJson(configSource.getProfileFile().toPath());
         validateSchemaVersion(schemaVersion);
         return this.getClass().getResource("/profileschema/" + schemaVersion + "/datahelix.schema.json");
     }

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
@@ -35,6 +35,9 @@ public class SupportedVersionsGetter {
      *  This method picks up any new schema versions added when following the instructions at
      *  docs/developer/HowToAddSupportForNewSchemaVersion.md
      *
+     *  An error in this method could cause the JarExecuteTests to fail because it uses different logic depending
+     *  on whether the JAR has been built.
+     *
      * @return all valid schema versions
      **/
     List<String> getSupportedSchemaVersions() {

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
@@ -25,7 +25,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 public class SupportedVersionsGetter {
-    private final String resourcesPath = "profileschema/";
+    private final static String RESOURCES_PATH = "profileschema/";
     /**
      *  Searches profile/src/main/resources/profileschema/ for sub-directories. The names of these directories
      *  are counted as valid schema versions.
@@ -50,7 +50,7 @@ public class SupportedVersionsGetter {
                 final Enumeration<JarEntry> entries = jar.entries(); //gives ALL entries in jar
                 while (entries.hasMoreElements()) {
                     final String name = entries.nextElement().getName();
-                    if (name.startsWith(resourcesPath)) { //filter according to the path
+                    if (name.startsWith(RESOURCES_PATH)) { //filter according to the path
                         if (name.split("/").length == 2) {
                             supportedSchemaVersions.add(name.split("/")[1]);
                         }
@@ -67,7 +67,7 @@ public class SupportedVersionsGetter {
     }
 
     private List<String> getSupportedSchemaVersionsFromResources() {
-        String directoryContainingSchemas = this.getClass().getResource("/" + resourcesPath).getPath();
+        String directoryContainingSchemas = this.getClass().getResource("/" + RESOURCES_PATH).getPath();
         File file = new File(directoryContainingSchemas);
         String[] directoriesArray = file.list((current, name) -> new File(current, name).isDirectory());
         List<String> directories;

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
@@ -70,9 +70,11 @@ public class SupportedVersionsGetter {
         String directoryContainingSchemas = this.getClass().getResource("/" + resourcesPath).getPath();
         File file = new File(directoryContainingSchemas);
         String[] directoriesArray = file.list((current, name) -> new File(current, name).isDirectory());
-        List<String> directories = new ArrayList<>();
+        List<String> directories;
         if (directoriesArray != null) {
             directories = Arrays.asList(directoriesArray);
+        } else {
+            directories = new ArrayList<>();
         }
         return directories;
     }

--- a/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.scottlogic.deg.profile.v0_1;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SupportedVersionsGetter {
+    List<String> getSupportedSchemaVersions() {
+        return Arrays.asList("0.1");
+    }
+}

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionCheckerTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionCheckerTests.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,7 +43,9 @@ class SupportedVersionCheckerTests {
         File mockFile = mock(File.class);
         when(mockFile.toPath()).thenReturn(mock(Path.class));
         when(configSource.getProfileFile()).thenReturn(mockFile);
-        SupportedVersionChecker validator = new SupportedVersionChecker(retriever, configSource);
+        SupportedVersionsGetter supportedVersionsGetter = mock(SupportedVersionsGetter.class);
+        when(supportedVersionsGetter.getSupportedSchemaVersions()).thenReturn(Arrays.asList("0.1"));
+        SupportedVersionChecker validator = new SupportedVersionChecker(retriever, configSource, supportedVersionsGetter);
 
         //Act
         URL schema = null;
@@ -65,8 +68,9 @@ class SupportedVersionCheckerTests {
         File mockFile = mock(File.class);
         when(mockFile.toPath()).thenReturn(mock(Path.class));
         when(configSource.getProfileFile()).thenReturn(mockFile);
-        SupportedVersionChecker validator = new SupportedVersionChecker(retriever, configSource);
-
+        SupportedVersionsGetter supportedVersionsGetter = mock(SupportedVersionsGetter.class);
+        when(supportedVersionsGetter.getSupportedSchemaVersions()).thenReturn(Arrays.asList("0.1"));
+        SupportedVersionChecker validator = new SupportedVersionChecker(retriever, configSource, supportedVersionsGetter);
 
         //Act & Assert
         assertThrows(ValidationException.class, validator::getSchemaFile);

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionCheckerTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionCheckerTests.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.profile.v0_1;
 
 import com.scottlogic.deg.common.ValidationException;
 import com.scottlogic.deg.profile.guice.ProfileConfigSource;
-import com.scottlogic.deg.profile.serialisation.SchemaVersionRetriever;
+import com.scottlogic.deg.profile.serialisation.SchemaVersionGetter;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -37,7 +37,7 @@ class SupportedVersionCheckerTests {
     @Test
     void getSchemaFile_withSupportedVersion_returnsNonNullURL() throws IOException {
         //Arrange
-        SchemaVersionRetriever retriever = mock(SchemaVersionRetriever.class);
+        SchemaVersionGetter retriever = mock(SchemaVersionGetter.class);
         when(retriever.getSchemaVersionOfJson(any())).thenReturn("0.1");
         ProfileConfigSource configSource = mock(ProfileConfigSource.class);
         File mockFile = mock(File.class);
@@ -62,7 +62,7 @@ class SupportedVersionCheckerTests {
     @Test
     void getSchemaFile_withUnsupportedVersion_throwsValidationException() throws IOException {
         //Arrange
-        SchemaVersionRetriever retriever = mock(SchemaVersionRetriever.class);
+        SchemaVersionGetter retriever = mock(SchemaVersionGetter.class);
         when(retriever.getSchemaVersionOfJson(any())).thenReturn("101.53");
         ProfileConfigSource configSource = mock(ProfileConfigSource.class);
         File mockFile = mock(File.class);

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetterTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetterTests.java
@@ -1,0 +1,31 @@
+package com.scottlogic.deg.profile.v0_1;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class SupportedVersionsGetterTests {
+    @Test
+    void getSupportedSchemaVersions_returnsAtLeastOneSchemaVersion() {
+        SupportedVersionsGetter supportedVersionsGetter = new SupportedVersionsGetter();
+
+        assertFalse(
+            supportedVersionsGetter.getSupportedSchemaVersions().isEmpty(),
+            "Expected there to be at least one valid version");
+    }
+}

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetterTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/SupportedVersionsGetterTests.java
@@ -1,9 +1,3 @@
-package com.scottlogic.deg.profile.v0_1;
-
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 /*
  * Copyright 2019 Scott Logic Ltd
  *
@@ -19,6 +13,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package com.scottlogic.deg.profile.v0_1;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 class SupportedVersionsGetterTests {
     @Test
     void getSupportedSchemaVersions_returnsAtLeastOneSchemaVersion() {


### PR DESCRIPTION
### Description
Searches profile/src/main/resources/profileschema/ for sub-directories. The names of these directories are counted as valid schema versions. Previously the valid schema versions were hard-coded.

### Notes
This could be more fragile than hard-coding the value. The trade-off between this and the old way needs to be considered.

### Issues
Related to #1146 
