### PR TITLE
Create DefinitionOfReady.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,12 +27,13 @@ Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@fino
 * [ ] Are you sure this is a bug or missing capability?
 
 ## Raising an Issue
-* Create your issue [here](https://github.com/finos/datahelix/issues/new).
-* New issues contain two templates in the description: bug report and enhancement request. Please pick the most appropriate for your issue, **then delete the other**.
-  * Please also tag the new issue with either "Bug" or "Enhancement".
+* Create your issue [here](https://github.com/finos/datahelix/issues/new/choose).
+* There are three issue templates - Bug Report, Feature Request and Support Question. Please pick the most appropriate for your issue.
+* Please fill out the different sections in the templates where possible.
 * Please use [Markdown formatting](https://help.github.com/categories/writing-on-github/)
 liberally to assist in readability.
-  * [Code fences](https://help.github.com/articles/creating-and-highlighting-code-blocks/) for exception stack traces and log entries, for example, massively improve readability.
+* [Code fences](https://help.github.com/articles/creating-and-highlighting-code-blocks/) for exception stack traces and log entries, for example, massively improve readability.
+* Further information regarding our Definition of Ready can be found [here] (https://github.com/finos/datahelix/blob/master/docs/developer/DefinitionOfReady.md)
 
 # Contributing Pull Requests (Code & Docs)
 To make review of PRs easier, please:
@@ -45,6 +46,7 @@ To make review of PRs easier, please:
  * Minimise non-functional changes (e.g. whitespace).
  * Ensure all new files include a header comment block containing the [Apache License v2.0 and your copyright information](http://www.apache.org/licenses/LICENSE-2.0#apply).
  * If necessary (e.g. due to 3rd party dependency licensing requirements), update the [NOTICE file](https://github.com/finos/datahelix/blob/master/NOTICE) with any new attribution or other notices
+ * Further information regarding our Definition of Done can be found [here] (https://github.com/finos/datahelix/blob/master/docs/developer/DefinitionOfDone.md) 
 
 ## Commit and PR Messages
 

--- a/docs/developer/DefinitionOfReady.md
+++ b/docs/developer/DefinitionOfReady.md
@@ -1,0 +1,17 @@
+## Definition of Ready
+
+* User Story has been defined and broken into tasks
+
+* Dependencies have been identified
+
+* User Story has been estimated by the delivery team - use either 1,2,3 or Fibonacci sequence
+
+* Acceptance criteria has been agreed
+
+* Consider what tests are required and whether any can be written up front
+
+* Consider the risks - what is the likelihood of this change breaking something? What is the impact?
+
+* Will this change require a documentation change? Who is going to update the documentation?
+
+* How will we demo this change? Who will we demo it to?


### PR DESCRIPTION
docs(#1314): add definition of ready document

### Description
Feedback suggested it would be useful to have a Definition of Ready document which could be referenced without having to open up a new feature to see the list

### Changes
Added Definition of Ready document

### Issue
Related to #1314 
