### PR TITLE
chore(#1198): throw exceptions properly in cucumber tests

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo.feature
@@ -151,19 +151,6 @@ Feature: User can specify that a value is equalTo a required value
       | "datetime" | 2000-01-01T00:00:00.001Z |
       | "decimal"  | 1.1                      |
 
-
-  Scenario Outline: 'EqualTo' should contradict with incorrect type <type>
-    Given there is a field foo
-    And foo is equal to <value>
-    And foo has type <type>
-    Then no data is created
-    Examples:
-      | type | value |
-      | "integer"  | 1.1   |
-      | "string"   | 1.1   |
-      | "datetime" | 1.1   |
-      | "decimal"  | "1.1" |
-
 ### constraints ###
 
   Scenario Outline: 'EqualTo' alongside a non-contradicting <operator> should be successful

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
@@ -77,11 +77,12 @@ Feature: User can specify that data must be created to conform to each of multip
 
   Scenario: User attempts to combine two constraints that only intersect at the empty set within an allOf operator should not generate data
     Given there is a field foo
+    And foo has type "string"
     And there is a constraint:
       """
       { "allOf": [
         { "field": "foo", "is": "equalTo", "value": "Test0" },
-        { "field": "foo", "is": "equalTo", "value": 5 }
+        { "field": "foo", "is": "equalTo", "value": "5" }
       ]}
       """
     Then no data is created

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ShorterThan.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ShorterThan.feature
@@ -85,6 +85,7 @@ Feature: User can specify that a string length is lower than, a specified number
       | foo  |
       | null |
 
+    @ignore #1361 shorter than 1001 not accepted
   Scenario: shorterThan with maximum permitted value should be successful
     Given foo is shorter than 1001
     And the generation strategy is random

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
@@ -122,6 +122,7 @@ public class GeneralTestStep {
 
     @But("^the profile is invalid because \"(.+)\"$")
     public void profileIsInvalidWithError(String expectedError) {
+        state.expectExceptions = true;
         cucumberTestHelper.generateAndGetData();
 
         List<String> errors = this.cucumberTestHelper

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestHelper.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestHelper.java
@@ -29,6 +29,7 @@ import com.scottlogic.deg.orchestrator.violate.ViolateModule;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -48,6 +49,19 @@ public class CucumberTestHelper {
     }
 
     public void runGenerationProcess() {
+        if (testState.expectExceptions){
+            generateAndExpectExceptions();
+        }
+        else {
+            try {
+                doGeneration();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private void generateAndExpectExceptions() {
         try {
             doGeneration();
         } catch (IOException e) {

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
@@ -42,6 +42,7 @@ public class CucumberTestState {
      * If true, generation is in violate mode.
      */
     public Boolean shouldViolate;
+    public boolean expectExceptions;
 
     /** If true, we inject a no-op generation engine during the test (e.g. because we're just testing profile validation) */
     private Boolean shouldSkipGeneration;


### PR DESCRIPTION
### Description
if not expecting exceptions in cucumber tests, don't catch the exceptions

### Additional notes
Some tests duplicate, so deleted, one test ignored and issue raised, one test fixed

### Issue
Resolves #1198 
