### PR TITLE
Improve integration testing of schema versioning

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/validator/ProfileValidationTests.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.orchestrator.validator;
 
+import com.scottlogic.deg.profile.serialisation.SchemaVersionGetter;
 import com.scottlogic.deg.profile.v0_1.ProfileSchemaValidatorLeadPony;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -40,9 +41,10 @@ public class ProfileValidationTests {
         for (File dir : directoriesArray) {
             File profileFile = Paths.get(dir.getCanonicalPath(), "profile.json").toFile();
 
-            String LATEST_REAL_SCHEMA_VERSION_PATH = "profileschema/0.2/datahelix.schema.json";
+            String schemaVersion = new SchemaVersionGetter().getSchemaVersionOfJson(profileFile.toPath());
+            String schemaVersionPath = "profileschema/" + schemaVersion + "/datahelix.schema.json";
             URL schemaUrl =
-                Thread.currentThread().getContextClassLoader().getResource(LATEST_REAL_SCHEMA_VERSION_PATH);
+                Thread.currentThread().getContextClassLoader().getResource(schemaVersionPath);
             DynamicTest test = DynamicTest.dynamicTest(
                 dir.getName(),
                 () -> new ProfileSchemaValidatorLeadPony().validateProfile(profileFile, schemaUrl));

--- a/profile/src/main/resources/profileschema/0.2/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.2/datahelix.schema.json
@@ -51,7 +51,7 @@
   "definitions": {
     "schemaVersion": {
       "title": "The version of the DataHelix profile schema",
-      "enum": ["0.1", "0.2"]
+      "const": "0.2"
     },
     "dataType": {
       "oneOf": [

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorLeadPonyTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorLeadPonyTests.java
@@ -34,14 +34,4 @@ class ProfileSchemaValidatorLeadPonyTests extends ProfileSchemaValidatorTests {
     Collection<DynamicTest> testValidProfiles() {
         return super.testValidProfiles(profileValidator);
     }
-
-    @TestFactory
-    Collection<DynamicTest> testValidSchemaVersions() {
-        return super.testValidSchemaVersions(profileValidator);
-    }
-
-    @TestFactory
-    Collection<DynamicTest> testInvalidSchemaVersions() {
-        return super.testInvalidSchemaVersions(profileValidator);
-    }
 }

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorMedeiaTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorMedeiaTests.java
@@ -34,14 +34,4 @@ class ProfileSchemaValidatorMedeiaTests  extends ProfileSchemaValidatorTests {
     Collection<DynamicTest> testValidProfiles() {
         return super.testValidProfiles(profileValidator);
     }
-
-    @TestFactory
-    Collection<DynamicTest> testValidSchemaVersions() {
-        return super.testValidSchemaVersions(profileValidator);
-    }
-
-    @TestFactory
-    Collection<DynamicTest> testInvalidSchemaVersions() {
-        return super.testInvalidSchemaVersions(profileValidator);
-    }
 }

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorTests.java
@@ -34,32 +34,24 @@ public class ProfileSchemaValidatorTests {
     private final String INVALID_PROFILE_DIR = "invalid";
     private final String VALID_PROFILE_DIR = "valid";
 
-    FilenameFilter jsonFilter = (dir, name) -> {
-        String lowercaseName = name.toLowerCase();
-        if (lowercaseName.endsWith(".json")) {
-            return true;
-        } else {
-            return false;
-        }
-    };
+    private FilenameFilter jsonFilter = (dir, name) -> name.toLowerCase().endsWith(".json");
 
     private File getFileFromURL(String profileDirName) {
         URL url = this.getClass().getResource(TEST_PROFILE_DIR + profileDirName);
-        File file = null;
+        File file;
         try {
             file = new File(url.toURI());
         } catch (URISyntaxException e) {
             file = new File(url.getPath());
-        } finally {
-            return file;
         }
+        return file;
     }
 
     Collection<DynamicTest> testInvalidProfiles(ProfileSchemaValidator profileValidator) {
-        File[] listOfFiles = getFileFromURL(INVALID_PROFILE_DIR).listFiles(jsonFilter);
+        File[] arrayOfFiles = getFileFromURL(INVALID_PROFILE_DIR).listFiles(jsonFilter);
         Collection<DynamicTest> dynTsts = new ArrayList<>();
 
-        for (File file : listOfFiles) {
+        for (File file : arrayOfFiles) {
             DynamicTest test = DynamicTest.dynamicTest(file.getName(), () -> {
                 URL testProfileUrl =
                     this.getClass().getResource(
@@ -83,10 +75,10 @@ public class ProfileSchemaValidatorTests {
     }
 
     Collection<DynamicTest> testValidProfiles(ProfileSchemaValidator profileValidator) {
-        File[] listOfFiles = getFileFromURL(VALID_PROFILE_DIR).listFiles(jsonFilter);
+        File[] arrayOfFiles = getFileFromURL(VALID_PROFILE_DIR).listFiles(jsonFilter);
         Collection<DynamicTest> dynTsts = new ArrayList<>();
 
-        for (File file : listOfFiles) {
+        for (File file : arrayOfFiles) {
             String profileFilename = file.getName();
             DynamicTest test = DynamicTest.dynamicTest(profileFilename, () -> {
                 URL testProfileUrl =

--- a/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/v0_1/ProfileSchemaValidatorTests.java
@@ -17,33 +17,29 @@
 package com.scottlogic.deg.profile.v0_1;
 
 import com.scottlogic.deg.common.ValidationException;
+import com.scottlogic.deg.profile.serialisation.SchemaVersionGetter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 
 public class ProfileSchemaValidatorTests {
     private final String TEST_PROFILE_DIR = "/test-profiles/";
     private final String INVALID_PROFILE_DIR = "invalid";
     private final String VALID_PROFILE_DIR = "valid";
-    private final String LATEST_REAL_SCHEMA_VERSION_PATH = "profileschema/0.2/datahelix.schema.json";
 
-    FilenameFilter jsonFilter = new FilenameFilter() {
-        public boolean accept(File dir, String name) {
-            String lowercaseName = name.toLowerCase();
-            if (lowercaseName.endsWith(".json")) {
-                return true;
-            } else {
-                return false;
-            }
+    FilenameFilter jsonFilter = (dir, name) -> {
+        String lowercaseName = name.toLowerCase();
+        if (lowercaseName.endsWith(".json")) {
+            return true;
+        } else {
+            return false;
         }
     };
 
@@ -63,20 +59,20 @@ public class ProfileSchemaValidatorTests {
         File[] listOfFiles = getFileFromURL(INVALID_PROFILE_DIR).listFiles(jsonFilter);
         Collection<DynamicTest> dynTsts = new ArrayList<>();
 
-        for (int i = 0; i < listOfFiles.length; i++) {
-            String profileFilename = listOfFiles[i].getName();
-            DynamicTest test = DynamicTest.dynamicTest(profileFilename, () -> {
+        for (File file : listOfFiles) {
+            DynamicTest test = DynamicTest.dynamicTest(file.getName(), () -> {
                 URL testProfileUrl =
                     this.getClass().getResource(
-                        TEST_PROFILE_DIR + INVALID_PROFILE_DIR + "/" + profileFilename
+                        TEST_PROFILE_DIR + INVALID_PROFILE_DIR + "/" + file.getName()
                     );
+                String schemaVersion = new SchemaVersionGetter().getSchemaVersionOfJson(file.toPath());
                 URL schemaUrl =
-                    Thread.currentThread().getContextClassLoader().getResource(LATEST_REAL_SCHEMA_VERSION_PATH);
+                    Thread.currentThread().getContextClassLoader().getResource(getSchemaPath(schemaVersion));
                 try {
                     profileValidator.validateProfile(new File(testProfileUrl.getPath()), schemaUrl);
 
                     Supplier<String> msgSupplier = () -> "Profile ["
-                        + profileFilename + "] should not be valid";
+                        + file.getName() + "] should not be valid";
                     Assertions.fail(msgSupplier);
                 } catch (ValidationException e) {
                 }
@@ -97,8 +93,9 @@ public class ProfileSchemaValidatorTests {
                     this.getClass().getResource(
                         TEST_PROFILE_DIR + VALID_PROFILE_DIR + "/" + profileFilename
                     );
+                String schemaVersion = new SchemaVersionGetter().getSchemaVersionOfJson(file.toPath());
                 URL schemaUrl =
-                    Thread.currentThread().getContextClassLoader().getResource(LATEST_REAL_SCHEMA_VERSION_PATH);
+                    Thread.currentThread().getContextClassLoader().getResource(getSchemaPath(schemaVersion));
                 try {
                     profileValidator.validateProfile(new File(testProfileUrl.getPath()), schemaUrl);
                 } catch (ValidationException e) {
@@ -112,57 +109,7 @@ public class ProfileSchemaValidatorTests {
         return dynTsts;
     }
 
-    Collection<DynamicTest> testValidSchemaVersions(ProfileSchemaValidator profileValidator) {
-        File[] listOfFiles = getFileFromURL(VALID_PROFILE_DIR).listFiles(jsonFilter);
-        String profileFilename = listOfFiles[0].getName();
-        Collection<DynamicTest> dynTsts = new ArrayList<>();
-
-        String schemaVersion = "0.2"; // Latest in profile/src/main/resources/profileschema
-        DynamicTest test = DynamicTest.dynamicTest(schemaVersion, () -> {
-            URL testProfileUrl =
-                this.getClass().getResource(
-                    TEST_PROFILE_DIR + VALID_PROFILE_DIR + "/" + profileFilename
-                );
-            String schemaVersionPath = "profileschema/" + schemaVersion + "/datahelix.schema.json";
-            URL schemaUrl = Thread.currentThread().getContextClassLoader().getResource(schemaVersionPath);
-            try {
-                profileValidator.validateProfile(new File(testProfileUrl.getPath()), schemaUrl);
-
-            } catch (ValidationException e) {
-                Assertions.fail(
-                    "Schema Version [" + schemaVersion + "] should be valid"
-                );
-            }
-        });
-        dynTsts.add(test);
-        return dynTsts;
-    }
-
-    Collection<DynamicTest> testInvalidSchemaVersions(ProfileSchemaValidator profileValidator) {
-        File[] listOfFiles = getFileFromURL(VALID_PROFILE_DIR).listFiles(jsonFilter);
-        String profileFilename = listOfFiles[0].getName();
-        Collection<DynamicTest> dynTsts = new ArrayList<>();
-
-        List<String> invalidSchemaVersions = Arrays.asList("0.0", "0.11", "0.3", "1.1", "2.0"); // Ones not in profile/src/main/resources/profileschema
-        invalidSchemaVersions.forEach(schemaVersion -> {
-            DynamicTest test = DynamicTest.dynamicTest(schemaVersion, () -> {
-                URL testProfileUrl =
-                    this.getClass().getResource(
-                        TEST_PROFILE_DIR + VALID_PROFILE_DIR + "/" + profileFilename
-                    );
-                String schemaVersionPath = "profileschema/" + schemaVersion + "/datahelix.schema.json";
-                URL schemaUrl = Thread.currentThread().getContextClassLoader().getResource(schemaVersionPath);
-                try {
-                    profileValidator.validateProfile(new File(testProfileUrl.getPath()), schemaUrl);
-                    Assertions.fail(
-                        "Schema Version [" + schemaVersion + "] should be invalid"
-                    );
-                } catch (ValidationException e) {
-
-                }
-            });
-            dynTsts.add(test);
-        });
-        return dynTsts;
+    private String getSchemaPath(String schemaVersion) {
+        return "profileschema/" + schemaVersion + "/datahelix.schema.json";
     }
 }

--- a/profile/src/test/resources/test-profiles/invalid/date-after-dynamic-with-incorrect-relation.json
+++ b/profile/src/test/resources/test-profiles/invalid/date-after-dynamic-with-incorrect-relation.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "0.2",
+  "fields": [
+    {
+      "name": "field1"
+    }, {
+      "name": "field2"
+    }, {
+      "name": "field3"
+    }, {
+      "name": "field4"
+    }
+  ],
+  "rules": [
+    {
+      "constraints": [
+        {
+          "not": {
+            "field": "field1",
+            "is": "null"
+          }
+        },
+        {
+          "not": {
+            "field": "field2",
+            "is": "null"
+          }
+        },
+        {
+          "not": {
+            "field": "field3",
+            "is": "null"
+          }
+        },
+        {
+          "not": {
+            "field": "field4",
+            "is": "null"
+          }
+        },
+        {
+          "field": "field1",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "field2",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "field3",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "field4",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "field1",
+          "is": "after",
+          "value": {
+            "date": "8001-02-03T04:05:06.007"
+          }
+        },
+        {
+          "field": "field2",
+          "is": "afterField",
+          "value": "field1"
+        },
+        {
+          "field": "field3",
+          "is": "beforeOr",
+          "value": "field4"
+        }
+      ]
+    }
+  ]
+}

--- a/profile/src/test/resources/test-profiles/invalid/invalid-schema-version.json
+++ b/profile/src/test/resources/test-profiles/invalid/invalid-schema-version.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "0.100",
+  "rules": [
+    {
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "equalTo",
+          "value": "hello"
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    },
+    {
+      "name": "field2"
+    }
+  ]
+}

--- a/profile/src/test/resources/test-profiles/invalid/v0-2-features-in-v0-1-profile.json
+++ b/profile/src/test/resources/test-profiles/invalid/v0-2-features-in-v0-1-profile.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "0.1",
+  "fields": [
+    {
+      "name": "first"
+    }, {
+      "name": "second"
+    }
+  ],
+  "rules": [
+    {
+      "constraints": [
+        {
+          "not": {
+            "field": "first",
+            "is": "null"
+          }
+        },
+        {
+          "not": {
+            "field": "second",
+            "is": "null"
+          }
+        },
+        {
+          "field": "first",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "second",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "first",
+          "is": "after",
+          "value": {
+            "date": "8001-02-03T04:05:06.007"
+          }
+        },
+        {
+          "field": "second",
+          "is": "equalToField",
+          "value": "first"
+        }
+      ]
+    }
+  ]
+}

--- a/profile/src/test/resources/test-profiles/valid/date-equal-to-dynamic-offset.json
+++ b/profile/src/test/resources/test-profiles/valid/date-equal-to-dynamic-offset.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "0.2",
+  "fields": [
+    {
+      "name": "first"
+    }, {
+      "name": "second"
+    }, {
+      "name": "firstWorking"
+    }, {
+      "name": "secondWorking"
+    }, {
+      "name": "current"
+    }
+  ],
+  "rules": [
+    {
+      "constraints": [
+        {
+          "not": {
+            "field": "first",
+            "is": "null"
+          }
+        },
+        {
+          "not": {
+            "field": "second",
+            "is": "null"
+          }
+        },
+        {
+          "field": "first",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "second",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "field": "first",
+          "is": "after",
+          "value": {
+            "date": "8001-02-03T04:05:06.007"
+          }
+        },
+        {
+          "field": "second",
+          "is": "equalToField",
+          "value": "first",
+          "offset": 3,
+          "offsetUnit": "days"
+        },
+        {
+          "field": "firstWorking",
+          "is": "equalTo",
+          "value": {
+            "date": "2019-08-12T12:00:00.000"
+          }
+        },
+        {
+          "field": "secondWorking",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "not": {
+            "field": "secondWorking",
+            "is": "null"
+          }
+        },
+        {
+          "field": "secondWorking",
+          "is": "equalToField",
+          "value": "firstWorking",
+          "offset": 8,
+          "offsetUnit": "working days"
+        },
+        {
+          "field": "current",
+          "is": "ofType",
+          "value": "datetime"
+        },
+        {
+          "not": {
+            "field": "current",
+            "is": "null"
+          }
+        },
+        {
+          "field": "current",
+          "is": "before",
+          "value": {
+            "date": "now"
+          }
+        },
+        {
+          "field": "current",
+          "is": "after",
+          "value": {
+            "date": "2019-06-01T12:00:00.000"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Changes
- Restricted allow schemaVersion of 0.2 schema version to just 0.2.
- Removed unneeded schema version testing.
- Added test profiles for testing the schema versioning:
  - One valid 0.2 profile.
  - One profile with an invalid schemaVersion.
  - One invalid 0.2 profile.
  - One valid 0.2 profile labelled as 0.1.