### PR TITLE
1303 expand field definitions formatting unique

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,22 +4,25 @@
 2. [Profiles](#Profiles)
     1. [Creating a Profile](#Creating-a-Profile)
     2. [Example Profile](#Example-Profile)
-    3. [Fields](#Fields)
+    
+3. [Fields](#Fields)
+    1. [Name](fields-name)
+    1. [Unique](fields-unique)
+    1. [Formatting](fields-formatting)
 
-3. [Data types](#Data-Types)
+4. [Data types](#Data-Types)
     1. [Integer/Decimal](#Integer/Decimal)
     2. [Strings](#Strings)
     3. [DateTime](#DateTime)
     4. [Custom Data Types](#Custom-Data-Types)
    
-4. [Predicate constraints](#Predicate-constraints)
+5. [Predicate constraints](#Predicate-constraints)
     1. [Theory](#Theory)
     2. [General constraints](#General-constraints)
         1. [equalTo](#predicate-equalto)
         2. [inSet](#predicate-inset)
         3. [null](#predicate-null)
         4. [ofType](#predicate-oftype)
-        5. [unique](#predicate-unique)
     3. [Textual constraints](#Textual-constraints)
         1. [matchingRegex](#predicate-matchingregex)
         2. [containingRegex](#predicate-containingregex)
@@ -42,13 +45,11 @@
         1. [otherField](#predicate-otherfield)
         2. [offset](#predicate-offset)
 
-5. [Grammatical constraints](#Grammatical-Constraints)
+6. [Grammatical constraints](#Grammatical-Constraints)
     1. [not](#not)
     2. [anyOf](#anyOf)
     3. [allOf](#allOf)
     4. [if](#if)
-
-6. [Presentational constraints](#Presentational-Constraints)
 
 # Introduction
 
@@ -64,8 +65,7 @@ This guide outlines how to create a profile and contains information on the synt
 
 This section will walk you through creating basic profiles with which you can generate data.
 
-Profiles are JSON documents consisting of three sections, the schema version, the list 
-of fields and the rules.
+Profiles are JSON documents consisting of three sections, the schema version, the list of fields and the rules.
 
 - **Schema Version** - Dictates the method of serialisation of the profile in order for the generator to 
 interpret the profile fields and rules. The latest version is 0.1.
@@ -89,8 +89,6 @@ to the desired range of values. They are formatted as JSON objects. There are th
     - [Predicate Constraints](#Predicate-constraints) - predicates that define any given value as being 
     _valid_ or _invalid_
     - [Grammatical Constraints](#Grammatical-constraints) - used to combine or modify other constraints
-    - [Presentational Constraints](#Presentational-constraints) - used by output serialisers where
-     string output is required 
      
 Here is a list of two rules comprised of one constraint each:
     
@@ -161,9 +159,46 @@ These three sections are combined to form the [complete profile](#Example-Profil
 * For a larger profile example see [here](user/Schema.md)
 * Further examples can be found in the Examples folder [here](https://github.com/finos/datahelix/tree/master/examples)
 
-## Fields
+# Fields
 
-Fields are the "slots" of data that can take values. If generating into a CSV or database, fields are columns. If generating into JSON, fields are object properties. Typical fields might be _email_address_ or _user_id_. By default, any piece of data is valid for a field. 
+Fields are the "slots" of data that can take values. Typical fields might be _email_address_ or _user_id_. By default, any piece of data is valid for a field. This is an example field object for the profile:
+
+```javascript
+{
+    "name": "field1",
+    "formatting": "%.5s",
+    "unique": true
+}
+```
+
+Each of the field properties are outlined below:
+
+<div id="fields-name"></div>
+
+## `name`
+
+Name of the field in the output which has to be unique within the `Fields` array. If generating into a CSV or database, the name is used as a column name. If generating into JSON, the name is used as the key for object properties.
+
+<div id="fields-formatting"></div>
+
+## `formatting`
+
+Used by output serialisers where string output is required. This is an optional property of the field object and will default to use no formatting.
+
+For the formatting to be applied, the generated data must be applicable, and the `value` must be:
+
+* a string recognised by Java's `String.format` method
+* appropriate for the data type of `field`
+* not `null` (formatting will not be applied for null values)
+
+Formatting will not be applied if not applicable to the field's value
+
+<div id="fields-unique"></div>
+
+## `unique`
+
+Sets the field as unique. This is an optional property of the field object and will default to false. Unique fields can not be used within [grammatical constraints](#Grammatical-Constraints).
+
 
 # Data Types
 
@@ -327,16 +362,6 @@ Is satisfied if `field` is null or absent.
 ```
 
 Is satisfied if `field` is of type represented by `value` (valid options: `decimal`, `integer`, `string`, `datetime`, `ISIN`, `SEDOL`, `CUSIP`, `RIC`, `firstname`, `lastname` or `fullname`)
-
-<div id="predicate-unique"></div>
-
-### `unique` _(field)_
-
-```javascript
-{ "field": "price", "is": "unique" }
-```
-
-Is satisfied if `field`'s values are unique.
 
 ## Textual constraints
 
@@ -580,22 +605,3 @@ Is satisfied if either:
 - The `if` constraint is not satisfied, and the `else` constraint is
 
 While it's not prohibited, wrapping conditional constraints in any other kind of constraint (eg, a `not`) may cause unintuitive results.
-
-# Presentational Constraints
-<div id="Presentational-constraints"></div>
-
-### `formattedAs` _(field, value)_
-
-```javascript
-{ "field": "price", "is": "formattedAs", "value": "%.5s" }
-```
-
-Used by output serialisers where string output is required.
-
-For the formatting to be applied, the generated data must be applicable, and the `value` must be:
-
-* a string recognised by Java's `String.format` method
-* appropriate for the data type of `field`
-* not `null` (formatting will not be applied for null values)
-
-Formatting will not be applied if not applicable to the field's value

--- a/docs/user/Schema.md
+++ b/docs/user/Schema.md
@@ -75,6 +75,8 @@
 A field in the data set.
 
 * `"name"`: The field's name. Should be unique, as constraints will reference fields by name. This property is used for, eg, column headers in CSV output
+* `"formatting"`: The formatting used for the output of the field. (Optional)
+* `"unique"`: Sets if the field is unique. (Optional)
 
 ### `Rule`
 A named collection of constraints. Test case generation revolves around rules, in that the generator will output a separate dataset for each rule, wherein each row violates the rule in a different way.

--- a/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
@@ -19,13 +19,5 @@ package com.scottlogic.deg.profile.dto;
 public class FieldDTO {
     public String name;
     public String formatting;
-    public Boolean unique;
-
-    public FieldDTO() {}
-
-    public FieldDTO(String name, String formatting, Boolean unique){
-        this.name = name;
-        this.formatting = formatting;
-        this.unique = unique;
-    }
+    public boolean unique;
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
@@ -18,10 +18,14 @@ package com.scottlogic.deg.profile.dto;
 
 public class FieldDTO {
     public String name;
+    public String formatting;
+    public Boolean unique;
 
     public FieldDTO() {}
 
-    public FieldDTO(String name){
+    public FieldDTO(String name, String formatting, Boolean unique){
         this.name = name;
+        this.formatting = formatting;
+        this.unique = unique;
     }
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
@@ -65,7 +65,7 @@ public class JsonProfileReader implements ProfileReader {
 
         ProfileFields profileFields = new ProfileFields(
             profileDto.fields.stream()
-                .map(fDto -> new Field(fDto.name, fDto.unique == null ? false : fDto.unique, fDto.formatting))
+                .map(fDto -> new Field(fDto.name, fDto.unique, fDto.formatting))
                 .collect(Collectors.toList()));
 
         Collection<Rule> rules = profileDto.rules.stream().map(

--- a/profile/src/main/resources/profileschema/0.5/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.5/datahelix.schema.json
@@ -1,0 +1,547 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://scottlogic.com/datahelix.json",
+  "title": "The Scott Logic DataHelix Profile Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "fields", "rules"],
+  "properties": {
+    "additionalProperties": false,
+    "schemaVersion": {
+      "$ref": "#/definitions/schemaVersion"
+    },
+    "description": {
+      "title": "A description of what data the profile is modelling",
+      "type": "string"
+    },
+    "fields": {
+      "title": "Defines the fields that data will be produced for. field names must begin with an alphabetic character.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/fieldDefinition"
+      }
+    },
+    "rules": {
+      "title": "The Rules defining the data to be output",
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "title": "A set of Rule objects.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["constraints"],
+        "properties": {
+          "rule": {
+            "title": "A collection of constraints. Test case generation revolves around rules, in that the generator will output a separate dataset for each rule, wherein each row violates the rule in a different way.",
+            "type": "string"
+          },
+          "constraints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/constraint"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "schemaVersion": {
+      "title": "The version of the DataHelix profile schema",
+      "const": "0.5"
+    },
+    "dataType": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/datetime"
+        },
+        {
+          "$ref": "#/definitions/string"
+        },
+        {
+          "$ref": "#/definitions/numeric"
+        }
+      ]
+    },
+    "datetime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["date"],
+      "default": {
+        "date": "2000-01-01T09:00:00.000"
+      },
+      "properties": {
+        "additionalProperties": false,
+        "date": {
+          "title": "an ISO 8610 compatible string denoting a date and time",
+          "type": "string",
+          "default": "2000-01-01T09:00:00.000",
+          "oneOf": [
+            {
+              "pattern": "^(?!0000)[0-9]{4}-([0][0-9]|[1][0-2])-([0-2][0-9]|3[01])T([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9][.][0-9]{3}Z?$"
+            },
+            {
+              "enum": ["now"]
+            }]
+        }
+      }
+    },
+    "numeric": {
+      "type": "number",
+      "minimum": -1e20,
+      "maximum": 1e20,
+      "default": 0
+    },
+    "integer": {
+      "$ref": "#/definitions/numeric",
+      "multipleOf": 1
+    },
+    "string": {
+      "type": "string",
+      "maxLength": 1000,
+      "default": "string"
+    },
+    "fieldDefinition": {
+      "title": "The field definitions of a field to generate data for",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "default": {
+        "name": "fieldName",
+        "formatting": "",
+        "unique": false
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "formatting": {
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        }
+      }
+    },
+    "constraint": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/anyOfConstraint"
+        },
+        {
+          "$ref": "#/definitions/allOfConstraint"
+        },
+        {
+          "$ref": "#/definitions/dataConstraint"
+        },
+        {
+          "$ref": "#/definitions/nullConstraint"
+        },
+        {
+          "$ref": "#/definitions/extendedDataConstraint"
+        },
+        {
+          "$ref": "#/definitions/inSetConstraint"
+        },
+        {
+          "$ref": "#/definitions/fromFileConstraint"
+        },
+        {
+          "$ref": "#/definitions/notConstraint"
+        },
+        {
+          "$ref": "#/definitions/ifThenConstraint"
+        },
+        {
+          "$ref": "#/definitions/ifThenElseConstraint"
+        }
+      ]
+    },
+    "dataConstraint": {
+      "type": "object",
+      "required": ["field", "is", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "enum": [
+            "ofType",
+            "equalTo",
+            "matchingRegex",
+            "containingRegex",
+            "ofLength",
+            "longerThan",
+            "shorterThan",
+            "greaterThan",
+            "lessThan",
+            "greaterThanOrEqualTo",
+            "lessThanOrEqualTo",
+            "granularTo",
+            "after",
+            "afterOrAt",
+            "before",
+            "beforeOrAt"
+          ]
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/datetime"
+            },
+            {
+              "$ref": "#/definitions/numeric"
+            },
+            {
+              "$ref": "#/definitions/string"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": ["after", "afterOrAt", "before", "beforeOrAt"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/datetime"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "equalTo"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/dataType"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "ofType"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "enum": ["decimal", "integer", "string", "datetime","ISIN","SEDOL","CUSIP","RIC","firstname","lastname","fullname"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": ["matchingRegex", "containingRegex"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "type": "string",
+                "default": ".*"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "shorterThan"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": 1,
+                "maximum": 1001
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "ofLength"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": 0,
+                "maximum": 1000
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "longerThan"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": -1,
+                "maximum": 999
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "granularTo"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "enum": [
+                  1,
+                  1e-1,
+                  1e-2,
+                  1e-3,
+                  1e-4,
+                  1e-5,
+                  1e-6,
+                  1e-7,
+                  1e-8,
+                  1e-9,
+                  1e-10,
+                  1e-11,
+                  1e-12,
+                  1e-13,
+                  1e-14,
+                  1e-15,
+                  1e-16,
+                  1e-17,
+                  1e-18,
+                  1e-19,
+                  1e-20,
+                  "millis",
+                  "seconds",
+                  "minutes",
+                  "hours",
+                  "days",
+                  "months",
+                  "years"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": [
+                  "greaterThan",
+                  "lessThan",
+                  "greaterThanOrEqualTo",
+                  "lessThanOrEqualTo"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/numeric"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "extendedDataConstraint": {
+      "type": "object",
+      "required": ["field", "is", "otherField"],
+      "additionalProperties": true,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "enum": [
+            "after",
+            "afterOrAt",
+            "before",
+            "beforeOrAt",
+            "equalTo"
+          ]
+        },
+        "otherField": {
+          "$ref": "#/definitions/string"
+        },
+        "offset": {
+          "$ref": "#/definitions/integer"
+        },
+        "offsetUnit": {
+          "type": "string"
+        }
+      }
+    },
+    "notConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "anyOfConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anyOf"],
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/constraint"
+          }
+        }
+      }
+    },
+    "allOfConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allOf"],
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/constraint"
+          }
+        }
+      }
+    },
+    "ifThenConstraint": {
+      "type": "object",
+      "required": ["if", "then"],
+      "additionalProperties": false,
+      "properties": {
+        "if": {
+          "$ref": "#/definitions/constraint"
+        },
+        "then": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "ifThenElseConstraint": {
+      "type": "object",
+      "required": ["if", "then", "else"],
+      "additionalProperties": false,
+      "properties": {
+        "if": {
+          "$ref": "#/definitions/constraint"
+        },
+        "then": {
+          "$ref": "#/definitions/constraint"
+        },
+        "else": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "nullConstraint": {
+      "type": "object",
+      "required": ["field", "is"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "null"
+        }
+      }
+    },
+    "fromFileConstraint": {
+      "type": "object",
+      "required": ["field", "is", "file"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "inSet"
+        },
+        "file": {
+          "type": "string"
+        }
+      }
+    },
+    "inSetConstraint": {
+      "type": "object",
+      "required": ["field", "is", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "inSet"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/datetime"
+              },
+              {
+                "$ref": "#/definitions/numeric"
+              },
+              {
+                "$ref": "#/definitions/string"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
@@ -70,6 +70,9 @@ public class ProfileSchemaImmutabilityTests {
         versionToHash.add(new VersionHash(
             "0.4",
             "9d4cdf397ae8d6c9e841a7577c859caca56fd906168eff77ba66d4ddf5e06ba7"));
+        versionToHash.add(new VersionHash(
+            "0.5",
+            "3d114a0ee1e3d201faa7442a8e6da7b9e8d67d72e772ed9324ced7f4c8936adc"));
         return versionToHash;
     }
 

--- a/profile/src/test/java/com/scottlogic/deg/profile/ProfileSerialiserTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/ProfileSerialiserTests.java
@@ -82,8 +82,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\" }," +
-                    "   { \"name\" : \"price\" }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false  }," +
+                    "   { \"name\" : \"price\", \"unique\": false  }" +
                     "]," +
                     "\"rules\" : [" +
                     " { \"rule\" : null," +
@@ -144,8 +144,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\" }," +
-                    "   { \"name\" : \"price\" }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false  }," +
+                    "   { \"name\" : \"price\", \"unique\": false  }" +
                     "]," +
                     "\"rules\" : [" +
                     " { " +
@@ -191,8 +191,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\" }," +
-                    "   { \"name\" : \"price\" }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false }," +
+                    "   { \"name\" : \"price\", \"unique\": false  }" +
                     "]," +
                     "\"rules\" : [" +
                     " { " +

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -287,15 +287,12 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseFormatConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
-                        "    \"fields\": [ { \"name\": \"foo\" } ]," +
-                        "    \"rules\": [" +
-                        "      {" +
-                        "        \"constraints\": [" +
-                        "        { \"field\": \"foo\", \"is\": \"formattedAs\", \"value\": \"%.5s\" }" +
-                        "        ]" +
-                        "      }" +
-                        "    ]" +
+                        "    \"schemaVersion\": \"0.5\"," +
+                        "    \"fields\": [ { " +
+                        "           \"name\": \"foo\"," +
+                        "           \"formatting\": \"%.5s\"" +
+                        "    } ]," +
+                        "    \"rules\": []" +
                         "}");
 
         expectFields(

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -828,4 +828,63 @@ public class JsonProfileReaderTests {
 
         expectInvalidProfileException();
     }
+
+    @Test
+    public void unique_setsFieldPropertyToTrue_whenSetToTrue() throws IOException {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": \"0.5\"," +
+                "    \"fields\": [ { " +
+                "           \"name\": \"foo\"," +
+                "           \"unique\": true" +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+
+        expectFields(
+            field -> {
+                Assert.assertThat(field.name, equalTo("foo"));
+                Assert.assertTrue(field.isUnique());
+            }
+        );
+    }
+
+    @Test
+    public void unique_setsFieldPropertyToFalse_whenOmitted() throws IOException {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": \"0.5\"," +
+                "    \"fields\": [ { " +
+                "           \"name\": \"foo\"" +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+
+        expectFields(
+            field -> {
+                Assert.assertThat(field.name, equalTo("foo"));
+                Assert.assertFalse(field.isUnique());
+            }
+        );
+    }
+
+    @Test
+    public void unique_setsFieldPropertyToFalse_whenSetToFalse() throws IOException {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": \"0.5\"," +
+                "    \"fields\": [ { " +
+                "           \"name\": \"foo\"," +
+                "           \"unique\": false" +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+
+        expectFields(
+            field -> {
+                Assert.assertThat(field.name, equalTo("foo"));
+                Assert.assertFalse(field.isUnique());
+            }
+        );
+    }
 }


### PR DESCRIPTION
### Description

Updated the profile schema so that the field definitions includes formatting and unique constraints. These have been removed from the constraints section of the profile. 

Backwards compatiblity for old schemas has been removed with this change but this will be addressed with issue #1315 

### Changes

- New profile version with the new field definition block
- Updated user docs for the new schema
- Added unit tests for checking the parsing of the schema

### Issue
Related to #1303
