### PR TITLE
fix(#1230): Prevent exhaustive mode from hanging

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGenerator.java
@@ -69,7 +69,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
         final DecisionTree decisionTree = decisionTreeGenerator.analyse(profile);
 
         final DecisionTree prunedTree = upfrontTreePruner.runUpfrontPrune(decisionTree, monitor);
-        if (decisionTree.getRootNode() == null) {
+        if (prunedTree.getRootNode() == null) {
             return Stream.empty();
         }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategy.java
@@ -18,8 +18,9 @@ package com.scottlogic.deg.generator.generation.combinationstrategies;
 
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface CombinationStrategy {
-    Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences);
+    Stream<DataBag> permute(Supplier<Stream<Stream<DataBag>>> dataBagSequences);
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
@@ -29,21 +29,16 @@ public class ExhaustiveCombinationStrategy implements CombinationStrategy {
     @Override
     public Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences) {
 
-        List<List<DataBag>> bagsAsLists = dataBagSequences
-            .map(sequence ->
-                StreamSupport.stream(sequence.spliterator(), false)
-                    .collect(Collectors.toList()))
-            .collect(Collectors.toList());
+        List<Stream<DataBag>> bagsAsLists = dataBagSequences.collect(Collectors.toList());
 
         return next(DataBag.empty, bagsAsLists, 0);
     }
 
-    public Stream<DataBag> next(DataBag accumulatingBag, List<List<DataBag>> bagSequences, int bagSequenceIndex) {
+    public Stream<DataBag> next(DataBag accumulatingBag, List<Stream<DataBag>> bagSequences, int bagSequenceIndex) {
         if (bagSequenceIndex < bagSequences.size()) {
-            List<DataBag> nextStream = bagSequences.get(bagSequenceIndex);
+            Stream<DataBag> nextStream = bagSequences.get(bagSequenceIndex);
 
             return FlatMappingSpliterator.flatMap(nextStream
-                .stream()
                 .map(innerBag -> DataBag.merge(innerBag, accumulatingBag)),
                 innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
@@ -19,28 +19,28 @@ package com.scottlogic.deg.generator.generation.combinationstrategies;
 import com.scottlogic.deg.common.util.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 
-import java.util.*;
+import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class ExhaustiveCombinationStrategy implements CombinationStrategy {
 
     @Override
-    public Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences) {
+    public Stream<DataBag> permute(Supplier<Stream<Stream<DataBag>>> dataBagSequences) {
+        Supplier<List<Stream<DataBag>>> listOfStreams = () -> dataBagSequences.get().collect(Collectors.toList());
 
-        List<Stream<DataBag>> bagsAsLists = dataBagSequences.collect(Collectors.toList());
-
-        return next(DataBag.empty, bagsAsLists, 0);
+        return next(DataBag.empty, listOfStreams, 0);
     }
 
-    public Stream<DataBag> next(DataBag accumulatingBag, List<Stream<DataBag>> bagSequences, int bagSequenceIndex) {
-        if (bagSequenceIndex < bagSequences.size()) {
-            Stream<DataBag> nextStream = bagSequences.get(bagSequenceIndex);
+    public Stream<DataBag> next(DataBag accumulatingBag, Supplier<List<Stream<DataBag>>> bagSequences, int index) {
+        List<Stream<DataBag>> bags = bagSequences.get();
+        if (index < bags.size()) {
+            Stream<DataBag> nextStream = bags.get(index);
 
             return FlatMappingSpliterator.flatMap(nextStream
                 .map(innerBag -> DataBag.merge(innerBag, accumulatingBag)),
-                innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
+                innerBag -> next(innerBag, bagSequences, index + 1));
         }
         else
             return Stream.of(accumulatingBag);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/MinimalCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/MinimalCombinationStrategy.java
@@ -19,13 +19,14 @@ package com.scottlogic.deg.generator.generation.combinationstrategies;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.*;
 
 public class MinimalCombinationStrategy implements CombinationStrategy {
 
     @Override
-    public Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences) {
-        List<Iterator<DataBag>> iterators = dataBagSequences
+    public Stream<DataBag> permute(Supplier<Stream<Stream<DataBag>>> dataBagSequences) {
+        List<Iterator<DataBag>> iterators = dataBagSequences.get()
                 .map(BaseStream::iterator)
                 .collect(Collectors.toList());
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategy.java
@@ -21,6 +21,7 @@ import com.scottlogic.deg.generator.generation.databags.DataBag;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -29,9 +30,9 @@ import java.util.stream.StreamSupport;
 public class PinningCombinationStrategy implements CombinationStrategy {
 
     @Override
-    public Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences) {
+    public Stream<DataBag> permute(Supplier<Stream<Stream<DataBag>>> dataBagSequences) {
         Iterable<DataBag> iterable = new PinningCombinationStrategy
-                .InternalIterable(dataBagSequences);
+                .InternalIterable(dataBagSequences.get());
 
         return StreamSupport.stream(iterable.spliterator(), false);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ReductiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ReductiveCombinationStrategy.java
@@ -23,14 +23,15 @@ import com.scottlogic.deg.generator.utils.RestartableIterator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class ReductiveCombinationStrategy implements CombinationStrategy {
     @Override
-    public Stream<DataBag> permute(Stream<Stream<DataBag>> dataBagSequences) {
-        List<RestartableIterator<DataBag>> bagsAsLists = dataBagSequences
+    public Stream<DataBag> permute(Supplier<Stream<Stream<DataBag>>> dataBagSequences) {
+        List<RestartableIterator<DataBag>> bagsAsLists = dataBagSequences.get()
             .map(dbs -> new RestartableIterator<>(dbs.iterator()))
             .collect(Collectors.toList());
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/RowSpecDataBagGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/RowSpecDataBagGenerator.java
@@ -50,8 +50,8 @@ public class RowSpecDataBagGenerator {
 
     private Stream<DataBag> generateDataForField(RowSpec rowSpec, Field field) {
         FieldSpec fieldSpec = rowSpec.getSpecForField(field);
-
-        return generator.generate(fieldSpec).map(value->toDataBag(field, value));
+        Stream<DataBagValue> stream = generator.generate(fieldSpec);
+        return stream.map(value -> toDataBag(field, value));
     }
 
     private DataBag toDataBag(Field field, DataBagValue value) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/RowSpecDataBagGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/RowSpecDataBagGenerator.java
@@ -24,6 +24,7 @@ import com.scottlogic.deg.generator.generation.combinationstrategies.Combination
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class RowSpecDataBagGenerator {
@@ -40,7 +41,7 @@ public class RowSpecDataBagGenerator {
     }
 
     public Stream<DataBag> createDataBags(RowSpec rowSpec) {
-        Stream<Stream<DataBag>> dataBagsForFields =
+        Supplier<Stream<Stream<DataBag>>> dataBagsForFields = () ->
             rowSpec.getFields().stream()
                 .map(field -> generateDataForField(rowSpec, field));
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategyTester.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategyTester.java
@@ -38,14 +38,14 @@ class CombinationStrategyTester {
     }
 
     void expect(Stream<DataBag> bagSequence) {
-        DataBag[] results = strategy.permute(dataBags).toArray(DataBag[]::new);
+        DataBag[] results = strategy.permute(() -> dataBags).toArray(DataBag[]::new);
         DataBag[] bagArray = bagSequence.toArray(DataBag[]::new);
 
         Assert.assertThat(results, IsArrayContainingInAnyOrder.arrayContainingInAnyOrder(bagArray));
     }
 
     void expectEmpty() {
-        Stream<DataBag> results = strategy.permute(dataBags);
+        Stream<DataBag> results = strategy.permute(() ->dataBags);
 
         Assert.assertFalse(results.iterator().hasNext());
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategyTester.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/CombinationStrategyTester.java
@@ -22,30 +22,31 @@ import com.scottlogic.deg.generator.generation.databags.DataBag;
 import org.hamcrest.collection.IsArrayContainingInAnyOrder;
 import org.junit.Assert;
 
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 class CombinationStrategyTester {
     private CombinationStrategy strategy;
-    private Stream<Stream<DataBag>> dataBags;
+    private Supplier<Stream<Stream<DataBag>>> dataBags;
 
     CombinationStrategyTester(CombinationStrategy combinationStrategy) {
         strategy = combinationStrategy;
     }
 
     @SafeVarargs
-    final void given(Stream<DataBag>... bagSequences) {
-        dataBags = Stream.of(bagSequences);
+    final void given(Supplier<Stream<DataBag>>... bagSequences) {
+        dataBags = () -> Stream.of(bagSequences).map(Supplier::get);
     }
 
     void expect(Stream<DataBag> bagSequence) {
-        DataBag[] results = strategy.permute(() -> dataBags).toArray(DataBag[]::new);
+        DataBag[] results = strategy.permute(dataBags).toArray(DataBag[]::new);
         DataBag[] bagArray = bagSequence.toArray(DataBag[]::new);
 
         Assert.assertThat(results, IsArrayContainingInAnyOrder.arrayContainingInAnyOrder(bagArray));
     }
 
     void expectEmpty() {
-        Stream<DataBag> results = strategy.permute(() ->dataBags);
+        Stream<DataBag> results = strategy.permute(dataBags);
 
         Assert.assertFalse(results.iterator().hasNext());
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategyTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategyTests.java
@@ -34,8 +34,8 @@ class ExhaustiveCombinationStrategyTests {
     @Test
     void shouldCombineExhaustively() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3")));
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3")));
 
         tester.expect(
             Stream.of(
@@ -53,9 +53,9 @@ class ExhaustiveCombinationStrategyTests {
     @Test
     void shouldCombineSequencesOfDifferentLengths() {
         tester.given(
-            Stream.of(bag("X")),
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
+            () -> Stream.of(bag("X")),
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
 
         tester.expect(
             Stream.of(
@@ -78,7 +78,7 @@ class ExhaustiveCombinationStrategyTests {
 
     @Test
     void shouldGiveInputForSingleSequence() {
-        tester.given(Stream.of(bag("A"), bag("B"), bag("C")));
+        tester.given(() -> Stream.of(bag("A"), bag("B"), bag("C")));
 
         tester.expect(Stream.of(bag("A"), bag("B"), bag("C")));
     }
@@ -86,8 +86,8 @@ class ExhaustiveCombinationStrategyTests {
     @Test
     void shouldGiveNoResultsForSingleEmptySequence() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of());
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of());
 
         tester.expectEmpty();
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/MinimalCombinationStrategyTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/MinimalCombinationStrategyTests.java
@@ -34,8 +34,8 @@ class MinimalCombinationStrategyTests {
     @Test
     void shouldCombineMinimally() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3")));
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3")));
 
         tester.expect(
             Stream.of(bag("A","1"), bag("B","2"), bag("C","3")));
@@ -44,9 +44,9 @@ class MinimalCombinationStrategyTests {
     @Test
     void shouldCombineSequencesOfDifferentLengths() {
         tester.given(
-            Stream.of(bag("X")),
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
+            () -> Stream.of(bag("X")),
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
 
         tester.expect(
             Stream.of(
@@ -59,7 +59,7 @@ class MinimalCombinationStrategyTests {
 
     @Test
     void shouldGiveInputForSingleSequence() {
-        tester.given(Stream.of(bag("A"), bag("B"), bag("C")));
+        tester.given(() -> Stream.of(bag("A"), bag("B"), bag("C")));
 
         tester.expect(Stream.of(bag("A"), bag("B"), bag("C")));
     }
@@ -67,8 +67,8 @@ class MinimalCombinationStrategyTests {
     @Test
     void shouldGiveNoResultsForSingleEmptySequence() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of());
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of());
 
         tester.expectEmpty();
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategyTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategyTests.java
@@ -34,8 +34,8 @@ class PinningCombinationStrategyTests {
     @Test
     void shouldCombineUsingPinning() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3")));
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3")));
 
         tester.expect(
             Stream.of(
@@ -49,9 +49,9 @@ class PinningCombinationStrategyTests {
     @Test
     void shouldCombineSequencesOfDifferentLengths() {
         tester.given(
-            Stream.of(bag("X")),
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
+            () -> Stream.of(bag("X")),
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            () -> Stream.of(bag("1"), bag("2"), bag("3"), bag("4"), bag("5")));
 
         tester.expect(
             Stream.of(
@@ -66,7 +66,7 @@ class PinningCombinationStrategyTests {
 
     @Test
     void shouldGiveInputForSingleSequence() {
-        tester.given(Stream.of(bag("A"), bag("B"), bag("C")));
+        tester.given(() -> Stream.of(bag("A"), bag("B"), bag("C")));
 
         tester.expect(Stream.of(bag("A"), bag("B"), bag("C")));
     }
@@ -74,8 +74,8 @@ class PinningCombinationStrategyTests {
     @Test
     void shouldGiveNoResultsForSingleEmptySequence() {
         tester.given(
-            Stream.of(bag("A"), bag("B"), bag("C")),
-            Stream.of());
+            () -> Stream.of(bag("A"), bag("B"), bag("C")),
+            Stream::of);
 
         tester.expectEmpty();
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/ReductiveCombinationStrategyTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/combinationstrategies/ReductiveCombinationStrategyTests.java
@@ -65,7 +65,7 @@ class ReductiveCombinationStrategyTests {
             add(firstFieldDataBags);
             add(secondFieldDataBags);
         }};
-        final List<DataBag> result = combinationStrategy.permute(dataBagSequences.stream().map(Collection::stream))
+        final List<DataBag> result = combinationStrategy.permute(() -> dataBagSequences.stream().map(Collection::stream))
             .collect(Collectors.toList());
 
         List<DataBag> expectedDataBags = new ArrayList<DataBag>() {{


### PR DESCRIPTION
### Description
Fixes stream creating a collection big enough to go out of memory.

Happy to discuss best testing strategy for this issue. To test I have manually run in the profile. The issue appears to be an internal detail of the method, so in order to test I'd have to expose internals, or verify that it doesn't throw an exception when run (?).

I think an integration test is the most appropriate way, but this should probably come under a larger umbrella discussion of the best way to go about testing.

### Issue
Resolves #1230
