### PR TITLE
perf(#1190): Determise the automaton after the char set is restricted

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -71,7 +71,7 @@ public class AutomatonUtils {
         // NB: AF if want to allow cmd line option to expand to a fuller character set make sure don't
         // make it unbounded as we don't want to see tabs or back spaces or null (\u0000) unicode chars
         generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007E');
-
+        generatedAutomaton.determinize();
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/AutomatonUtils.java
@@ -71,6 +71,10 @@ public class AutomatonUtils {
         // NB: AF if want to allow cmd line option to expand to a fuller character set make sure don't
         // make it unbounded as we don't want to see tabs or back spaces or null (\u0000) unicode chars
         generatedAutomaton = restrictCharacterSet(generatedAutomaton, '\u0020', '\u007E');
+
+        // The automaton is determinised to improve performance. See
+        // https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton#Equivalence_to_DFA
+        // for details.
         generatedAutomaton.determinize();
         cache.put(regexStr, generatedAutomaton);
         return generatedAutomaton;


### PR DESCRIPTION
### Description
Determise the automaton after the character set is restricted.

This appears to improve performance for large  profiles


### Issue
Related to #1190 
