### PR TITLE
1359 Refactor blacklist filtering in RealNumberFieldValueSource

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -32,10 +32,7 @@ import java.util.Collections;
 import java.util.regex.Pattern;
 
 import static com.scottlogic.deg.common.profile.constraints.atomic.StandardConstraintTypes.RIC;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.*;
 
 public class FieldSpecFactory {
     private final StringRestrictionsFactory stringRestrictionsFactory;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluator.java
@@ -37,11 +37,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
 import static com.scottlogic.deg.common.profile.Types.*;
+import static com.scottlogic.deg.generator.utils.Defaults.*;
 
 public class StandardFieldValueSourceEvaluator implements FieldValueSourceEvaluator {
     private static final FieldValueSource NULL_ONLY_SOURCE = new NullOnlySource();

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
@@ -16,17 +16,17 @@
 
 package com.scottlogic.deg.generator.generation.fieldvaluesources;
 
-import com.scottlogic.deg.common.util.NumberUtils;
 import com.scottlogic.deg.common.util.Defaults;
-import com.scottlogic.deg.generator.restrictions.linear.Granularity;
+import com.scottlogic.deg.common.util.NumberUtils;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
-import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
-import com.scottlogic.deg.generator.utils.*;
+import com.scottlogic.deg.generator.utils.RandomNumberGenerator;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -99,14 +99,14 @@ public class RealNumberFieldValueSource implements FieldValueSource {
 
         return list.stream()
             .distinct()
-            .filter(i -> !blacklist.contains(i))
+            .filter(this::notInBlacklist)
             .map(Function.identity());
     }
 
     @Override
     public Stream<Object> generateAllValues() {
         return stream(new LinearIterator<>(restrictions))
-            .filter(i -> !blacklist.contains(i))
+            .filter(this::notInBlacklist)
             .map(Function.identity());
     }
 
@@ -117,8 +117,13 @@ public class RealNumberFieldValueSource implements FieldValueSource {
                 inclusiveLowerLimit,
                 inclusiveUpperLimit))
             .map(val -> restrictions.getGranularity().trimToGranularity(val))
-            .filter(i -> !blacklist.contains(i))
+            .filter(this::notInBlacklist)
             .map(Function.identity());
+    }
+
+
+    private boolean notInBlacklist(BigDecimal i) {
+        return blacklist.stream().noneMatch(x->x.compareTo(i)==0);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/NumericGranularity.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/NumericGranularity.java
@@ -49,10 +49,6 @@ public class NumericGranularity implements Granularity<BigDecimal> {
         return value.setScale(decimalPlaces, RoundingMode.DOWN);
     }
 
-    public int getDecimalPlaces() {
-        return decimalPlaces;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/NumericRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/NumericRestrictions.java
@@ -23,9 +23,7 @@ import static com.scottlogic.deg.common.util.Defaults.*;
 
 public class NumericRestrictions extends LinearRestrictions<BigDecimal> {
 
-    public static final Limit<BigDecimal> NUMERIC_MIN_LIMIT = new Limit<>(NUMERIC_MIN, true);
-    public static final Limit<BigDecimal> NUMERIC_MAX_LIMIT = new Limit<>(NUMERIC_MAX, true);
-    public static final NumericConverter CONVERTER = new NumericConverter();
+    private static final NumericConverter CONVERTER = new NumericConverter();
 
     public NumericRestrictions(Limit<BigDecimal> min, Limit<BigDecimal> max){
         this(min, max, DEFAULT_NUMERIC_SCALE);

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -18,25 +18,25 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedSet;
 import com.scottlogic.deg.generator.generation.string.generators.StringGenerator;
-import com.scottlogic.deg.generator.restrictions.*;
+import com.scottlogic.deg.generator.restrictions.MergeResult;
+import com.scottlogic.deg.generator.restrictions.StringRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.DateTimeRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
-import com.scottlogic.deg.generator.utils.SetUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
 import static com.scottlogic.deg.common.profile.Types.*;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
@@ -298,7 +298,7 @@ class FieldSpecTests {
 
     @Test
     void permitsRejectsInvalidNumeric() {
-        NumericRestrictions numeric = new NumericRestrictions(new Limit<>(BigDecimal.TEN, true), NumericRestrictions.NUMERIC_MAX_LIMIT);
+        NumericRestrictions numeric = new NumericRestrictions(new Limit<>(BigDecimal.TEN, true), NUMERIC_MAX_LIMIT);
         FieldSpec spec = FieldSpec.fromType(NUMERIC).withNumericRestrictions(numeric);
 
         assertFalse(spec.permits(BigDecimal.ONE));

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -16,22 +16,19 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.common.profile.Types;
 import com.scottlogic.deg.generator.restrictions.MergeResult;
-import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
-import static com.scottlogic.deg.common.profile.Types.*;
+import static com.scottlogic.deg.common.profile.Types.NUMERIC;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluatorTests.java
@@ -35,8 +35,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import static com.scottlogic.deg.common.profile.Types.*;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 public class StandardFieldValueSourceEvaluatorTests {

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
@@ -17,17 +17,15 @@
 package com.scottlogic.deg.generator.generation.fieldvaluesources;
 
 import com.scottlogic.deg.common.util.Defaults;
-import com.scottlogic.deg.generator.fieldspecs.NumericRestrictionsMergeOperation;
+import com.scottlogic.deg.common.util.NumberUtils;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
-import com.scottlogic.deg.common.util.NumberUtils;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -38,8 +36,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.*;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
@@ -185,7 +185,6 @@ class RealNumberFieldValueSourceTests {
     }
 
     @Test
-    @Disabled("This should be looked at but appears to not be an issue when using a similar setup with a profile")
     void shouldSupplyInterestingNonBlacklistedValues() {
         givenLowerBound(-10, true);
         givenUpperBound(10, true);

--- a/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
@@ -43,9 +43,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
 import static com.scottlogic.deg.common.profile.Types.*;
+import static com.scottlogic.deg.generator.utils.Defaults.*;
 import static org.hamcrest.Matchers.*;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 
@@ -163,9 +162,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no upper bound", outputSpec.getNumericRestrictions().getMax(),
-            Is.is(equalTo(NumericRestrictions.NUMERIC_MAX_LIMIT)));
+            Is.is(equalTo(NUMERIC_MAX_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions have lower bound", outputSpec.getNumericRestrictions().getMin(),
-            Is.is(not(equalTo(NumericRestrictions.NUMERIC_MIN_LIMIT))));
+            Is.is(not(equalTo(NUMERIC_MIN_LIMIT))));
         Assert.assertThat("Fieldspec numeric restriction lower bound is correct",
             outputSpec.getNumericRestrictions().getMin().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is exclusive",
@@ -198,9 +197,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(equalTo(NumericRestrictions.NUMERIC_MIN_LIMIT)));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(equalTo(NUMERIC_MIN_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions have upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(not(equalTo(NumericRestrictions.NUMERIC_MAX_LIMIT))));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(not(equalTo(NUMERIC_MAX_LIMIT))));
         Assert.assertThat("Fieldspec numeric restrictions upper bound limit is correct",
             outputSpec.getNumericRestrictions().getMax().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric resitrctions upper bound is inclusive",
@@ -232,9 +231,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no upper bound", outputSpec.getNumericRestrictions().getMax(),
-            Is.is(NumericRestrictions.NUMERIC_MAX_LIMIT));
+            Is.is(NUMERIC_MAX_LIMIT));
         Assert.assertThat("Fieldspec numeric restrictions have lower bound", outputSpec.getNumericRestrictions().getMin(),
-            Is.is(not(NumericRestrictions.NUMERIC_MIN_LIMIT)));
+            Is.is(not(NUMERIC_MIN_LIMIT)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is correct",
             outputSpec.getNumericRestrictions().getMin().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is inclusive",
@@ -267,9 +266,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(NumericRestrictions.NUMERIC_MIN_LIMIT));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(NUMERIC_MIN_LIMIT));
         Assert.assertThat("Fieldspec numeric restrictions have upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NumericRestrictions.NUMERIC_MAX_LIMIT)));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NUMERIC_MAX_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound limit is correct",
             outputSpec.getNumericRestrictions().getMax().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound is exclusive",
@@ -302,9 +301,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(NumericRestrictions.NUMERIC_MIN_LIMIT));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(NUMERIC_MIN_LIMIT));
         Assert.assertThat("Fieldspec numeric restrictions have upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NumericRestrictions.NUMERIC_MAX_LIMIT)));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NUMERIC_MAX_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound limit is correct",
             outputSpec.getNumericRestrictions().getMax().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound is exclusive",
@@ -336,9 +335,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(NumericRestrictions.NUMERIC_MAX_LIMIT));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(NUMERIC_MAX_LIMIT));
         Assert.assertThat("Fieldspec numeric restrictions have lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(not(NumericRestrictions.NUMERIC_MIN_LIMIT)));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(not(NUMERIC_MIN_LIMIT)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is correct",
             outputSpec.getNumericRestrictions().getMin().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is inclusive",
@@ -371,9 +370,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(NumericRestrictions.NUMERIC_MIN_LIMIT));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(NUMERIC_MIN_LIMIT));
         Assert.assertThat("Fieldspec numeric restrictions have upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NumericRestrictions.NUMERIC_MAX_LIMIT)));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(not(NUMERIC_MAX_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound limit is correct",
             outputSpec.getNumericRestrictions().getMax().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restrictions upper bound is inclusive",
@@ -405,9 +404,9 @@ class ConstraintReducerTest {
         Assert.assertThat("Fieldspec has numeric restrictions", outputSpec.getNumericRestrictions(),
             Is.is(IsNull.notNullValue()));
         Assert.assertThat("Fieldspec numeric restrictions have no upper bound",
-            outputSpec.getNumericRestrictions().getMax(), Is.is(equalTo(NumericRestrictions.NUMERIC_MAX_LIMIT)));
+            outputSpec.getNumericRestrictions().getMax(), Is.is(equalTo(NUMERIC_MAX_LIMIT)));
         Assert.assertThat("Fieldspec numeric restrictions have lower bound",
-            outputSpec.getNumericRestrictions().getMin(), Is.is(not(equalTo(NumericRestrictions.NUMERIC_MIN_LIMIT))));
+            outputSpec.getNumericRestrictions().getMin(), Is.is(not(equalTo(NUMERIC_MIN_LIMIT))));
         Assert.assertThat("Fieldspec numeric restriction lower bound is correct",
             outputSpec.getNumericRestrictions().getMin().getValue(), Is.is(BigDecimal.valueOf(5)));
         Assert.assertThat("Fieldspec numeric restriction lower bound is exclusive",

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
@@ -19,16 +19,14 @@ package com.scottlogic.deg.generator.restrictions;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
-
 import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsTests.java
@@ -21,12 +21,11 @@ import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 
 import java.math.BigDecimal;
 
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.restrictions.linear.NumericRestrictions.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 


### PR DESCRIPTION
### Description
Cleaned up a bit of code and changed how blacklised values were being checked.

### Changes
- Removed global limits from numericRestrictions class and changed all usuages of said limits to use the defaults class.
- Changed how blacklisted value filtering works 

### Issue
Resolves #1359
Related to #1235