### PR TITLE
1334 EqualToConstraint toString bug

### DIFF
--- a/common/src/main/java/com/scottlogic/deg/common/profile/constraints/atomic/EqualToConstraint.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/constraints/atomic/EqualToConstraint.java
@@ -21,7 +21,7 @@ public class EqualToConstraint implements AtomicConstraint {
 
     @Override
     public String toString(){
-        return String.format("equalTo: {}", value);
+        return String.format("`%s` = %s", field.name, value);
     }
 
     @Override


### PR DESCRIPTION
### Description
Fixed up EqualToConstrint.toString so prints out string which includes field name and value

### Changes
1 line change in EqualToConstraint

### Issue
Resolves #1334
Related #1322 
