### PR TITLE
fix(#1203): Fix crash on long running generation

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/RegexStringGenerator.java
@@ -204,7 +204,7 @@ public class RegexStringGenerator implements StringGenerator {
 
     }
 
-    private String buildStringFromNode(Node node, int indexOrder) {
+    private String buildStringFromNode(Node node, long indexOrder) {
         String result = "";
         long passedStringNbr = 0;
         long step = node.getMatchedStringIdx() / node.getNbrChar();
@@ -352,7 +352,7 @@ public class RegexStringGenerator implements StringGenerator {
     private class FiniteStringAutomatonIterator implements Iterator<String> {
 
         private final long matches;
-        private int currentIndex;
+        private long currentIndex;
         private String currentValue;
 
         FiniteStringAutomatonIterator(RegexStringGenerator stringGenerator) {
@@ -395,7 +395,7 @@ public class RegexStringGenerator implements StringGenerator {
             return currentValue != null;
         }
 
-        private String getMatchedString(int indexOrder) {
+        private String getMatchedString(long indexOrder) {
             buildRootNode();
             if (indexOrder < 1) {
                 throw new IllegalArgumentException("indexOrder must be >= 1");


### PR DESCRIPTION
### Description
Fixes crash. Checked by creating a long running process that goes past the 22nd million row.

The issue was caused by a signed `int` overflow causing the index to be negative, and hence illegal.

A long has twice the number of significant digits, so we would expect long to fail in the same way if the generator is run for a factor of over `10^9` longer than for the crash that happened previously.

### Issue
Resolves #1203

