### PR TITLE
Reenable combination strategy as a command line argument

### DIFF
--- a/docs/user/CombinationStrategies.md
+++ b/docs/user/CombinationStrategies.md
@@ -7,7 +7,7 @@ In multiple areas of the generator, we find ourselves with multiple streams of v
 
 There are multiple ways to perform this selection process; we refer to these as **combination strategies**. Different combination strategies have different properties.
 
-Our current default is the **exhaustive** strategy.
+Our current default is the **minimal** strategy. The combination strategy can be specified with the ```--combination-strategy``` command line argument with ```EXHAUSTIVE```, ```MINIMAL``` and ```PINNING``` as options (eg. ```--combination-strategy=PINNING```).
 
 ## Exhaustive
 
@@ -59,13 +59,3 @@ It has these properties:
 * It is always possible to find another output differing by just one field
 * Output size increases **linearly** with number of fields
 * The maximum number of rows generated can be calculated as: ( the sum of the total number of possible values for all fields ) less ( the total number of fields ) plus 1
-
-## Random
-
-Whereas other strategies produce a bounded set of outputs, the random strategy produces an infinite series by repeatedly randomly picking values for each field.
-
-## Possible future strategies
-
-### Hybrid
-
-We may want to be exhaustive over some fields (because the user thinks there may be unknown interactions between them) but minimal over others.

--- a/docs/user/generationTypes/GenerationTypes.md
+++ b/docs/user/generationTypes/GenerationTypes.md
@@ -32,6 +32,7 @@ Examples:
 
 Notes:
 - For more information about the behaviour of this example, see the [behaviour in detail.](../../developer/behaviour/BehaviourInDetail.md)
+- There are a few [combination strategies](../CombinationStrategies.md) for full sequential with [minimal](../CombinationStrategies.md#Minimal) being the default.
 
 ## Interesting
 _This is an alpha feature. Please do not rely on it. If you find issues with it, please [report them](https://github.com/finos/datahelix/issues)._

--- a/docs/user/generationTypes/GenerationTypes.md
+++ b/docs/user/generationTypes/GenerationTypes.md
@@ -32,7 +32,7 @@ Examples:
 
 Notes:
 - For more information about the behaviour of this example, see the [behaviour in detail.](../../developer/behaviour/BehaviourInDetail.md)
-- There are a few [combination strategies](../CombinationStrategies.md) for full sequential with [minimal](../CombinationStrategies.md#Minimal) being the default.
+- There are a few [combination strategies](../CombinationStrategies.md) for full sequential mode with [minimal](../CombinationStrategies.md#Minimal) being the default.
 
 ## Interesting
 _This is an alpha feature. Please do not rely on it. If you find issues with it, please [report them](https://github.com/finos/datahelix/issues)._

--- a/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateCommandLine.java
+++ b/orchestrator/src/main/java/com/scottlogic/deg/orchestrator/generate/GenerateCommandLine.java
@@ -105,9 +105,7 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
     private DataGenerationType generationType = RANDOM;
 
     @CommandLine.Option(names = {"-c", "--combination-strategy"},
-        description = "Determines the type of combination strategy used (${COMPLETION-CANDIDATES})",
-        hidden = true)
-    @SuppressWarnings("unused")
+        description = "Determines the type of combination strategy used (${COMPLETION-CANDIDATES})")
     private CombinationStrategyType combinationType = MINIMAL;
 
     @CommandLine.Option(


### PR DESCRIPTION
### Description/Changes
- Change combination strategy flag to not be hidden.
- Update docs to reflect actual default behaviour.
- Added a few links to make it easier to find information on combination strategy.

### Issue
Resolves #1234 
