### PR TITLE
1303 expand field definitions nullable

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,9 +6,10 @@
     2. [Example Profile](#Example-Profile)
     
 3. [Fields](#Fields)
-    1. [Name](fields-name)
-    1. [Unique](fields-unique)
-    1. [Formatting](fields-formatting)
+    1. [Name](#fields-name)
+    1. [Nullable](#fields-nullable)
+    1. [Formatting](#fields-formatting)
+    1. [Unique](#fields-unique)
 
 4. [Data types](#Data-Types)
     1. [Integer/Decimal](#Integer/Decimal)
@@ -166,6 +167,7 @@ Fields are the "slots" of data that can take values. Typical fields might be _em
 ```javascript
 {
     "name": "field1",
+    "nullable": false,
     "formatting": "%.5s",
     "unique": true
 }
@@ -178,6 +180,13 @@ Each of the field properties are outlined below:
 ## `name`
 
 Name of the field in the output which has to be unique within the `Fields` array. If generating into a CSV or database, the name is used as a column name. If generating into JSON, the name is used as the key for object properties.
+
+
+<div id="fields-nullable"></div>
+
+## `nullable`
+
+Sets the field as nullable. This is an optional property of the field and will default to true. When set to false it is the same as a [not](#not) [null](#predicate-null) constraint for the field.
 
 <div id="fields-formatting"></div>
 

--- a/docs/user/Schema.md
+++ b/docs/user/Schema.md
@@ -77,6 +77,7 @@ A field in the data set.
 * `"name"`: The field's name. Should be unique, as constraints will reference fields by name. This property is used for, eg, column headers in CSV output
 * `"formatting"`: The formatting used for the output of the field. (Optional)
 * `"unique"`: Sets if the field is unique. (Optional)
+* `"nullable"`: Sets if null is an allowed output of the field. (Optional)
 
 ### `Rule`
 A named collection of constraints. Test case generation revolves around rules, in that the generator will output a separate dataset for each rule, wherein each row violates the rule in a different way.

--- a/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
@@ -20,5 +20,5 @@ public class FieldDTO {
     public String name;
     public String formatting;
     public boolean unique;
-    public boolean nullable;
+    public boolean nullable = true;
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/dto/FieldDTO.java
@@ -20,4 +20,5 @@ public class FieldDTO {
     public String name;
     public String formatting;
     public boolean unique;
+    public boolean nullable;
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
@@ -82,7 +82,7 @@ public class JsonProfileReader implements ProfileReader {
 
         // add nullable
         Collection<Constraint> nullableRules = profileDto.fields.stream()
-            .filter(fieldDTO -> fieldDTO.nullable != null && !fieldDTO.nullable)
+            .filter(fieldDTO -> !fieldDTO.nullable)
             .map(fieldDTO -> create(AtomicConstraintType.IS_NULL, profileFields.getByName(fieldDTO.name), null).negate())
             .collect(Collectors.toList());
 

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/JsonProfileReader.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.scottlogic.deg.common.profile.*;
 import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
+import com.scottlogic.deg.common.profile.constraints.Constraint;
 import com.scottlogic.deg.profile.serialisation.ProfileDeserialiser;
 import com.scottlogic.deg.profile.dto.ProfileDTO;
 
@@ -78,13 +79,16 @@ public class JsonProfileReader implements ProfileReader {
                 return new Rule(constraintRule, mainConstraintReader.getSubConstraints(profileFields, r.constraints));
             }).collect(Collectors.toList());
 
+
         // add nullable
-        rules.add(new Rule(new RuleInformation("nullable-rules"),
-            profileDto.fields.stream()
-                .filter(fieldDTO -> fieldDTO.nullable != null && !fieldDTO.nullable)
-                .map(fieldDTO -> create(AtomicConstraintType.IS_NULL, profileFields.getByName(fieldDTO.name), null).negate())
-                .collect(Collectors.toList())
-        ));
+        Collection<Constraint> nullableRules = profileDto.fields.stream()
+            .filter(fieldDTO -> fieldDTO.nullable != null && !fieldDTO.nullable)
+            .map(fieldDTO -> create(AtomicConstraintType.IS_NULL, profileFields.getByName(fieldDTO.name), null).negate())
+            .collect(Collectors.toList());
+
+        if (nullableRules.size() > 0) {
+            rules.add(new Rule(new RuleInformation("nullable-rules"), nullableRules));
+        }
 
         return new Profile(profileFields, rules, profileDto.description);
     }

--- a/profile/src/main/resources/profileschema/0.6/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/0.6/datahelix.schema.json
@@ -1,0 +1,551 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://scottlogic.com/datahelix.json",
+  "title": "The Scott Logic DataHelix Profile Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "fields", "rules"],
+  "properties": {
+    "additionalProperties": false,
+    "schemaVersion": {
+      "$ref": "#/definitions/schemaVersion"
+    },
+    "description": {
+      "title": "A description of what data the profile is modelling",
+      "type": "string"
+    },
+    "fields": {
+      "title": "Defines the fields that data will be produced for. field names must begin with an alphabetic character.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "additionalItems": false,
+      "items": {
+        "$ref": "#/definitions/fieldDefinition"
+      }
+    },
+    "rules": {
+      "title": "The Rules defining the data to be output",
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "title": "A set of Rule objects.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["constraints"],
+        "properties": {
+          "rule": {
+            "title": "A collection of constraints. Test case generation revolves around rules, in that the generator will output a separate dataset for each rule, wherein each row violates the rule in a different way.",
+            "type": "string"
+          },
+          "constraints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/constraint"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "schemaVersion": {
+      "title": "The version of the DataHelix profile schema",
+      "const": "0.6"
+    },
+    "dataType": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/datetime"
+        },
+        {
+          "$ref": "#/definitions/string"
+        },
+        {
+          "$ref": "#/definitions/numeric"
+        }
+      ]
+    },
+    "datetime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["date"],
+      "default": {
+        "date": "2000-01-01T09:00:00.000"
+      },
+      "properties": {
+        "additionalProperties": false,
+        "date": {
+          "title": "an ISO 8610 compatible string denoting a date and time",
+          "type": "string",
+          "default": "2000-01-01T09:00:00.000",
+          "oneOf": [
+            {
+              "pattern": "^(?!0000)[0-9]{4}-([0][0-9]|[1][0-2])-([0-2][0-9]|3[01])T([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9][.][0-9]{3}Z?$"
+            },
+            {
+              "enum": ["now"]
+            }]
+        }
+      }
+    },
+    "numeric": {
+      "type": "number",
+      "minimum": -1e20,
+      "maximum": 1e20,
+      "default": 0
+    },
+    "integer": {
+      "$ref": "#/definitions/numeric",
+      "multipleOf": 1
+    },
+    "string": {
+      "type": "string",
+      "maxLength": 1000,
+      "default": "string"
+    },
+    "fieldDefinition": {
+      "title": "The field definitions of a field to generate data for",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "default": {
+        "name": "fieldName",
+        "formatting": "",
+        "unique": false,
+        "nullable": true
+      },
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "formatting": {
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        },
+        "nullable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "constraint": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/anyOfConstraint"
+        },
+        {
+          "$ref": "#/definitions/allOfConstraint"
+        },
+        {
+          "$ref": "#/definitions/dataConstraint"
+        },
+        {
+          "$ref": "#/definitions/nullConstraint"
+        },
+        {
+          "$ref": "#/definitions/extendedDataConstraint"
+        },
+        {
+          "$ref": "#/definitions/inSetConstraint"
+        },
+        {
+          "$ref": "#/definitions/fromFileConstraint"
+        },
+        {
+          "$ref": "#/definitions/notConstraint"
+        },
+        {
+          "$ref": "#/definitions/ifThenConstraint"
+        },
+        {
+          "$ref": "#/definitions/ifThenElseConstraint"
+        }
+      ]
+    },
+    "dataConstraint": {
+      "type": "object",
+      "required": ["field", "is", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "enum": [
+            "ofType",
+            "equalTo",
+            "matchingRegex",
+            "containingRegex",
+            "ofLength",
+            "longerThan",
+            "shorterThan",
+            "greaterThan",
+            "lessThan",
+            "greaterThanOrEqualTo",
+            "lessThanOrEqualTo",
+            "granularTo",
+            "after",
+            "afterOrAt",
+            "before",
+            "beforeOrAt"
+          ]
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/datetime"
+            },
+            {
+              "$ref": "#/definitions/numeric"
+            },
+            {
+              "$ref": "#/definitions/string"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": ["after", "afterOrAt", "before", "beforeOrAt"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/datetime"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "equalTo"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/dataType"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "ofType"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "enum": ["decimal", "integer", "string", "datetime","ISIN","SEDOL","CUSIP","RIC","firstname","lastname","fullname"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": ["matchingRegex", "containingRegex"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "type": "string",
+                "default": ".*"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "shorterThan"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": 1,
+                "maximum": 1001
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "ofLength"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": 0,
+                "maximum": 1000
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "longerThan"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/integer",
+                "minimum": -1,
+                "maximum": 999
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "const": "granularTo"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "enum": [
+                  1,
+                  1e-1,
+                  1e-2,
+                  1e-3,
+                  1e-4,
+                  1e-5,
+                  1e-6,
+                  1e-7,
+                  1e-8,
+                  1e-9,
+                  1e-10,
+                  1e-11,
+                  1e-12,
+                  1e-13,
+                  1e-14,
+                  1e-15,
+                  1e-16,
+                  1e-17,
+                  1e-18,
+                  1e-19,
+                  1e-20,
+                  "millis",
+                  "seconds",
+                  "minutes",
+                  "hours",
+                  "days",
+                  "months",
+                  "years"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": [
+                  "greaterThan",
+                  "lessThan",
+                  "greaterThanOrEqualTo",
+                  "lessThanOrEqualTo"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "$ref": "#/definitions/numeric"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "extendedDataConstraint": {
+      "type": "object",
+      "required": ["field", "is", "otherField"],
+      "additionalProperties": true,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "enum": [
+            "after",
+            "afterOrAt",
+            "before",
+            "beforeOrAt",
+            "equalTo"
+          ]
+        },
+        "otherField": {
+          "$ref": "#/definitions/string"
+        },
+        "offset": {
+          "$ref": "#/definitions/integer"
+        },
+        "offsetUnit": {
+          "type": "string"
+        }
+      }
+    },
+    "notConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "anyOfConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anyOf"],
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/constraint"
+          }
+        }
+      }
+    },
+    "allOfConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allOf"],
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/constraint"
+          }
+        }
+      }
+    },
+    "ifThenConstraint": {
+      "type": "object",
+      "required": ["if", "then"],
+      "additionalProperties": false,
+      "properties": {
+        "if": {
+          "$ref": "#/definitions/constraint"
+        },
+        "then": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "ifThenElseConstraint": {
+      "type": "object",
+      "required": ["if", "then", "else"],
+      "additionalProperties": false,
+      "properties": {
+        "if": {
+          "$ref": "#/definitions/constraint"
+        },
+        "then": {
+          "$ref": "#/definitions/constraint"
+        },
+        "else": {
+          "$ref": "#/definitions/constraint"
+        }
+      }
+    },
+    "nullConstraint": {
+      "type": "object",
+      "required": ["field", "is"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "null"
+        }
+      }
+    },
+    "fromFileConstraint": {
+      "type": "object",
+      "required": ["field", "is", "file"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "inSet"
+        },
+        "file": {
+          "type": "string"
+        }
+      }
+    },
+    "inSetConstraint": {
+      "type": "object",
+      "required": ["field", "is", "values"],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "is": {
+          "const": "inSet"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/datetime"
+              },
+              {
+                "$ref": "#/definitions/numeric"
+              },
+              {
+                "$ref": "#/definitions/string"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
@@ -73,6 +73,9 @@ public class ProfileSchemaImmutabilityTests {
         versionToHash.add(new VersionHash(
             "0.5",
             "3d114a0ee1e3d201faa7442a8e6da7b9e8d67d72e772ed9324ced7f4c8936adc"));
+        versionToHash.add(new VersionHash(
+            "0.6",
+            "943ca15209ba515a9be9885c93fcc2f876e7e5ece0814a73c138ad965e29bbc6"));
         return versionToHash;
     }
 

--- a/profile/src/test/java/com/scottlogic/deg/profile/ProfileSerialiserTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/ProfileSerialiserTests.java
@@ -82,8 +82,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\", \"unique\": false  }," +
-                    "   { \"name\" : \"price\", \"unique\": false  }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false, \"nullable\": true }," +
+                    "   { \"name\" : \"price\", \"unique\": false, \"nullable\": true }" +
                     "]," +
                     "\"rules\" : [" +
                     " { \"rule\" : null," +
@@ -144,8 +144,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\", \"unique\": false  }," +
-                    "   { \"name\" : \"price\", \"unique\": false  }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false, \"nullable\": true  }," +
+                    "   { \"name\" : \"price\", \"unique\": false, \"nullable\": true  }" +
                     "]," +
                     "\"rules\" : [" +
                     " { " +
@@ -191,8 +191,8 @@ public class ProfileSerialiserTests {
                 "{" +
                     "\"schemaVersion\" : \"0.1\"," +
                     "\"fields\" : [" +
-                    "   { \"name\" : \"typecode\", \"unique\": false }," +
-                    "   { \"name\" : \"price\", \"unique\": false  }" +
+                    "   { \"name\" : \"typecode\", \"unique\": false, \"nullable\": true }," +
+                    "   { \"name\" : \"price\", \"unique\": false, \"nullable\": true  }" +
                     "]," +
                     "\"rules\" : [" +
                     " { " +

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -933,6 +933,20 @@ public class JsonProfileReaderTests {
     }
 
     @Test
+    public void nullable_DoesNotAddConstraintForField_whenNotSet() throws IOException  {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": " + schemaVersion + "," +
+                "    \"fields\": [ { " +
+                "       \"name\": \"foo\" " +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+
+        Assert.assertEquals(this.getResultingProfile().getRules().size(), 0);
+    }
+
+    @Test
     public void nullable_addsConstraintForFields_whenSetToFalse() throws IOException  {
         givenJson(
             "{" +

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -41,6 +41,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.IsNull.nullValue;
 
 public class JsonProfileReaderTests {
+    private final String schemaVersion = "\"0.6\"";
     private String json;
     private JsonProfileReader jsonProfileReader = new JsonProfileReader(
         null,
@@ -116,7 +117,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseSingleField() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"f1\" } ]," +
                         "    \"rules\": []" +
                         "}");
@@ -129,7 +130,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseMultipleFields() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"f1\" }, { \"name\": \"f2\" } ]," +
                         "    \"rules\": []" +
                         "}");
@@ -143,7 +144,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseInvalidProfileAsEmptyRule() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "       { \"field\": \"foo\", \"is\": \"null\" } " +
@@ -157,7 +158,7 @@ public class JsonProfileReaderTests {
     public void shouldGiveDefaultNameToUnnamedRules() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -176,7 +177,7 @@ public class JsonProfileReaderTests {
     public void shouldReadNameOfNamedRules() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "        {" +
@@ -196,7 +197,7 @@ public class JsonProfileReaderTests {
     public void shouldNotThrowIsNullWithValueNull() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "        {" +
@@ -216,7 +217,7 @@ public class JsonProfileReaderTests {
     public void shouldNotThrowIsNullWithValuesNull() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "        {" +
@@ -236,7 +237,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseIsOfTypeConstraint() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -260,7 +261,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseIsEqualToConstraint() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -287,7 +288,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseFormatConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.5\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { " +
                         "           \"name\": \"foo\"," +
                         "           \"formatting\": \"%.5s\"" +
@@ -307,7 +308,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseIsOfLengthConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"id\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -330,7 +331,7 @@ public class JsonProfileReaderTests {
         // Arrange
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -356,7 +357,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseOrConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -385,7 +386,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseAndConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -414,7 +415,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseIfConstraint() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -452,7 +453,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseIfConstraintWithoutElse() throws IOException {
         givenJson(
                 "{" +
-                        "    \"schemaVersion\": \"0.1\"," +
+                        "    \"schemaVersion\": " + schemaVersion + "," +
                         "    \"fields\": [ { \"name\": \"foo\" } ]," +
                         "    \"rules\": [" +
                         "      {" +
@@ -489,7 +490,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseOneAsNumericGranularToConstraint() throws IOException {
         givenJson(
             "{" +
-            "    \"schemaVersion\": \"0.1\"," +
+            "    \"schemaVersion\": " + schemaVersion + "," +
             "    \"fields\": [ { \"name\": \"foo\" } ]," +
             "    \"rules\": [" +
             "      {" +
@@ -515,7 +516,7 @@ public class JsonProfileReaderTests {
     public void shouldDeserialiseTenthAsNumericGranularToConstraint() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -541,7 +542,7 @@ public class JsonProfileReaderTests {
     public void shouldDisregardTrailingZeroesInNumericGranularities() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -567,7 +568,7 @@ public class JsonProfileReaderTests {
     public void shouldAllowValidISO8601DateTime() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -604,7 +605,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectGreaterThanOneNumericGranularityConstraint() {
         givenJson(
             "{" +
-            "    \"schemaVersion\": \"0.1\"," +
+            "    \"schemaVersion\": " + schemaVersion + "," +
             "    \"fields\": [ { \"name\": \"foo\" } ]," +
             "    \"rules\": [" +
             "      {" +
@@ -622,7 +623,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectNonPowerOfTenNumericGranularityConstraint() {
         givenJson(
             "{" +
-            "    \"schemaVersion\": \"0.1\"," +
+            "    \"schemaVersion\": " + schemaVersion + "," +
             "    \"fields\": [ { \"name\": \"foo\" } ]," +
             "    \"rules\": [" +
             "      {" +
@@ -640,7 +641,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectNonISO8601DateTime() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -658,7 +659,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectEqualToWithNullValue() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -676,7 +677,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectLessThanWithNullValue() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -694,7 +695,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectInSetWithANullValue() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -712,7 +713,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectInSetSetToNull() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -729,7 +730,7 @@ public class JsonProfileReaderTests {
     @Test
     public void shouldRejectAllOfWithEmptySet() {
         givenJson("{" +
-            "    \"schemaVersion\": \"0.1\"," +
+            "    \"schemaVersion\": " + schemaVersion + "," +
             "    \"fields\": [ { \"name\": \"foo\" } ]," +
             "    \"rules\": [" +
             "      {" +
@@ -746,7 +747,7 @@ public class JsonProfileReaderTests {
     @Test
     public void shouldRejectAllOfWithEmptySetWithExplicitConstraint() {
         givenJson("{" +
-            "    \"schemaVersion\": \"0.1\"," +
+            "    \"schemaVersion\": " + schemaVersion + "," +
             "    \"fields\": [ { \"name\": \"foo\" } ]," +
             "    \"rules\": [{" +
             "        \"rule\": \"foo rule\"," +
@@ -763,7 +764,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectIsConstraintSetToNull() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -781,7 +782,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectIsConstraintSetToNullWithRuleAndConstraintFormat() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "       {" +
@@ -798,7 +799,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectIsConstraintSetToNullForNot() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "      {" +
@@ -816,7 +817,7 @@ public class JsonProfileReaderTests {
     public void shouldRejectIsConstraintSetToNullForNotWithRuleAndConstraintFormat() {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.1\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { \"name\": \"foo\" } ]," +
                 "    \"rules\": [" +
                 "       {" +
@@ -833,7 +834,7 @@ public class JsonProfileReaderTests {
     public void unique_setsFieldPropertyToTrue_whenSetToTrue() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.5\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { " +
                 "           \"name\": \"foo\"," +
                 "           \"unique\": true" +
@@ -853,9 +854,28 @@ public class JsonProfileReaderTests {
     public void unique_setsFieldPropertyToFalse_whenOmitted() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.5\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { " +
                 "           \"name\": \"foo\"" +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+        expectFields(
+            field -> {
+                Assert.assertThat(field.name, equalTo("foo"));
+                Assert.assertFalse(field.isUnique());
+            }
+        );
+    }
+
+    @Test
+    public void unique_setsFieldPropertyToFalse_whenSetToFalse() throws IOException {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": " + schemaVersion + "," +
+                "    \"fields\": [ { " +
+                "           \"name\": \"foo\"," +
+                "           \"unique\": false" +
                 "    } ]," +
                 "    \"rules\": []" +
                 "}");
@@ -869,22 +889,121 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void unique_setsFieldPropertyToFalse_whenSetToFalse() throws IOException {
+    public void nullable_addsConstraintForField_whenSetToFalse() throws IOException {
         givenJson(
             "{" +
-                "    \"schemaVersion\": \"0.5\"," +
+                "    \"schemaVersion\": " + schemaVersion + "," +
                 "    \"fields\": [ { " +
-                "           \"name\": \"foo\"," +
-                "           \"unique\": false" +
+                "       \"name\": \"foo\" ," +
+                "       \"nullable\": false" +
                 "    } ]," +
                 "    \"rules\": []" +
                 "}");
 
-        expectFields(
-            field -> {
-                Assert.assertThat(field.name, equalTo("foo"));
-                Assert.assertFalse(field.isUnique());
-            }
+        expectRules(
+            ruleWithConstraints(
+                typedConstraint(
+                    NotConstraint.class,
+                    c -> {
+                        Assert.assertThat(
+                            c.negatedConstraint,
+                            instanceOf(IsNullConstraint.class));
+                        Assert.assertEquals(
+                            c.negatedConstraint.getField().name,
+                            "foo");
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void nullable_DoesNotAddConstraintForField_whenSetToTrue() throws IOException  {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": " + schemaVersion + "," +
+                "    \"fields\": [ { " +
+                "       \"name\": \"foo\" ," +
+                "       \"nullable\": true" +
+                "    } ]," +
+                "    \"rules\": []" +
+                "}");
+
+        Assert.assertEquals(this.getResultingProfile().getRules().size(), 0);
+    }
+
+    @Test
+    public void nullable_addsConstraintForFields_whenSetToFalse() throws IOException  {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": " + schemaVersion + "," +
+                "    \"fields\": [ { " +
+                "       \"name\": \"foo\" ," +
+                "       \"nullable\": false" +
+                "    }, { " +
+                "       \"name\": \"bar\" ," +
+                "       \"nullable\": false" +
+                "    }]," +
+                "    \"rules\": []" +
+                "}");
+
+        expectRules(
+            ruleWithConstraints(
+                typedConstraint(
+                    NotConstraint.class,
+                    c -> {
+                        Assert.assertThat(
+                            c.negatedConstraint,
+                            instanceOf(IsNullConstraint.class));
+                        Assert.assertEquals(
+                            c.negatedConstraint.getField().name,
+                            "foo");
+                    }
+                ),
+                typedConstraint(
+                    NotConstraint.class,
+                    c -> {
+                        Assert.assertThat(
+                            c.negatedConstraint,
+                            instanceOf(IsNullConstraint.class));
+                        Assert.assertEquals(
+                            c.negatedConstraint.getField().name,
+                            "bar");
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void nullable_addsConstraintForFields_whenOneSetToFalse() throws IOException  {
+        givenJson(
+            "{" +
+                "    \"schemaVersion\": " + schemaVersion + "," +
+                "    \"fields\": [ { " +
+                "       \"name\": \"foo\" ," +
+                "       \"nullable\": true" +
+                "    }, { " +
+                "       \"name\": \"bar\" ," +
+                "       \"nullable\": false" +
+                "    }]," +
+                "    \"rules\": []" +
+                "}");
+
+        expectRules(
+            ruleWithConstraints(
+                typedConstraint(
+                    NotConstraint.class,
+                    c -> {
+                        Assert.assertThat(
+                            c.negatedConstraint,
+                            instanceOf(IsNullConstraint.class));
+                        Assert.assertEquals(
+                            c.negatedConstraint.getField().name,
+                            "bar");
+                    }
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
### Description

Added nullable to the field definition in the profile schema. This is shorthand for creating the constraint not null for the field when nullable is false. By default nullable will be set to true.

### Changes
- Added `nullable` to the profile schema for the field definition
- Updated user documentation
- Added unit tests

### Issue
Resolves #1303