### PR TITLE
fix(#1196): fixed reading directory paths without trailing separator

### DIFF
--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/atomic/FromFileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/atomic/FromFileReader.java
@@ -16,7 +16,7 @@ public class FromFileReader {
 
     @Inject
     public FromFileReader(@Named("config:fromFilePath") String fromFilePath) {
-        if (fromFilePath.endsWith(File.separator)) {
+        if (fromFilePath.endsWith(File.separator) || fromFilePath.isEmpty()) {
             this.fromFilePath = fromFilePath;
         } else {
             this.fromFilePath = fromFilePath + File.separator;

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/atomic/FromFileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/atomic/FromFileReader.java
@@ -3,14 +3,9 @@ package com.scottlogic.deg.profile.reader.atomic;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.scottlogic.deg.common.ValidationException;
-import com.scottlogic.deg.common.profile.Field;
-import com.scottlogic.deg.common.profile.ProfileFields;
-import com.scottlogic.deg.common.profile.constraints.Constraint;
-import com.scottlogic.deg.common.profile.constraints.atomic.IsInSetConstraint;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedSet;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
-import com.scottlogic.deg.profile.dto.ConstraintDTO;
 import com.scottlogic.deg.profile.reader.file.CsvInputStreamReader;
 
 import java.io.*;
@@ -21,7 +16,11 @@ public class FromFileReader {
 
     @Inject
     public FromFileReader(@Named("config:fromFilePath") String fromFilePath) {
-        this.fromFilePath = fromFilePath;
+        if (fromFilePath.endsWith(File.separator)) {
+            this.fromFilePath = fromFilePath;
+        } else {
+            this.fromFilePath = fromFilePath + File.separator;
+        }
     }
 
     public DistributedSet<Object> setFromFile(String file) {


### PR DESCRIPTION
### Description
Updated the FromFileReader constructor so if the provided file path doesn't have a trailing file separator it will append one.

### Issue
Resolves #1196
