### PR TITLE
1333 remove empty fieldspec

### DIFF
--- a/common/src/test/java/com/scottlogic/deg/common/profile/FieldBuilder.java
+++ b/common/src/test/java/com/scottlogic/deg/common/profile/FieldBuilder.java
@@ -20,7 +20,7 @@ import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.T
 
 public class FieldBuilder {
     public static Field createField(String name) {
-        return new Field(name, Types.STRING, false, null);
+        return createField(name, Types.STRING);
     }
     public static Field createField(String name, Types type) {
         return new Field(name, type, false, null);

--- a/common/src/test/java/com/scottlogic/deg/common/profile/FieldBuilder.java
+++ b/common/src/test/java/com/scottlogic/deg/common/profile/FieldBuilder.java
@@ -22,4 +22,7 @@ public class FieldBuilder {
     public static Field createField(String name) {
         return new Field(name, Types.STRING, false, null);
     }
+    public static Field createField(String name, Types type) {
+        return new Field(name, type, false, null);
+    }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperation.java
@@ -20,7 +20,6 @@ import com.google.inject.Inject;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 
 public class DateTimeRestrictionsMergeOperation implements RestrictionMergeOperation {
     private final DateTimeRestrictionsMerger merger;
@@ -40,7 +39,7 @@ public class DateTimeRestrictionsMergeOperation implements RestrictionMergeOpera
             left.getDateTimeRestrictions(), right.getDateTimeRestrictions());
 
         if (!mergeResult.successful){
-            return NullOnly;
+            return FieldSpec.nullOnlyFromType(merging.getType());
         }
 
         return merging.withDateTimeRestrictions(mergeResult.restrictions);

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -33,9 +33,15 @@ import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConst
  * This is enforced during merging.
  */
 public class FieldSpec {
-    public static final Types ALL_TYPES_PERMITTED = null;
-    public static final FieldSpec Empty = new FieldSpec(null, null, true, Collections.emptySet(), ALL_TYPES_PERMITTED);
-    public static final FieldSpec NullOnly = Empty.withWhitelist(FrequencyDistributedSet.empty());
+    public static final FieldSpec NullOnly = new FieldSpec(FrequencyDistributedSet.empty(), null, true, Collections.emptySet(), null);
+
+    public static FieldSpec fromType(Types type) {
+        return new FieldSpec(null, null, true, Collections.emptySet(), type);
+    }
+
+    public static FieldSpec nullOnlyFromType(Types type) {
+        return new FieldSpec(FrequencyDistributedSet.empty(), null, true, Collections.emptySet(), type);
+    }
 
     private final boolean nullable;
     private final DistributedSet<Object> whitelist;

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -33,12 +33,15 @@ import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConst
  * This is enforced during merging.
  */
 public class FieldSpec {
+
+    private static final FrequencyDistributedSet<Object> NO_VALUES = FrequencyDistributedSet.empty();
+
     public static FieldSpec fromType(Types type) {
         return new FieldSpec(null, null, true, Collections.emptySet(), type);
     }
 
     public static FieldSpec nullOnlyFromType(Types type) {
-        return new FieldSpec(FrequencyDistributedSet.empty(), null, true, Collections.emptySet(), type);
+        return new FieldSpec(NO_VALUES, null, true, Collections.emptySet(), type);
     }
 
     private final boolean nullable;
@@ -107,10 +110,6 @@ public class FieldSpec {
 
     public FieldSpec withBlacklist(Set<Object> blacklist) {
         return new FieldSpec(whitelist, restrictions, nullable, blacklist, types);
-    }
-
-    public FieldSpec withType(Types type) {
-        return new FieldSpec(whitelist, restrictions, nullable, blacklist, type);
     }
 
     public FieldSpec withStringRestrictions(StringRestrictions stringRestrictions) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -33,8 +33,6 @@ import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConst
  * This is enforced during merging.
  */
 public class FieldSpec {
-    public static final FieldSpec NullOnly = new FieldSpec(FrequencyDistributedSet.empty(), null, true, Collections.emptySet(), null);
-
     public static FieldSpec fromType(Types type) {
         return new FieldSpec(null, null, true, Collections.emptySet(), type);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -122,8 +122,11 @@ public class FieldSpecFactory {
         if (negate) {
             throw new UnsupportedOperationException("cannot negate types");
         }
+        if (field.getType() != constraint.requiredType) {
+            return FieldSpec.nullOnlyFromType(null);
+        }
 
-        return FieldSpec.fromType(field.getType()).withType(constraint.requiredType);
+        return FieldSpec.fromType(field.getType());
     }
 
     private FieldSpec construct(Field field, IsGreaterThanConstantConstraint constraint, boolean negate) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -115,7 +115,7 @@ public class FieldSpecFactory {
             return FieldSpec.fromType(field.getType()).withNotNull();
         }
 
-        return FieldSpec.NullOnly;
+        return FieldSpec.nullOnlyFromType(field.getType());
     }
 
     private FieldSpec construct(Field field, IsOfTypeConstraint constraint, boolean negate) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -17,6 +17,7 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
 import com.google.inject.Inject;
+import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.constraints.atomic.*;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
 import com.scottlogic.deg.generator.restrictions.*;
@@ -37,103 +38,103 @@ public class FieldSpecFactory {
         this.stringRestrictionsFactory = stringRestrictionsFactory;
     }
 
-    public FieldSpec construct(AtomicConstraint constraint) {
-        return construct(constraint, false);
+    public FieldSpec construct(Field field, AtomicConstraint constraint) {
+        return construct(field, constraint, false);
     }
 
-    private FieldSpec construct(AtomicConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, AtomicConstraint constraint, boolean negate) {
         if (constraint instanceof ViolatedAtomicConstraint) {
-            return construct(((ViolatedAtomicConstraint) constraint).violatedConstraint, negate);
+            return construct(field, ((ViolatedAtomicConstraint) constraint).violatedConstraint, negate);
         } else if (constraint instanceof NotConstraint) {
-            return construct(((NotConstraint) constraint).negatedConstraint, !negate);
+            return construct(field, ((NotConstraint) constraint).negatedConstraint, !negate);
         } else if (constraint instanceof IsInSetConstraint) {
-            return construct((IsInSetConstraint) constraint, negate);
+            return construct(field, (IsInSetConstraint) constraint, negate);
         } else if (constraint instanceof EqualToConstraint) {
-            return construct((EqualToConstraint) constraint, negate);
+            return construct(field, (EqualToConstraint) constraint, negate);
         } else if (constraint instanceof IsGreaterThanConstantConstraint) {
-            return construct((IsGreaterThanConstantConstraint) constraint, negate);
+            return construct(field, (IsGreaterThanConstantConstraint) constraint, negate);
         } else if (constraint instanceof IsGreaterThanOrEqualToConstantConstraint) {
-            return construct((IsGreaterThanOrEqualToConstantConstraint) constraint, negate);
+            return construct(field, (IsGreaterThanOrEqualToConstantConstraint) constraint, negate);
         } else if (constraint instanceof IsLessThanConstantConstraint) {
-            return construct((IsLessThanConstantConstraint) constraint, negate);
+            return construct(field, (IsLessThanConstantConstraint) constraint, negate);
         } else if (constraint instanceof IsLessThanOrEqualToConstantConstraint) {
-            return construct((IsLessThanOrEqualToConstantConstraint) constraint, negate);
+            return construct(field, (IsLessThanOrEqualToConstantConstraint) constraint, negate);
         } else if (constraint instanceof IsAfterConstantDateTimeConstraint) {
-            return construct((IsAfterConstantDateTimeConstraint) constraint, negate);
+            return construct(field, (IsAfterConstantDateTimeConstraint) constraint, negate);
         } else if (constraint instanceof IsAfterOrEqualToConstantDateTimeConstraint) {
-            return construct((IsAfterOrEqualToConstantDateTimeConstraint) constraint, negate);
+            return construct(field, (IsAfterOrEqualToConstantDateTimeConstraint) constraint, negate);
         } else if (constraint instanceof IsBeforeConstantDateTimeConstraint) {
-            return construct((IsBeforeConstantDateTimeConstraint) constraint, negate);
+            return construct(field, (IsBeforeConstantDateTimeConstraint) constraint, negate);
         } else if (constraint instanceof IsBeforeOrEqualToConstantDateTimeConstraint) {
-            return construct((IsBeforeOrEqualToConstantDateTimeConstraint) constraint, negate);
+            return construct(field, (IsBeforeOrEqualToConstantDateTimeConstraint) constraint, negate);
         } else if (constraint instanceof IsGranularToNumericConstraint) {
-            return construct((IsGranularToNumericConstraint) constraint, negate);
+            return construct(field, (IsGranularToNumericConstraint) constraint, negate);
         } else if (constraint instanceof IsGranularToDateConstraint) {
-            return construct((IsGranularToDateConstraint) constraint, negate);
+            return construct(field, (IsGranularToDateConstraint) constraint, negate);
         } else if (constraint instanceof IsNullConstraint) {
-            return constructIsNull(negate);
+            return constructIsNull(field, negate);
         } else if (constraint instanceof MatchesRegexConstraint) {
-            return construct((MatchesRegexConstraint) constraint, negate);
+            return construct(field, (MatchesRegexConstraint) constraint, negate);
         } else if (constraint instanceof ContainsRegexConstraint) {
-            return construct((ContainsRegexConstraint) constraint, negate);
+            return construct(field, (ContainsRegexConstraint) constraint, negate);
         } else if (constraint instanceof MatchesStandardConstraint) {
-            return construct((MatchesStandardConstraint) constraint, negate);
+            return construct(field, (MatchesStandardConstraint) constraint, negate);
         } else if (constraint instanceof IsOfTypeConstraint) {
-            return construct((IsOfTypeConstraint) constraint, negate);
+            return construct(field, (IsOfTypeConstraint) constraint, negate);
         } else if (constraint instanceof StringHasLengthConstraint) {
-            return construct((StringHasLengthConstraint) constraint, negate);
+            return construct(field, (StringHasLengthConstraint) constraint, negate);
         } else if (constraint instanceof IsStringLongerThanConstraint) {
-            return construct((IsStringLongerThanConstraint) constraint, negate);
+            return construct(field, (IsStringLongerThanConstraint) constraint, negate);
         } else if (constraint instanceof IsStringShorterThanConstraint) {
-            return construct((IsStringShorterThanConstraint) constraint, negate);
+            return construct(field, (IsStringShorterThanConstraint) constraint, negate);
         } else {
             throw new UnsupportedOperationException();
         }
     }
 
-    private FieldSpec construct(IsInSetConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, IsInSetConstraint constraint, boolean negate) {
         if (negate) {
-            return FieldSpec.Empty.withBlacklist(constraint.legalValuesWithoutFrequency());
+            return FieldSpec.fromType(field.getType()).withBlacklist(constraint.legalValuesWithoutFrequency());
         }
 
-        return FieldSpec.Empty.withWhitelist(constraint.legalValues);
+        return FieldSpec.fromType(field.getType()).withWhitelist(constraint.legalValues);
     }
 
-    private FieldSpec construct(EqualToConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, EqualToConstraint constraint, boolean negate) {
         if (negate) {
-            return FieldSpec.Empty.withBlacklist(Collections.singleton(constraint.value));
+            return FieldSpec.fromType(field.getType()).withBlacklist(Collections.singleton(constraint.value));
         }
 
-        return FieldSpec.Empty
+        return FieldSpec.fromType(field.getType())
             .withWhitelist(FrequencyDistributedSet.singleton(constraint.value))
             .withNotNull();
     }
 
-    private FieldSpec constructIsNull(boolean negate) {
+    private FieldSpec constructIsNull(Field field, boolean negate) {
         if (negate) {
-            return FieldSpec.Empty.withNotNull();
+            return FieldSpec.fromType(field.getType()).withNotNull();
         }
 
         return FieldSpec.NullOnly;
     }
 
-    private FieldSpec construct(IsOfTypeConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, IsOfTypeConstraint constraint, boolean negate) {
         if (negate) {
             throw new UnsupportedOperationException("cannot negate types");
         }
 
-        return FieldSpec.Empty.withType(constraint.requiredType);
+        return FieldSpec.fromType(field.getType()).withType(constraint.requiredType);
     }
 
-    private FieldSpec construct(IsGreaterThanConstantConstraint constraint, boolean negate) {
-        return constructGreaterThanConstraint(constraint.referenceValue, false, negate);
+    private FieldSpec construct(Field field, IsGreaterThanConstantConstraint constraint, boolean negate) {
+        return constructGreaterThanConstraint(field, constraint.referenceValue, false, negate);
     }
 
-    private FieldSpec construct(IsGreaterThanOrEqualToConstantConstraint constraint, boolean negate) {
-        return constructGreaterThanConstraint(constraint.referenceValue, true, negate);
+    private FieldSpec construct(Field field, IsGreaterThanOrEqualToConstantConstraint constraint, boolean negate) {
+        return constructGreaterThanConstraint(field, constraint.referenceValue, true, negate);
     }
 
-    private FieldSpec constructGreaterThanConstraint(Number limitValue, boolean inclusive, boolean negate) {
+    private FieldSpec constructGreaterThanConstraint(Field field, Number limitValue, boolean inclusive, boolean negate) {
         final NumericRestrictions numericRestrictions = new NumericRestrictions();
 
         final BigDecimal limit = NumberUtils.coerceToBigDecimal(limitValue);
@@ -147,18 +148,18 @@ public class FieldSpecFactory {
                 inclusive);
         }
 
-        return FieldSpec.Empty.withNumericRestrictions(numericRestrictions);
+        return FieldSpec.fromType(field.getType()).withNumericRestrictions(numericRestrictions);
     }
 
-    private FieldSpec construct(IsLessThanConstantConstraint constraint, boolean negate) {
-        return constructLessThanConstraint(constraint.referenceValue, false, negate);
+    private FieldSpec construct(Field field, IsLessThanConstantConstraint constraint, boolean negate) {
+        return constructLessThanConstraint(field, constraint.referenceValue, false, negate);
     }
 
-    private FieldSpec construct(IsLessThanOrEqualToConstantConstraint constraint, boolean negate) {
-        return constructLessThanConstraint(constraint.referenceValue, true, negate);
+    private FieldSpec construct(Field field, IsLessThanOrEqualToConstantConstraint constraint, boolean negate) {
+        return constructLessThanConstraint(field, constraint.referenceValue, true, negate);
     }
 
-    private FieldSpec constructLessThanConstraint(Number limitValue, boolean inclusive, boolean negate) {
+    private FieldSpec constructLessThanConstraint(Field field, Number limitValue, boolean inclusive, boolean negate) {
         final NumericRestrictions numericRestrictions = new NumericRestrictions();
         final BigDecimal limit = NumberUtils.coerceToBigDecimal(limitValue);
         if (negate) {
@@ -171,36 +172,36 @@ public class FieldSpecFactory {
                 inclusive);
         }
 
-        return FieldSpec.Empty.withNumericRestrictions(numericRestrictions);
+        return FieldSpec.fromType(field.getType()).withNumericRestrictions(numericRestrictions);
     }
 
-    private FieldSpec construct(IsGranularToNumericConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, IsGranularToNumericConstraint constraint, boolean negate) {
         if (negate) {
             // negated granularity is a future enhancement
-            return FieldSpec.Empty;
+            return FieldSpec.fromType(field.getType());
         }
 
-        return FieldSpec.Empty.withNumericRestrictions(new NumericRestrictions(constraint.granularity.getNumericGranularity().scale()));
+        return FieldSpec.fromType(field.getType()).withNumericRestrictions(new NumericRestrictions(constraint.granularity.getNumericGranularity().scale()));
     }
 
-    private FieldSpec construct(IsGranularToDateConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, IsGranularToDateConstraint constraint, boolean negate) {
         if (negate) {
             // negated granularity is a future enhancement
-            return FieldSpec.Empty;
+            return FieldSpec.fromType(field.getType());
         }
 
-        return FieldSpec.Empty.withDateTimeRestrictions(new DateTimeRestrictions(constraint.granularity.getGranularity()));
+        return FieldSpec.fromType(field.getType()).withDateTimeRestrictions(new DateTimeRestrictions(constraint.granularity.getGranularity()));
     }
 
-    private FieldSpec construct(IsAfterConstantDateTimeConstraint constraint, boolean negate) {
-        return constructIsAfterConstraint(constraint.referenceValue, false, negate);
+    private FieldSpec construct(Field field, IsAfterConstantDateTimeConstraint constraint, boolean negate) {
+        return constructIsAfterConstraint(field, constraint.referenceValue, false, negate);
     }
 
-    private FieldSpec construct(IsAfterOrEqualToConstantDateTimeConstraint constraint, boolean negate) {
-        return constructIsAfterConstraint(constraint.referenceValue, true, negate);
+    private FieldSpec construct(Field field, IsAfterOrEqualToConstantDateTimeConstraint constraint, boolean negate) {
+        return constructIsAfterConstraint(field, constraint.referenceValue, true, negate);
     }
 
-    private FieldSpec constructIsAfterConstraint(OffsetDateTime limit, boolean inclusive, boolean negate) {
+    private FieldSpec constructIsAfterConstraint(Field field, OffsetDateTime limit, boolean inclusive, boolean negate) {
         final DateTimeRestrictions dateTimeRestrictions = new DateTimeRestrictions();
 
         if (negate) {
@@ -209,18 +210,18 @@ public class FieldSpecFactory {
             dateTimeRestrictions.min = new DateTimeLimit(limit, inclusive);
         }
 
-        return FieldSpec.Empty.withDateTimeRestrictions(dateTimeRestrictions);
+        return FieldSpec.fromType(field.getType()).withDateTimeRestrictions(dateTimeRestrictions);
     }
 
-    private FieldSpec construct(IsBeforeConstantDateTimeConstraint constraint, boolean negate) {
-        return constructIsBeforeConstraint(constraint.referenceValue, false, negate);
+    private FieldSpec construct(Field field, IsBeforeConstantDateTimeConstraint constraint, boolean negate) {
+        return constructIsBeforeConstraint(field, constraint.referenceValue, false, negate);
     }
 
-    private FieldSpec construct(IsBeforeOrEqualToConstantDateTimeConstraint constraint, boolean negate) {
-        return constructIsBeforeConstraint(constraint.referenceValue, true, negate);
+    private FieldSpec construct(Field field, IsBeforeOrEqualToConstantDateTimeConstraint constraint, boolean negate) {
+        return constructIsBeforeConstraint(field, constraint.referenceValue, true, negate);
     }
 
-    private FieldSpec constructIsBeforeConstraint(OffsetDateTime limit, boolean inclusive, boolean negate) {
+    private FieldSpec constructIsBeforeConstraint(Field field, OffsetDateTime limit, boolean inclusive, boolean negate) {
         final DateTimeRestrictions dateTimeRestrictions = new DateTimeRestrictions();
 
         if (negate) {
@@ -229,39 +230,39 @@ public class FieldSpecFactory {
             dateTimeRestrictions.max = new DateTimeLimit(limit, inclusive);
         }
 
-        return FieldSpec.Empty.withDateTimeRestrictions(dateTimeRestrictions);
+        return FieldSpec.fromType(field.getType()).withDateTimeRestrictions(dateTimeRestrictions);
     }
 
-    private FieldSpec construct(MatchesRegexConstraint constraint, boolean negate) {
-        return FieldSpec.Empty
+    private FieldSpec construct(Field field, MatchesRegexConstraint constraint, boolean negate) {
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(stringRestrictionsFactory.forStringMatching(constraint.regex, negate));
     }
 
-    private FieldSpec construct(ContainsRegexConstraint constraint, boolean negate) {
-        return FieldSpec.Empty
+    private FieldSpec construct(Field field, ContainsRegexConstraint constraint, boolean negate) {
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(stringRestrictionsFactory.forStringContaining(constraint.regex, negate));
     }
 
-    private FieldSpec construct(MatchesStandardConstraint constraint, boolean negate) {
+    private FieldSpec construct(Field field, MatchesStandardConstraint constraint, boolean negate) {
         if (constraint.standard.equals(RIC)) {
-            return construct(new MatchesRegexConstraint(constraint.field, Pattern.compile(RIC.getRegex())), negate);
+            return construct(field, new MatchesRegexConstraint(constraint.field, Pattern.compile(RIC.getRegex())), negate);
         }
 
         if (negate){
-            return construct(new MatchesRegexConstraint(constraint.field, Pattern.compile(constraint.standard.getRegex())), negate);
+            return construct(field, new MatchesRegexConstraint(constraint.field, Pattern.compile(constraint.standard.getRegex())), negate);
         }
 
-        return FieldSpec.Empty
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(new MatchesStandardStringRestrictions(constraint.standard));
     }
 
-    private FieldSpec construct(StringHasLengthConstraint constraint, boolean negate) {
-        return FieldSpec.Empty
+    private FieldSpec construct(Field field, StringHasLengthConstraint constraint, boolean negate) {
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(stringRestrictionsFactory.forLength(constraint.referenceValue, negate));
     }
 
-    private FieldSpec construct(IsStringShorterThanConstraint constraint, boolean negate) {
-        return FieldSpec.Empty
+    private FieldSpec construct(Field field, IsStringShorterThanConstraint constraint, boolean negate) {
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(
                 negate
                     ? stringRestrictionsFactory.forMinLength(constraint.referenceValue)
@@ -269,8 +270,8 @@ public class FieldSpecFactory {
             );
     }
 
-    private FieldSpec construct(IsStringLongerThanConstraint constraint, boolean negate) {
-        return FieldSpec.Empty
+    private FieldSpec construct(Field field, IsStringLongerThanConstraint constraint, boolean negate) {
+        return FieldSpec.fromType(field.getType())
             .withStringRestrictions(
                 negate
                     ? stringRestrictionsFactory.forMaxLength(constraint.referenceValue)

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelper.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelper.java
@@ -16,15 +16,17 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 
 public class FieldSpecHelper {
-    public FieldSpec getFieldSpecForValue(DataBagValue fieldValue) {
+    public FieldSpec getFieldSpecForValue(Field field, DataBagValue fieldValue) {
         if (fieldValue.getValue() == null) {
             return getNullRequiredFieldSpec();
         }
-        return FieldSpec.Empty
+
+        return FieldSpec.fromType(field.getType())
             .withWhitelist(FrequencyDistributedSet.singleton(fieldValue.getValue()))
             .withNotNull();
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelper.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelper.java
@@ -23,15 +23,11 @@ import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 public class FieldSpecHelper {
     public FieldSpec getFieldSpecForValue(Field field, DataBagValue fieldValue) {
         if (fieldValue.getValue() == null) {
-            return getNullRequiredFieldSpec();
+            return FieldSpec.nullOnlyFromType(field.getType());
         }
 
         return FieldSpec.fromType(field.getType())
             .withWhitelist(FrequencyDistributedSet.singleton(fieldValue.getValue()))
             .withNotNull();
-    }
-
-    private FieldSpec getNullRequiredFieldSpec() {
-        return FieldSpec.NullOnly;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedSet;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
@@ -67,7 +68,7 @@ public class FieldSpecMerger {
                 .map(rightHolder -> mergeElements(leftHolder, rightHolder)))
             .collect(Collectors.toSet()));
 
-        return addNullable(left, right, setRestriction(set));
+        return addNullable(left, right, setRestriction(left.getType(), set));
     }
 
     private static <T> boolean elementsEqual(WeightedElement<T> left, WeightedElement<T> right) {
@@ -80,7 +81,7 @@ public class FieldSpecMerger {
                 .filter(holder -> restrictions.permits(holder.element()))
                 .collect(Collectors.toSet()));
 
-        return addNullable(set, restrictions, setRestriction(newSet));
+        return addNullable(set, restrictions, setRestriction(set.getType(), newSet));
     }
 
     private Optional<FieldSpec> addNullable(FieldSpec left, FieldSpec right, FieldSpec newFieldSpec) {
@@ -99,8 +100,8 @@ public class FieldSpecMerger {
         return (fieldSpec.getWhitelist() != null && fieldSpec.getWhitelist().isEmpty());
     }
 
-    private FieldSpec setRestriction(DistributedSet<Object> set) {
-        return FieldSpec.Empty.withWhitelist(set);
+    private FieldSpec setRestriction(Types type, DistributedSet<Object> set) {
+        return FieldSpec.fromType(type).withWhitelist(set);
     }
 
     private boolean hasSet(FieldSpec fieldSpec) {
@@ -112,7 +113,7 @@ public class FieldSpecMerger {
     }
 
     private Optional<FieldSpec> combineRestrictions(FieldSpec left, FieldSpec right) {
-        FieldSpec merging = FieldSpec.Empty;
+        FieldSpec merging = FieldSpec.fromType(left.getType());
 
         for (RestrictionMergeOperation operation : mergeOperations) {
             merging = operation.applyMergeOperation(left, right, merging);

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
@@ -20,7 +20,6 @@ import com.google.inject.Inject;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.NUMERIC;
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 
 public class NumericRestrictionsMergeOperation implements RestrictionMergeOperation {
     private final NumericRestrictionsMerger merger;
@@ -40,7 +39,7 @@ public class NumericRestrictionsMergeOperation implements RestrictionMergeOperat
             left.getNumericRestrictions(), right.getNumericRestrictions());
 
         if (!mergeResult.successful) {
-            return NullOnly;
+            return FieldSpec.nullOnlyFromType(merging.getType());
         }
 
         return merging.withNumericRestrictions(mergeResult.restrictions);

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RowSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RowSpec.java
@@ -48,8 +48,9 @@ public class RowSpec {
     public FieldSpec getSpecForField(Field field) {
         FieldSpec ownFieldSpec = this.fieldToFieldSpec.get(field);
 
-        if (ownFieldSpec == null)
-            return FieldSpec.Empty;
+        if (ownFieldSpec == null) {
+            return FieldSpec.fromType(field.getType());
+        }
 
         return ownFieldSpec;
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/StringRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/StringRestrictionsMergeOperation.java
@@ -19,7 +19,6 @@ package com.scottlogic.deg.generator.fieldspecs;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.STRING;
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 
 public class StringRestrictionsMergeOperation implements RestrictionMergeOperation {
     private static final StringRestrictionsMerger stringRestrictionsMerger = new StringRestrictionsMerger();
@@ -34,7 +33,7 @@ public class StringRestrictionsMergeOperation implements RestrictionMergeOperati
             left.getStringRestrictions(), right.getStringRestrictions());
 
         if (!mergeResult.successful) {
-            return NullOnly;
+            return FieldSpec.nullOnlyFromType(merging.getType());
         }
 
         return merging.withStringRestrictions(mergeResult.restrictions);

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/TypesRestrictionMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/TypesRestrictionMergeOperation.java
@@ -16,14 +16,6 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
-import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types;
-import com.scottlogic.deg.generator.utils.SetUtils;
-
-import java.util.Set;
-
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
-
 public class TypesRestrictionMergeOperation implements RestrictionMergeOperation {
 
     @Override
@@ -38,7 +30,7 @@ public class TypesRestrictionMergeOperation implements RestrictionMergeOperation
             return merging.withType(left.getType());
         }
 
-        return NullOnly;
+        return FieldSpec.nullOnlyFromType(null);
 
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/TypesRestrictionMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/TypesRestrictionMergeOperation.java
@@ -21,13 +21,13 @@ public class TypesRestrictionMergeOperation implements RestrictionMergeOperation
     @Override
     public FieldSpec applyMergeOperation(FieldSpec left, FieldSpec right, FieldSpec merging) {
         if (left.getType() == null){
-            return merging.withType(right.getType());
+            return FieldSpec.fromType(right.getType());
         }
         if (right.getType() == null){
-            return merging.withType(left.getType());
+            return FieldSpec.fromType(left.getType());
         }
         if (left.getType() == right.getType()){
-            return merging.withType(left.getType());
+            return FieldSpec.fromType(left.getType());
         }
 
         return FieldSpec.nullOnlyFromType(null);

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AbstractDateInequalityRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AbstractDateInequalityRelation.java
@@ -46,9 +46,9 @@ abstract class AbstractDateInequalityRelation implements FieldSpecRelations {
             DateTimeRestrictions restrictions = new DateTimeRestrictions();
             appendValueToRestrictions(restrictions, value);
 
-            return FieldSpec.Empty.withDateTimeRestrictions(restrictions);
+            return FieldSpec.fromType(otherValue.getType()).withDateTimeRestrictions(restrictions);
         } else {
-            return FieldSpec.Empty;
+            return FieldSpec.fromType(otherValue.getType());
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetDateRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetDateRelation.java
@@ -50,9 +50,9 @@ public class EqualToOffsetDateRelation implements FieldSpecRelations {
             DateTimeRestrictions newRestrictions = new DateTimeRestrictions();
             newRestrictions.min = newLimit;
             newRestrictions.max = newLimit;
-            return FieldSpec.Empty.withDateTimeRestrictions(newRestrictions);
+            return FieldSpec.fromType(otherValue.getType()).withDateTimeRestrictions(newRestrictions);
         } else {
-            return FieldSpec.Empty;
+            return FieldSpec.fromType(otherValue.getType());
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
@@ -45,7 +45,7 @@ public class UpfrontTreePruner {
             .collect(
                 Collectors.toMap(
                     Function.identity(),
-                    f -> FieldSpec.Empty));
+                    f -> FieldSpec.fromType(f.type)));
 
         Merged<ConstraintNode> prunedNode = treePruner.pruneConstraintNode(tree.getRootNode(), fieldSpecs);
         DecisionTree markedTree = validator.markContradictions(tree);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/grouped/FieldSpecGroupDateHelper.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/grouped/FieldSpecGroupDateHelper.java
@@ -24,7 +24,7 @@ public class FieldSpecGroupDateHelper {
         DateTimeRestrictions restrictions = new DateTimeRestrictions();
         restrictions.min = limit;
         restrictions.max = limit;
-        FieldSpec newSpec = FieldSpec.Empty.withNotNull().withDateTimeRestrictions(restrictions);
+        FieldSpec newSpec = FieldSpec.fromType(field.type).withNotNull().withDateTimeRestrictions(restrictions);
 
         return adjustBoundsOfDateFromFieldSpec(field, newSpec, group);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
@@ -96,7 +96,7 @@ public class ContradictionDecisionTreeValidator {
 
     private RowSpec getIdentityRowSpec(ProfileFields profileFields) {
         final Map<Field, FieldSpec> fieldToFieldSpec = profileFields.stream()
-            .collect(Collectors.toMap(Function.identity(), field -> FieldSpec.Empty));
+            .collect(Collectors.toMap(Function.identity(), field -> FieldSpec.fromType(field.type)));
 
         return new RowSpec(profileFields, fieldToFieldSpec, Collections.emptyList());
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolver.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolver.java
@@ -77,7 +77,7 @@ public class RowSpecTreeSolver {
             .distinct()
             .collect(Collectors.toMap(
                 Function.identity(),
-                field -> FieldSpec.Empty));
+                field -> FieldSpec.fromType(field.type)));
     }
 
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
@@ -71,7 +71,7 @@ class PrunedConstraintState {
     Map<Field, FieldSpec> addPulledUpFieldsToMap(Map<Field, FieldSpec> previousFieldSpecs) {
         Map<Field, FieldSpec> mapWithPulledUpFields = new HashMap<>(previousFieldSpecs);
         for (AtomicConstraint c : pulledUpAtomicConstraints) {
-            mapWithPulledUpFields.putIfAbsent(c.getField(), FieldSpec.Empty);
+            mapWithPulledUpFields.putIfAbsent(c.getField(), FieldSpec.fromType(c.getField().type));
         }
         return mapWithPulledUpFields;
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/TreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/TreePruner.java
@@ -49,7 +49,7 @@ public class TreePruner {
      */
     public Merged<ConstraintNode> pruneConstraintNode(ConstraintNode constraintNode, Field field, DataBagValue value) {
         Map<Field, FieldSpec> fieldToSpec = new HashMap<>();
-        fieldToSpec.put(field, fieldSpecHelper.getFieldSpecForValue(value));
+        fieldToSpec.put(field, fieldSpecHelper.getFieldSpecForValue(field, value));
         return pruneConstraintNode(constraintNode, fieldToSpec);
     }
 
@@ -117,7 +117,7 @@ public class TreePruner {
         Map<Field, FieldSpec> newFieldSpecs = new HashMap<>();
         for (Map.Entry<Field, Collection<AtomicConstraint>> fieldToConstraints : relevantConstraints.entrySet()) {
 
-            Optional<FieldSpec> fieldSpec = constraintReducer.reduceConstraintsToFieldSpec(fieldToConstraints.getValue());
+            Optional<FieldSpec> fieldSpec = constraintReducer.reduceConstraintsToFieldSpec(fieldToConstraints.getKey(), fieldToConstraints.getValue());
             if (!fieldSpec.isPresent()){
                 return Merged.contradictory();
             }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
@@ -25,14 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.NUMERIC;
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.IsSame.sameInstance;
@@ -73,7 +69,7 @@ class DateTimeRestrictionsMergeOperationTests {
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(NullOnly));
+        Assert.assertEquals(result, FieldSpec.nullOnlyFromType(DATETIME));
     }
 
     @Test
@@ -84,7 +80,7 @@ class DateTimeRestrictionsMergeOperationTests {
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(NullOnly));
+        Assert.assertEquals(result, FieldSpec.nullOnlyFromType(DATETIME));
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.NUMERIC;
 import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
@@ -49,24 +50,24 @@ class DateTimeRestrictionsMergeOperationTests {
         merger = mock(DateTimeRestrictionsMerger.class);
         operation = new DateTimeRestrictionsMergeOperation(merger);
 
-        left = FieldSpec.Empty.withDateTimeRestrictions(new DateTimeRestrictions());
-        right = FieldSpec.Empty.withDateTimeRestrictions(new DateTimeRestrictions());
+        left = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(new DateTimeRestrictions());
+        right = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(new DateTimeRestrictions());
     }
 
     @Test
     public void applyMergeOperation_withNoDateTimeRestrictions_shouldNotApplyAnyRestrictions() {
-        FieldSpec merging = FieldSpec.Empty;
+        FieldSpec merging = FieldSpec.fromType(DATETIME);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(new MergeResult<>(null));
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(merging));
+        Assert.assertEquals(result, merging);
     }
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndNoTypeRestrictions_shouldPreventAnyDateTimeValues() {
-        FieldSpec merging = FieldSpec.Empty.withType((DATETIME));
+        FieldSpec merging = FieldSpec.fromType(DATETIME);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -77,8 +78,7 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictions_shouldPreventAnyDateTimeValues() {
-        FieldSpec merging = FieldSpec.Empty
-            .withType((DATETIME));
+        FieldSpec merging = FieldSpec.fromType(DATETIME);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -89,8 +89,7 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndDateTimeTypeAlreadyNotPermitted_shouldPreventAnyDateTimeValues() {
-        FieldSpec merging = FieldSpec.Empty
-            .withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -104,8 +103,7 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndDateTimeTypeOnlyPermittedType_shouldPreventAnyDateTimeValues() {
-        FieldSpec merging = FieldSpec.Empty
-            .withType((DATETIME));
+        FieldSpec merging = FieldSpec.fromType(DATETIME);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -118,8 +116,7 @@ class DateTimeRestrictionsMergeOperationTests {
     @Disabled("same instance check not working due to being casted")
     @Test
     public void applyMergeOperation_withMergableDateTimeRestrictions_shouldApplyMergedDateTimeRestrictions() {
-        FieldSpec merging = FieldSpec.Empty
-            .withType((DATETIME));
+        FieldSpec merging = FieldSpec.fromType(DATETIME);
         DateTimeRestrictions merged = new DateTimeRestrictions();
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(new MergeResult<>(merged));

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelperTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelperTests.java
@@ -18,7 +18,6 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.FieldBuilder;
-import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ class FieldSpecHelperTests {
 
         FieldSpec actual = fieldSpecHelper.getFieldSpecForValue(field, input);
 
-        FieldSpec expected = FieldSpec.NullOnly;
+        FieldSpec expected = FieldSpec.nullOnlyFromType(field.getType());
 
         assertEquals(actual, expected);
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelperTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecHelperTests.java
@@ -16,6 +16,9 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.FieldBuilder;
+import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import org.junit.jupiter.api.Test;
@@ -27,14 +30,15 @@ import static org.junit.Assert.assertEquals;
 class FieldSpecHelperTests {
 
     private FieldSpecHelper fieldSpecHelper = new FieldSpecHelper();
+    private Field field = FieldBuilder.createField("test");
 
     @Test
     void getFieldSpecForValue() {
         DataBagValue input = new DataBagValue("value");
 
-        FieldSpec actual = fieldSpecHelper.getFieldSpecForValue(input);
+        FieldSpec actual = fieldSpecHelper.getFieldSpecForValue(field, input);
 
-        FieldSpec expected = FieldSpec.Empty
+        FieldSpec expected = FieldSpec.fromType(field.getType())
             .withWhitelist((FrequencyDistributedSet.uniform(Collections.singleton("value"))))
             .withNotNull();
 
@@ -45,7 +49,7 @@ class FieldSpecHelperTests {
     void getFieldSpecForNullValue() {
         DataBagValue input = new DataBagValue(null);
 
-        FieldSpec actual = fieldSpecHelper.getFieldSpecForValue(input);
+        FieldSpec actual = fieldSpecHelper.getFieldSpecForValue(field, input);
 
         FieldSpec expected = FieldSpec.NullOnly;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -303,7 +303,7 @@ class FieldSpecTests {
     @Test
     public void fieldSpecsWithUnequalNullRestrictionsShouldBeUnequal() {
         FieldSpec a = FieldSpec.fromType(STRING).withNotNull();
-        FieldSpec b = FieldSpec.NullOnly;
+        FieldSpec b = FieldSpec.nullOnlyFromType(STRING);
 
         Assert.assertThat(a, not(equalTo(b)));
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -179,16 +179,6 @@ class FieldSpecTests {
     }
 
     @Test
-    public void shouldCreateNewInstanceWithTypeRestrictions() {
-        FieldSpec original = FieldSpec.fromType(STRING);
-        Types restrictions = STRING;
-        FieldSpec augmentedFieldSpec = original.withType(restrictions);
-
-        Assert.assertNotSame(original, augmentedFieldSpec);
-        Assert.assertSame(augmentedFieldSpec.getType(), restrictions);
-    }
-
-    @Test
     public void shouldCreateNewInstanceWithNullRestrictions() {
         FieldSpec original = FieldSpec.fromType(NUMERIC);
         FieldSpec augmentedFieldSpec = original.withNotNull();
@@ -276,8 +266,8 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithEqualTypeRestrictionsShouldBeEqual() {
-        FieldSpec a = FieldSpec.fromType(STRING).withType(STRING);
-        FieldSpec b = FieldSpec.fromType(STRING).withType(STRING);
+        FieldSpec a = FieldSpec.fromType(STRING);
+        FieldSpec b = FieldSpec.fromType(STRING);
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -285,8 +275,8 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithUnequalTypeRestrictionsShouldBeUnequal() {
-        FieldSpec a = FieldSpec.fromType(STRING).withType(STRING);
-        FieldSpec b = FieldSpec.fromType(DATETIME).withType(DATETIME);
+        FieldSpec a = FieldSpec.fromType(STRING);
+        FieldSpec b = FieldSpec.fromType(DATETIME);
 
         Assert.assertThat(a, not(equalTo(b)));
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -16,7 +16,6 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedSet;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.FrequencyDistributedSet;
@@ -30,8 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 
-import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
-import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.STRING;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
@@ -42,7 +40,7 @@ class FieldSpecTests {
 
     @Test
     void equals_objTypeIsNotFieldSpec_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty;
+        FieldSpec fieldSpec = FieldSpec.fromType(STRING);
 
         boolean result = fieldSpec.equals("Test");
 
@@ -54,10 +52,10 @@ class FieldSpecTests {
 
     @Test
     void equals_fieldSpecHasSetRestrictionsAndOtherObjectSetRestrictionsNull_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty
+        FieldSpec fieldSpec = FieldSpec.fromType(STRING)
             .withWhitelist((FrequencyDistributedSet.uniform(Collections.singleton("whitelist"))));
 
-        boolean result = fieldSpec.equals(FieldSpec.Empty);
+        boolean result = fieldSpec.equals(FieldSpec.fromType(STRING));
 
         assertFalse(
             "Expected that when the field spec has set restrictions and the other object set restrictions are null a false value should be returned but was true",
@@ -67,10 +65,10 @@ class FieldSpecTests {
 
     @Test
     void equals_fieldSpecSetRestrictionsNullAndOtherObjectHasSetRestrictions_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty;
+        FieldSpec fieldSpec = FieldSpec.fromType(STRING);
 
         boolean result = fieldSpec.equals(
-            FieldSpec.Empty.withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("whitelist")))
+            FieldSpec.fromType(STRING).withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("whitelist")))
         );
 
         assertFalse(
@@ -81,7 +79,7 @@ class FieldSpecTests {
 
     @Test
     void equals_fieldSpecSetRestrictionsNotNullAndOtherObjectSetRestrictionsNotNullAndSetRestrictionsAreNotEqual_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC)
             .withWhitelist(
                 (FrequencyDistributedSet.uniform(
                     new HashSet<>(
@@ -89,7 +87,7 @@ class FieldSpecTests {
                     ))));
 
         boolean result = fieldSpec.equals(
-            FieldSpec.Empty.withWhitelist(
+            FieldSpec.fromType(NUMERIC).withWhitelist(
                 (FrequencyDistributedSet.uniform(
                     new HashSet<>(
                         Arrays.asList(1, 2, 3, 4)
@@ -104,10 +102,10 @@ class FieldSpecTests {
 
     @Test
     void equals_fieldSpecNumericRestrictionsNotNullAndOtherObjectNumericRestrictionsNull_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions());
 
-        boolean result = fieldSpec.equals(FieldSpec.Empty);
+        boolean result = fieldSpec.equals(FieldSpec.fromType(NUMERIC));
 
         assertFalse(
             "Expected that when the field spec numeric restrictions is not null and the other object numeric restrictions are null a false value is returned but was true",
@@ -117,10 +115,10 @@ class FieldSpecTests {
 
     @Test
     void equals_fieldSpecNumericRestrictionsNullAndOtherObjectNumericRestrictionsNotNull_returnsFalse() {
-        FieldSpec fieldSpec = FieldSpec.Empty;
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC);
 
         boolean result = fieldSpec.equals(
-            FieldSpec.Empty.withNumericRestrictions(
+            FieldSpec.fromType(NUMERIC).withNumericRestrictions(
                 new NumericRestrictions())
         );
 
@@ -135,13 +133,13 @@ class FieldSpecTests {
         NumericRestrictions firstFieldSpecRestrictions = new NumericRestrictions();
         firstFieldSpecRestrictions.min = new NumericLimit<>(new BigDecimal(1), false);
         firstFieldSpecRestrictions.max = new NumericLimit<>(new BigDecimal(20), false);
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(firstFieldSpecRestrictions);
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(firstFieldSpecRestrictions);
 
         NumericRestrictions secondFieldSpecRestrictions = new NumericRestrictions();
         secondFieldSpecRestrictions.min = new NumericLimit<>(new BigDecimal(5), false);
         secondFieldSpecRestrictions.max = new NumericLimit<>(new BigDecimal(20), false);
         boolean result = fieldSpec.equals(
-            FieldSpec.Empty.withNumericRestrictions(secondFieldSpecRestrictions)
+            FieldSpec.fromType(NUMERIC).withNumericRestrictions(secondFieldSpecRestrictions)
         );
 
         assertFalse(
@@ -152,7 +150,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithSetRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(STRING);
         DistributedSet<Object> restrictions = FrequencyDistributedSet.uniform(Collections.singleton("whitelist"));
         FieldSpec augmentedFieldSpec = original.withWhitelist(restrictions);
 
@@ -162,7 +160,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithNumericRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(NUMERIC);
         NumericRestrictions restrictions = mock(NumericRestrictions.class);
         FieldSpec augmentedFieldSpec = original.withNumericRestrictions(restrictions);
 
@@ -172,7 +170,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithStringRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(STRING);
         StringRestrictions restrictions = mock(StringRestrictions.class);
         FieldSpec augmentedFieldSpec = original.withStringRestrictions(restrictions);
 
@@ -182,7 +180,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithTypeRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(STRING);
         Types restrictions = STRING;
         FieldSpec augmentedFieldSpec = original.withType(restrictions);
 
@@ -192,7 +190,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithNullRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(NUMERIC);
         FieldSpec augmentedFieldSpec = original.withNotNull();
 
         Assert.assertNotSame(original, augmentedFieldSpec);
@@ -200,7 +198,7 @@ class FieldSpecTests {
 
     @Test
     public void shouldCreateNewInstanceWithDateTimeRestrictions() {
-        FieldSpec original = FieldSpec.Empty;
+        FieldSpec original = FieldSpec.fromType(DATETIME);
         DateTimeRestrictions restrictions = mock(DateTimeRestrictions.class);
         FieldSpec augmentedFieldSpec = original.withDateTimeRestrictions(restrictions);
 
@@ -210,8 +208,8 @@ class FieldSpecTests {
 
     @Test
     public void emptyFieldSpecsShouldBeEqualAndHaveSameHashCode() {
-        FieldSpec first = FieldSpec.Empty;
-        FieldSpec second = FieldSpec.Empty;
+        FieldSpec first = FieldSpec.fromType(NUMERIC);
+        FieldSpec second = FieldSpec.fromType(NUMERIC);
 
         Assert.assertThat(first, equalTo(second));
         Assert.assertThat(first.hashCode(), equalTo(second.hashCode()));
@@ -219,8 +217,8 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithEqualSetRestrictionsShouldBeEqual() {
-        FieldSpec a = FieldSpec.Empty.withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("same")));
-        FieldSpec b = FieldSpec.Empty.withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("same")));
+        FieldSpec a = FieldSpec.fromType(STRING).withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("same")));
+        FieldSpec b = FieldSpec.fromType(STRING).withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("same")));
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -228,8 +226,8 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithUnequalSetRestrictionsShouldBeUnequal() {
-        FieldSpec a = FieldSpec.Empty.withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("not same")));
-        FieldSpec b = FieldSpec.Empty.withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("different")));
+        FieldSpec a = FieldSpec.fromType(STRING).withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("not same")));
+        FieldSpec b = FieldSpec.fromType(STRING).withWhitelist(FrequencyDistributedSet.uniform(Collections.singleton("different")));
 
         Assert.assertThat(a, not(equalTo(b)));
     }
@@ -238,8 +236,8 @@ class FieldSpecTests {
     public void fieldSpecsWithEqualNumericRestrictionsShouldBeEqual() {
         NumericRestrictions aRestrictions = new MockNumericRestrictions(true);
         NumericRestrictions bRestrictions = new MockNumericRestrictions(true);
-        FieldSpec a = FieldSpec.Empty.withNumericRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withNumericRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(NUMERIC).withNumericRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(NUMERIC).withNumericRestrictions(bRestrictions);
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -249,8 +247,8 @@ class FieldSpecTests {
     public void fieldSpecsWithUnequalNumericRestrictionsShouldBeUnequal() {
         NumericRestrictions aRestrictions = new MockNumericRestrictions(false);
         NumericRestrictions bRestrictions = new MockNumericRestrictions(false);
-        FieldSpec a = FieldSpec.Empty.withNumericRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withNumericRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(NUMERIC).withNumericRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(NUMERIC).withNumericRestrictions(bRestrictions);
 
         Assert.assertThat(a, not(equalTo(b)));
     }
@@ -259,8 +257,8 @@ class FieldSpecTests {
     public void fieldSpecsWithEqualStringRestrictionsShouldBeEqual() {
         StringRestrictions aRestrictions = new MockStringRestrictions(true);
         StringRestrictions bRestrictions = new MockStringRestrictions(true);
-        FieldSpec a = FieldSpec.Empty.withStringRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withStringRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(STRING).withStringRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(STRING).withStringRestrictions(bRestrictions);
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -270,16 +268,16 @@ class FieldSpecTests {
     public void fieldSpecsWithUnequalStringRestrictionsShouldBeUnequal() {
         StringRestrictions aRestrictions = new MockStringRestrictions(false);
         StringRestrictions bRestrictions = new MockStringRestrictions(false);
-        FieldSpec a = FieldSpec.Empty.withStringRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withStringRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(STRING).withStringRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(STRING).withStringRestrictions(bRestrictions);
 
         Assert.assertThat(a, not(equalTo(b)));
     }
 
     @Test
     public void fieldSpecsWithEqualTypeRestrictionsShouldBeEqual() {
-        FieldSpec a = FieldSpec.Empty.withType(STRING);
-        FieldSpec b = FieldSpec.Empty.withType(STRING);
+        FieldSpec a = FieldSpec.fromType(STRING).withType(STRING);
+        FieldSpec b = FieldSpec.fromType(STRING).withType(STRING);
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -287,16 +285,16 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithUnequalTypeRestrictionsShouldBeUnequal() {
-        FieldSpec a = FieldSpec.Empty.withType(STRING);
-        FieldSpec b = FieldSpec.Empty.withType(DATETIME);
+        FieldSpec a = FieldSpec.fromType(STRING).withType(STRING);
+        FieldSpec b = FieldSpec.fromType(DATETIME).withType(DATETIME);
 
         Assert.assertThat(a, not(equalTo(b)));
     }
 
     @Test
     public void fieldSpecsWithEqualNullRestrictionsShouldBeEqual() {
-        FieldSpec a = FieldSpec.Empty.withNotNull();
-        FieldSpec b = FieldSpec.Empty.withNotNull();
+        FieldSpec a = FieldSpec.fromType(STRING).withNotNull();
+        FieldSpec b = FieldSpec.fromType(STRING).withNotNull();
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -304,7 +302,7 @@ class FieldSpecTests {
 
     @Test
     public void fieldSpecsWithUnequalNullRestrictionsShouldBeUnequal() {
-        FieldSpec a = FieldSpec.Empty.withNotNull();
+        FieldSpec a = FieldSpec.fromType(STRING).withNotNull();
         FieldSpec b = FieldSpec.NullOnly;
 
         Assert.assertThat(a, not(equalTo(b)));
@@ -314,8 +312,8 @@ class FieldSpecTests {
     public void fieldSpecsWithEqualDateTimeRestrictionsShouldBeEqual() {
         DateTimeRestrictions aRestrictions = new MockDateTimeRestrictions(true);
         DateTimeRestrictions bRestrictions = new MockDateTimeRestrictions(true);
-        FieldSpec a = FieldSpec.Empty.withDateTimeRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withDateTimeRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(bRestrictions);
 
         Assert.assertThat(a, equalTo(b));
         Assert.assertThat(a.hashCode(), equalTo(b.hashCode()));
@@ -325,8 +323,8 @@ class FieldSpecTests {
     public void fieldSpecsWithUnequalDateTimeRestrictionsShouldBeUnequal() {
         DateTimeRestrictions aRestrictions = new MockDateTimeRestrictions(false);
         DateTimeRestrictions bRestrictions = new MockDateTimeRestrictions(false);
-        FieldSpec a = FieldSpec.Empty.withDateTimeRestrictions(aRestrictions);
-        FieldSpec b = FieldSpec.Empty.withDateTimeRestrictions(bRestrictions);
+        FieldSpec a = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(aRestrictions);
+        FieldSpec b = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(bRestrictions);
 
         Assert.assertThat(a, not(equalTo(b)));
     }
@@ -335,7 +333,7 @@ class FieldSpecTests {
     @Test
     void permitsRejectsInvalidNumeric() {
         NumericRestrictions numeric = new NumericRestrictions();
-        FieldSpec spec = FieldSpec.Empty.withNumericRestrictions(numeric);
+        FieldSpec spec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(numeric);
 
         numeric.min = new NumericLimit<>(BigDecimal.TEN, true);
 
@@ -345,7 +343,7 @@ class FieldSpecTests {
     @Test
     void permitsRejectsInvalidDateTime() {
         DateTimeRestrictions dateTime = new DateTimeRestrictions();
-        FieldSpec spec = FieldSpec.Empty.withDateTimeRestrictions(dateTime);
+        FieldSpec spec = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(dateTime);
 
         OffsetDateTime time = OffsetDateTime.of(100, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC);
         dateTime.max = new DateTimeLimit(time, true);
@@ -371,7 +369,7 @@ class FieldSpecTests {
                 return null;
             }
         };
-        FieldSpec spec = FieldSpec.Empty.withStringRestrictions(string);
+        FieldSpec spec = FieldSpec.fromType(STRING).withStringRestrictions(string);
 
         assertFalse(spec.permits("Anything"));
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
-import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
@@ -70,7 +69,7 @@ class NumericRestrictionsMergeOperationTests {
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(NullOnly));
+        Assert.assertEquals(result, FieldSpec.nullOnlyFromType(NUMERIC));
     }
 
     @Test
@@ -83,7 +82,7 @@ class NumericRestrictionsMergeOperationTests {
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(NullOnly));
+        Assert.assertEquals(result, FieldSpec.nullOnlyFromType(NUMERIC));
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -63,7 +63,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNoTypeRestrictions_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.fromType(NUMERIC).withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -74,8 +74,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictions_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.fromType(NUMERIC)
-            .withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
@@ -87,8 +86,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeAlreadyNotPermitted_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.fromType(NUMERIC)
-            .withType((IsOfTypeConstraint.Types.STRING));
+        FieldSpec merging = FieldSpec.fromType(STRING);
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
@@ -103,8 +101,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeOnlyPermittedType_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.fromType(NUMERIC)
-            .withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
@@ -118,8 +115,7 @@ class NumericRestrictionsMergeOperationTests {
     @Disabled("same instance check not working due to being casted")
     @Test
     public void applyMergeOperation_withMergableNumericRestrictions_shouldApplyMergedNumericRestrictions(){
-        FieldSpec merging = FieldSpec.fromType(NUMERIC)
-            .withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
         NumericRestrictions merged = new NumericRestrictions();
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(new MergeResult<>(merged));

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -25,12 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 import static com.scottlogic.deg.generator.fieldspecs.FieldSpec.NullOnly;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.IsSame.sameInstance;
@@ -47,26 +45,26 @@ class NumericRestrictionsMergeOperationTests {
     public void beforeEach(){
         merger = mock(NumericRestrictionsMerger.class);
         operation = new NumericRestrictionsMergeOperation(merger);
-        left = FieldSpec.Empty.withNumericRestrictions(
+        left = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions());
-        right = FieldSpec.Empty.withNumericRestrictions(
+        right = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions());
     }
 
     @Test
     public void applyMergeOperation_withNoNumericRestrictions_shouldNotApplyAnyRestriction(){
-        FieldSpec merging = FieldSpec.Empty;
+        FieldSpec merging = FieldSpec.fromType(NUMERIC);
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(new MergeResult<>(null));
 
         FieldSpec result = operation.applyMergeOperation(left, right, merging);
 
-        Assert.assertThat(result, sameInstance(merging));
+        Assert.assertEquals(result, merging);
     }
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNoTypeRestrictions_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.Empty.withType((IsOfTypeConstraint.Types.NUMERIC));
+        FieldSpec merging = FieldSpec.fromType(NUMERIC).withType((IsOfTypeConstraint.Types.NUMERIC));
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(MergeResult.unsuccessful());
 
@@ -77,7 +75,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictions_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.Empty
+        FieldSpec merging = FieldSpec.fromType(NUMERIC)
             .withType((IsOfTypeConstraint.Types.NUMERIC));
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
@@ -90,7 +88,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeAlreadyNotPermitted_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.Empty
+        FieldSpec merging = FieldSpec.fromType(NUMERIC)
             .withType((IsOfTypeConstraint.Types.STRING));
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
@@ -106,7 +104,7 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeOnlyPermittedType_shouldPreventAnyNumericValues(){
-        FieldSpec merging = FieldSpec.Empty
+        FieldSpec merging = FieldSpec.fromType(NUMERIC)
             .withType((IsOfTypeConstraint.Types.NUMERIC));
 
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
@@ -121,7 +119,7 @@ class NumericRestrictionsMergeOperationTests {
     @Disabled("same instance check not working due to being casted")
     @Test
     public void applyMergeOperation_withMergableNumericRestrictions_shouldApplyMergedNumericRestrictions(){
-        FieldSpec merging = FieldSpec.Empty
+        FieldSpec merging = FieldSpec.fromType(NUMERIC)
             .withType((IsOfTypeConstraint.Types.NUMERIC));
         NumericRestrictions merged = new NumericRestrictions();
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RowSpecMergerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RowSpecMergerTest.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.STRING;
 import static org.junit.jupiter.api.Assertions.*;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 
@@ -16,7 +18,7 @@ class RowSpecMergerTest {
     RowSpecMerger rowSpecMerger = new RowSpecMerger(new FieldSpecMerger());
 
     FieldSpec isNull = FieldSpec.NullOnly;
-    FieldSpec notNull = FieldSpec.Empty.withNotNull();
+    FieldSpec notNull = FieldSpec.fromType(STRING).withNotNull();
     Field A = createField("A");
     Field B = createField("B");
     ProfileFields fields = new ProfileFields(Arrays.asList(A, B));

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RowSpecMergerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RowSpecMergerTest.java
@@ -17,7 +17,7 @@ import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 class RowSpecMergerTest {
     RowSpecMerger rowSpecMerger = new RowSpecMerger(new FieldSpecMerger());
 
-    FieldSpec isNull = FieldSpec.NullOnly;
+    FieldSpec isNull = FieldSpec.nullOnlyFromType(STRING);
     FieldSpec notNull = FieldSpec.fromType(STRING).withNotNull();
     Field A = createField("A");
     Field B = createField("B");

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
@@ -28,6 +28,7 @@ import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 
 class AfterDateRelationTest {
 
@@ -66,13 +67,13 @@ class AfterDateRelationTest {
         inRestrictions.min = lower;
         inRestrictions.max = upper;
 
-        FieldSpec inSpec = FieldSpec.Empty.withDateTimeRestrictions(inRestrictions);
+        FieldSpec inSpec = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(inRestrictions);
 
         FieldSpec reducedSpec = relation.reduceToRelatedFieldSpec(inSpec);
 
         DateTimeRestrictions expectedRestrictions = new DateTimeRestrictions();
         expectedRestrictions.max = upper;
-        FieldSpec expectedSpec = FieldSpec.Empty.withDateTimeRestrictions(expectedRestrictions);
+        FieldSpec expectedSpec = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(expectedRestrictions);
 
         assertEquals(expectedSpec, reducedSpec);
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
@@ -25,6 +25,7 @@ package com.scottlogic.deg.generator.fieldspecs.relations;
     import java.time.OffsetDateTime;
     import java.time.ZoneOffset;
 
+    import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
     import static org.junit.jupiter.api.Assertions.*;
     import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
     
@@ -65,13 +66,13 @@ class BeforeDateRelationTest {
         inRestrictions.min = lower;
         inRestrictions.max = upper;
 
-        FieldSpec inSpec = FieldSpec.Empty.withDateTimeRestrictions(inRestrictions);
+        FieldSpec inSpec = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(inRestrictions);
 
         FieldSpec reducedSpec = relation.reduceToRelatedFieldSpec(inSpec);
 
         DateTimeRestrictions expectedRestrictions = new DateTimeRestrictions();
         expectedRestrictions.min = lower;
-        FieldSpec expectedSpec = FieldSpec.Empty.withDateTimeRestrictions(expectedRestrictions);
+        FieldSpec expectedSpec = FieldSpec.fromType(DATETIME).withDateTimeRestrictions(expectedRestrictions);
 
         assertEquals(expectedSpec, reducedSpec);
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetDateRelationTest.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.DATETIME;
 import static org.junit.jupiter.api.Assertions.*;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 
@@ -83,6 +84,6 @@ class EqualToOffsetDateRelationTest {
         DateTimeRestrictions restrictions = new DateTimeRestrictions();
         restrictions.min = limit;
         restrictions.max = limit;
-        return FieldSpec.Empty.withDateTimeRestrictions(restrictions);
+        return FieldSpec.fromType(DATETIME).withDateTimeRestrictions(restrictions);
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecValueGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecValueGeneratorTests.java
@@ -33,6 +33,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 import static com.scottlogic.deg.generator.config.detail.DataGenerationType.*;
 import static com.shazam.shazamcrest.MatcherAssert.assertThat;
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
@@ -43,7 +44,7 @@ class FieldSpecValueGeneratorTests {
 
     @Test
     void generate_fieldSpecMustContainRestrictionNullAndSetRestrictionsHasValues_returnsDataBagsWithValuesInSetRestrictions() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNotNull()
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNotNull()
             .withWhitelist(
                 (FrequencyDistributedSet.uniform(
                     new HashSet<>(
@@ -65,7 +66,7 @@ class FieldSpecValueGeneratorTests {
 
     @Test
     void generate_fieldSpecMustContainRestrictionNullAndNumericRestrictionApplied_returnsExpectedDataBagsForNumericRestriction() {
-        FieldSpec fieldSpec = FieldSpec.Empty
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC)
             .withNumericRestrictions(
                 new NumericRestrictions() {{
                     min = new NumericLimit<>(new BigDecimal(10), false);
@@ -124,7 +125,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateRandom_uniqueFieldSpec_returnsAllValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(STRING).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 RANDOM,
@@ -141,7 +142,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateRandom_notUniqueFieldSpec_returnsRandomValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 RANDOM,
@@ -158,7 +159,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateInteresting_uniqueFieldSpec_returnsAllValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(STRING).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 INTERESTING,
@@ -166,7 +167,7 @@ class FieldSpecValueGeneratorTests {
                 randomNumberGenerator
             );
 
-            fieldSpecFulfiller.generate(new Field(null, Types.STRING, true, null), fieldSpec).collect(Collectors.toSet());
+            fieldSpecFulfiller.generate(new Field(null, STRING, true, null), fieldSpec).collect(Collectors.toSet());
 
             verify(fieldValueSource, times(1)).generateAllValues();
             verify(fieldValueSource, times(0)).generateInterestingValues();
@@ -175,7 +176,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateInteresting_notUniqueFieldSpec_returnsInterestingValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(STRING).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 INTERESTING,
@@ -192,7 +193,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateSequential_uniqueFieldSpec_returnsAllValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(STRING).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 FULL_SEQUENTIAL,
@@ -209,7 +210,7 @@ class FieldSpecValueGeneratorTests {
 
         @Test
         void generateSequential_notUniqueFieldSpec_returnsAllValues() {
-            FieldSpec fieldSpec = FieldSpec.Empty.withNotNull();
+            FieldSpec fieldSpec = FieldSpec.fromType(STRING).withNotNull();
 
             FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
                 FULL_SEQUENTIAL,

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
@@ -39,7 +39,7 @@ public class StandardFieldValueSourceEvaluatorTests {
     @Test
     public void shouldReturnNullSourceOnlyWithMustBeNullRestrictions() {
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
-        FieldSpec fieldSpecMustBeNull = FieldSpec.NullOnly;
+        FieldSpec fieldSpecMustBeNull = FieldSpec.nullOnlyFromType(STRING);
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecMustBeNull);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
@@ -31,8 +31,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.NUMERIC;
-import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.STRING;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 public class StandardFieldValueSourceEvaluatorTests {
@@ -51,7 +50,7 @@ public class StandardFieldValueSourceEvaluatorTests {
     @Test
     public void returnsNullSourceOnlyWithSetRestrictionWithEmptyWhitelist() {
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
-        FieldSpec fieldSpecMustBeNull = FieldSpec.Empty
+        FieldSpec fieldSpecMustBeNull = FieldSpec.fromType(STRING)
             .withWhitelist((new FrequencyDistributedSet<>(Collections.emptySet())));
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecMustBeNull);
@@ -63,7 +62,7 @@ public class StandardFieldValueSourceEvaluatorTests {
     @Test
     public void shouldReturnNullSourceLastWithNoRestrictions() {
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
-        FieldSpec fieldSpecWithNoRestrictions = FieldSpec.Empty;
+        FieldSpec fieldSpecWithNoRestrictions = FieldSpec.fromType(STRING);
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecWithNoRestrictions);
 
@@ -73,7 +72,7 @@ public class StandardFieldValueSourceEvaluatorTests {
     @Test
     public void shouldReturnNullSourceLastWithInSetRestrictionsAndNullNotDisallowed() {
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
-        FieldSpec fieldSpecInSetAndNullNotDisallowed = FieldSpec.Empty
+        FieldSpec fieldSpecInSetAndNullNotDisallowed = FieldSpec.fromType(NUMERIC)
             .withWhitelist(FrequencyDistributedSet.uniform(new HashSet<>(Arrays.asList(15, 25))));
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecInSetAndNullNotDisallowed);
@@ -88,7 +87,7 @@ public class StandardFieldValueSourceEvaluatorTests {
             min = new NumericLimit<>(new BigDecimal(10), false);
             max = new NumericLimit<>(new BigDecimal(30), false);
         }};
-        FieldSpec fieldSpecWithTypedNumericRestrictionsAndNullNotDisallowed = FieldSpec.Empty
+        FieldSpec fieldSpecWithTypedNumericRestrictionsAndNullNotDisallowed = FieldSpec.fromType(NUMERIC)
             .withNumericRestrictions(numericRestrictions);
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecWithTypedNumericRestrictionsAndNullNotDisallowed);
@@ -100,7 +99,7 @@ public class StandardFieldValueSourceEvaluatorTests {
     public void shouldReturnNullSourceLastWithTypedStringRestrictionsAndNullNotDisallowed() {
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
         StringRestrictions stringRestrictions = matchesRegex("/[ab]{2}/", false);
-        FieldSpec fieldSpecInSetWithTypedStringRestrictionsAndNullNotDisallowedd = FieldSpec.Empty
+        FieldSpec fieldSpecInSetWithTypedStringRestrictionsAndNullNotDisallowedd = FieldSpec.fromType(NUMERIC)
             .withStringRestrictions(stringRestrictions);
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecInSetWithTypedStringRestrictionsAndNullNotDisallowedd);
@@ -115,7 +114,7 @@ public class StandardFieldValueSourceEvaluatorTests {
             min = new DateTimeLimit(OffsetDateTime.MIN, false);
             max = new DateTimeLimit(OffsetDateTime.MAX, false);
         }};
-        FieldSpec fieldSpecInSetWithTypedDateTimeRestrictionsAndNullNotDisallowed = FieldSpec.Empty
+        FieldSpec fieldSpecInSetWithTypedDateTimeRestrictionsAndNullNotDisallowed = FieldSpec.fromType(DATETIME)
             .withDateTimeRestrictions(datetimeRestrictions);
 
         List<FieldValueSource> sources = evaluator.getFieldValueSources(fieldSpecInSetWithTypedDateTimeRestrictionsAndNullNotDisallowed);
@@ -125,7 +124,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNumericRestrictionsWithValueTooLargeForInteger_generatesExpectedValues() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions() {{
                 min = new NumericLimit<>(new BigDecimal(0), false);
                 max = new NumericLimit<>(new BigDecimal("1E+18"), false);
@@ -155,7 +154,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNumericRestrictionsWithDecimalValues_generatesDecimalValues() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions() {{
                 min = new NumericLimit<>(new BigDecimal("15.00000000000000000001"), false);
                 max = new NumericLimit<>(new BigDecimal("15.00000000000000000010"), false);
@@ -190,7 +189,7 @@ public class StandardFieldValueSourceEvaluatorTests {
         NumericRestrictions restrictions = new NumericRestrictions(2);
         restrictions.min = new NumericLimit<>(new BigDecimal("15"), false);
         restrictions.max = new NumericLimit<>(new BigDecimal("16"), false);
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             restrictions
         ).withNotNull();
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
@@ -215,7 +214,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNumericRestrictionsWithMinAndMaxNull_generatesBoundaryValues() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions()
         ).withNotNull();
         StandardFieldValueSourceEvaluator evaluator = new StandardFieldValueSourceEvaluator();
@@ -241,7 +240,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNumericRestrictionWithNullMinAndMaxIsDecimal_generatesDecimalValues() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions() {{
                 max = new NumericLimit<>(new BigDecimal("150.5"), false);
             }}
@@ -263,7 +262,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNumericRestrictionWithHighGranularity_generates20DecimalGranularity() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions() {{
                 min = new NumericLimit<>(new BigDecimal("1.1E-30"), false);
                 max = new NumericLimit<>(new BigDecimal("1.5E-20"), false);
@@ -286,7 +285,7 @@ public class StandardFieldValueSourceEvaluatorTests {
 
     @Test
     void getFieldValueSources_fieldSpecContainsNegativeMinAndPositiveMax_generatesExpectedNegativeToPositiveValues() {
-        FieldSpec fieldSpec = FieldSpec.Empty.withNumericRestrictions(
+        FieldSpec fieldSpec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(
             new NumericRestrictions() {{
                 min = new NumericLimit<>(new BigDecimal("-3E-20"), false);
                 max = new NumericLimit<>(new BigDecimal("3E-20"), false);

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
@@ -61,7 +61,7 @@ class UpfrontTreePrunerTests {
             List<Field> fields = Collections.singletonList(fieldA);
             ConstraintNode prunedRoot = Mockito.mock(ConstraintNode.class);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
@@ -85,8 +85,8 @@ class UpfrontTreePrunerTests {
             List<Field> fields = Arrays.asList(fieldA, fieldB);
             ConstraintNode prunedRoot = Mockito.mock(ConstraintNode.class);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
-            fieldSpecs.put(fieldB, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
+            fieldSpecs.put(fieldB, FieldSpec.fromType(fieldB.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
@@ -110,7 +110,7 @@ class UpfrontTreePrunerTests {
             //Arrange
             List<Field> fields = Collections.singletonList(fieldA);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
@@ -129,7 +129,7 @@ class UpfrontTreePrunerTests {
             //Arrange
             List<Field> fields = Collections.singletonList(fieldA);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
@@ -152,7 +152,7 @@ class UpfrontTreePrunerTests {
             //Arrange
             List<Field> fields = Collections.singletonList(fieldA);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
@@ -180,7 +180,7 @@ class UpfrontTreePrunerTests {
             //Arrange
             List<Field> fields = Collections.singletonList(fieldA);
             Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
-            fieldSpecs.put(fieldA, FieldSpec.Empty);
+            fieldSpecs.put(fieldA, FieldSpec.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
             DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/grouped/FieldSpecGroupValueGeneratorTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/grouped/FieldSpecGroupValueGeneratorTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.STRING;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -27,9 +28,9 @@ class FieldSpecGroupValueGeneratorTest {
     @Test
     public void generate_withGroupOfSingleField_returnsCorrectStream() {
         Map<Field, FieldSpec> specMap = new HashMap<>();
-        FieldSpec firstSpec = FieldSpec.Empty;
+        FieldSpec firstSpec = FieldSpec.fromType(STRING);
         Field firstField = createField("first");
-        specMap.put(firstField, FieldSpec.Empty);
+        specMap.put(firstField, FieldSpec.fromType(STRING));
 
         FieldSpecValueGenerator underlyingGenerator = mock(FieldSpecValueGenerator.class);
         String result = "result";

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/grouped/RowSpecGrouperTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/grouped/RowSpecGrouperTest.java
@@ -183,6 +183,6 @@ class RowSpecGrouperTest {
     }
 
     private static Map<Field, FieldSpec> fieldSpecMapOf(Field... fields) {
-        return Arrays.stream(fields).collect(Collectors.toMap(Function.identity(), x -> FieldSpec.Empty));
+        return Arrays.stream(fields).collect(Collectors.toMap(Function.identity(), x -> FieldSpec.fromType(x.getType())));
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
@@ -60,7 +60,7 @@ class ConstraintReducerTest {
     @Test
     void shouldProduceCorrectFieldSpecsForExample() {
         // ARRANGE
-        final Field quantityField = createField("quantity");
+        final Field quantityField = createField("quantity", NUMERIC);
         final Field countryField = createField("country");
         final Field cityField = createField("city");
 
@@ -138,7 +138,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceIsGreaterThanConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsGreaterThanConstantConstraint(field, 5));
@@ -172,7 +172,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceNegatedIsGreaterThanConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsGreaterThanConstantConstraint(field, 5).negate());
@@ -207,7 +207,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceIsGreaterThanOrEqualToConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsGreaterThanOrEqualToConstantConstraint(field, 5));
@@ -241,7 +241,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceNegatedIsGreaterThanOrEqualToConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsGreaterThanOrEqualToConstantConstraint(field, 5).negate());
@@ -276,7 +276,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceIsLessThanConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsLessThanConstantConstraint(field, 5));
@@ -311,7 +311,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceNegatedIsLessThanConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsLessThanConstantConstraint(field, 5).negate());
@@ -345,7 +345,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceIsLessThanOrEqualToConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsLessThanOrEqualToConstantConstraint(field, 5));
@@ -380,7 +380,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldReduceNegatedIsLessThanOrEqualToConstantConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
             new IsLessThanOrEqualToConstantConstraint(field, 5).negate());
@@ -414,7 +414,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceIsAfterConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -449,7 +449,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceNegatedIsAfterConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16,0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -484,7 +484,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceIsAfterOrEqualToConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -519,7 +519,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceNegatedIsAfterOrEqualToConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -555,7 +555,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceIsBeforeConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -591,7 +591,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceNegatedIsBeforeConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -626,7 +626,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceIsBeforeOrEqualToConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -662,7 +662,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldreduceNegatedIsBeforeorEqualToConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
         List<AtomicConstraint> constraints = Collections.singletonList(
@@ -697,7 +697,7 @@ class ConstraintReducerTest {
 
     @Test
     void shouldMergeAndReduceIsAfterConstantDateTimeConstraintWithIsBeforeConstantDateTimeConstraint() {
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         final OffsetDateTime startTimestamp = OffsetDateTime.of(2013, 11, 19, 10, 43, 12, 0, ZoneOffset.UTC);
         final OffsetDateTime endTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 8, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
@@ -853,7 +853,7 @@ class ConstraintReducerTest {
     @Test
     void whenHasNumericRestrictions_shouldFilterSet() {
 
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
 
         List<AtomicConstraint> constraints = Arrays.asList(
@@ -894,7 +894,7 @@ class ConstraintReducerTest {
     @Test
     void whenHasNumericRestrictions_shouldOnlyFilterNumericValuesInSet() {
 
-        final Field field = createField("test0");
+        final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
 
         OffsetDateTime datetimeValue = OffsetDateTime.of(2001, 02, 03, 04, 05, 06, 0, ZoneOffset.UTC);
@@ -915,7 +915,7 @@ class ConstraintReducerTest {
     @Test
     void whenHasDateTimeRestrictions_shouldOnlyFilterDateTimeValuesInSet() {
 
-        final Field field = createField("test0");
+        final Field field = createField("test0", DATETIME);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
 
         OffsetDateTime datetimeValue = OffsetDateTime.of(2001, 02, 03, 04, 05, 06, 0, ZoneOffset.UTC);

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/FieldSpecFactoryTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/FieldSpecFactoryTests.java
@@ -16,8 +16,8 @@
 
 package com.scottlogic.deg.generator.restrictions;
 
-import com.scottlogic.deg.common.profile.constraints.atomic.*;
 import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.constraints.atomic.*;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import org.junit.jupiter.api.Test;
@@ -28,17 +28,18 @@ import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 class FieldSpecFactoryTests {
     private static final StringRestrictionsFactory stringRestrictionsFactory = new StringRestrictionsFactory();
     private FieldSpecFactory fieldSpecFactory = new FieldSpecFactory(stringRestrictionsFactory);
+    private Field testField = createField("Test");
 
 
     @Test
     void construct_stringHasLengthConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
         StringHasLengthConstraint constraint = new StringHasLengthConstraint(
-            createField("Test"),
+            testField,
             10
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -47,13 +48,13 @@ class FieldSpecFactoryTests {
     void construct_stringHasLengthConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
         ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
             new StringHasLengthConstraint(
-                createField("Test"),
+                testField,
                 10
             )
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -61,16 +62,16 @@ class FieldSpecFactoryTests {
     @Test
     void construct_twoInstancesOfStringHasLengthConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
         StringHasLengthConstraint firstConstraint = new StringHasLengthConstraint(
-            createField("Test"),
+            testField,
             20
         );
         StringHasLengthConstraint secondConstraint = new StringHasLengthConstraint(
-            createField("Test"),
+            testField,
             20
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, secondConstraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -78,12 +79,12 @@ class FieldSpecFactoryTests {
     @Test
     void construct_isStringLongerThanConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
         IsStringLongerThanConstraint constraint = new IsStringLongerThanConstraint(
-            createField("Test"),
+            testField,
             15
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -92,13 +93,13 @@ class FieldSpecFactoryTests {
     void construct_isStringLongerThanConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
         ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
             new IsStringLongerThanConstraint(
-                createField("Test"),
+                testField,
                 10
             )
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -106,16 +107,16 @@ class FieldSpecFactoryTests {
     @Test
     void construct_twoInstancesOfIsStringLongerThanConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
         IsStringLongerThanConstraint firstConstraint = new IsStringLongerThanConstraint(
-            createField("Test"),
+            testField,
             20
         );
         IsStringLongerThanConstraint secondConstraint = new IsStringLongerThanConstraint(
-            createField("Test"),
+            testField,
             20
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, secondConstraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -123,12 +124,12 @@ class FieldSpecFactoryTests {
     @Test
     void construct_isStringShorterThanConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
         IsStringShorterThanConstraint constraint = new IsStringShorterThanConstraint(
-            createField("Test"),
+            testField,
             25
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -137,13 +138,13 @@ class FieldSpecFactoryTests {
     void construct_isStringShorterThanConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
         ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
             new IsStringShorterThanConstraint(
-                createField("Test"),
+                testField,
                 10
             )
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, constraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }
@@ -151,16 +152,16 @@ class FieldSpecFactoryTests {
     @Test
     void construct_twoInstancesOfIsStringShorterThanConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
         IsStringShorterThanConstraint firstConstraint = new IsStringShorterThanConstraint(
-            createField("Test"),
+            testField,
             20
         );
         IsStringShorterThanConstraint secondConstraint = new IsStringShorterThanConstraint(
-            createField("Test"),
+            testField,
             20
         );
 
-        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
-        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+        final FieldSpec firstInstance = fieldSpecFactory.construct(testField, firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(testField, secondConstraint);
 
         assertEquals(firstInstance.getStringRestrictions(), secondInstance.getStringRestrictions());
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolverTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolverTests.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
+import static com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint.Types.*;
 
 class RowSpecTreeSolverTests {
     private Field fieldA = createField("A");
@@ -56,8 +57,8 @@ class RowSpecTreeSolverTests {
         //Assert
         List<RowSpec> expectedRowSpecs = new ArrayList<>();
         Map<Field, FieldSpec> fieldToFieldSpec = new HashMap<>();
-        fieldToFieldSpec.put(fieldA, FieldSpec.Empty);
-        fieldToFieldSpec.put(fieldB, FieldSpec.Empty);
+        fieldToFieldSpec.put(fieldA, FieldSpec.fromType(fieldA.getType()));
+        fieldToFieldSpec.put(fieldB, FieldSpec.fromType(fieldB.getType()));
         expectedRowSpecs.add(new RowSpec(profileFields, fieldToFieldSpec, Collections.emptyList()));
 
         assertThat(expectedRowSpecs, sameBeanAs(rowSpecs.collect(Collectors.toList())));
@@ -76,8 +77,8 @@ class RowSpecTreeSolverTests {
         List<RowSpec> expectedRowSpecs = new ArrayList<>();
         Map<Field, FieldSpec> fieldToFieldSpec = new HashMap<>();
         DistributedSet<Object> whitelist = new NullDistributedSet<>();
-        fieldToFieldSpec.put(fieldA, FieldSpec.Empty.withWhitelist(whitelist));
-        fieldToFieldSpec.put(fieldB, FieldSpec.Empty);
+        fieldToFieldSpec.put(fieldA, FieldSpec.fromType(fieldA.getType()).withWhitelist(whitelist));
+        fieldToFieldSpec.put(fieldB, FieldSpec.fromType(fieldB.getType()));
         expectedRowSpecs.add(new RowSpec(profileFields, fieldToFieldSpec, Collections.emptyList()));
 
         assertThat(expectedRowSpecs, sameBeanAs(rowSpecs.collect(Collectors.toList())));
@@ -96,20 +97,20 @@ class RowSpecTreeSolverTests {
         DecisionTree tree = new DecisionTree(root, profileFields);
 
         //Act
-        Stream<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree);
+        List<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toList());
 
         //Assert
         List<RowSpec> expectedRowSpecs = new ArrayList<>();
         Map<Field, FieldSpec> option0 = new HashMap<>();
         DistributedSet<Object> whitelist = new NullDistributedSet<>();
-        option0.put(fieldA, FieldSpec.Empty);
-        option0.put(fieldB, FieldSpec.Empty.withWhitelist(whitelist));
+        option0.put(fieldA, FieldSpec.fromType(fieldA.getType()));
+        option0.put(fieldB, FieldSpec.fromType(fieldB.getType()).withWhitelist(whitelist));
         expectedRowSpecs.add(new RowSpec(profileFields, option0, Collections.emptyList()));
         Map<Field, FieldSpec> option1 = new HashMap<>();
-        option1.put(fieldA, FieldSpec.Empty);
-        option1.put(fieldB, FieldSpec.NullOnly);
+        option1.put(fieldA, FieldSpec.fromType(fieldA.getType()));
+        option1.put(fieldB, FieldSpec.nullOnlyFromType(fieldB.getType()));
         expectedRowSpecs.add(new RowSpec(profileFields, option1, Collections.emptyList()));
 
-        assertThat(expectedRowSpecs, sameBeanAs(rowSpecs.collect(Collectors.toList())));
+        assertThat(expectedRowSpecs, sameBeanAs(rowSpecs));
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/pruner/TreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/pruner/TreePrunerTests.java
@@ -41,9 +41,9 @@ import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 
 class TreePrunerTests {
 
-    private static final FieldSpec notNull = FieldSpec.Empty
-        .withNotNull();
     private Field field = createField("foo");
+    private final FieldSpec notNull = FieldSpec.fromType(field.getType())
+        .withNotNull();
     private Field unrelatedField = createField("unrelated");
     private FieldSpecHelper fieldSpecHelper = mock(FieldSpecHelper.class);
     private TreePruner treePruner = new TreePruner(
@@ -67,7 +67,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         Merged<ConstraintNode> actual = treePruner.pruneConstraintNode(tree, field, fieldValue());
@@ -83,10 +83,10 @@ class TreePrunerTests {
         //Arrange
         Set<Object> inputWhitelist = new HashSet<>(Arrays.asList(1, 2));
         ConstraintNode tree = new ConstraintNodeBuilder().addAtomicConstraints(new IsLessThanConstantConstraint(field, 5)).build();
-        FieldSpec inputFieldSpec = FieldSpec.Empty.withWhitelist(
+        FieldSpec inputFieldSpec = FieldSpec.fromType(field.getType()).withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -110,7 +110,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         Merged<ConstraintNode> actual = treePruner.pruneConstraintNode(tree, field, fieldValue());
@@ -133,7 +133,7 @@ class TreePrunerTests {
         DistributedSet<Object> inputWhitelist = FrequencyDistributedSet.uniform(new HashSet<>(Arrays.asList("a", "b")));
         FieldSpec inputFieldSpec = notNull.withWhitelist((inputWhitelist));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -157,7 +157,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -184,7 +184,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -212,7 +212,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -244,7 +244,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         Merged<ConstraintNode> actual = treePruner.pruneConstraintNode(tree, field, fieldValue());
@@ -274,7 +274,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -305,7 +305,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -338,7 +338,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();
@@ -372,7 +372,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         Merged<ConstraintNode> actual = treePruner.pruneConstraintNode(tree, field, fieldValue());
@@ -400,7 +400,7 @@ class TreePrunerTests {
         FieldSpec inputFieldSpec = notNull.withWhitelist(
             (FrequencyDistributedSet.uniform(inputWhitelist)));
 
-        when(fieldSpecHelper.getFieldSpecForValue(any())).thenReturn(inputFieldSpec);
+        when(fieldSpecHelper.getFieldSpecForValue(any(), any())).thenReturn(inputFieldSpec);
 
         //Act
         ConstraintNode actual = treePruner.pruneConstraintNode(tree, field, fieldValue()).get();


### PR DESCRIPTION
### Description
Updated the FieldSpec class so the objects that are created are always typed. If the types do not match then the type will be set to Null. Removed the withType function from FieldSpec as they are always typed now.

### Issue
Related to #1333
