### PR TITLE
Update link in schema validation error message

### DIFF
--- a/profile/src/main/java/com/scottlogic/deg/profile/dto/ProfileSchemaValidatorLeadPony.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/dto/ProfileSchemaValidatorLeadPony.java
@@ -68,7 +68,7 @@ public class ProfileSchemaValidatorLeadPony implements ProfileSchemaValidator {
             errorMessages.add(0,
                 "Error(s) occurred during schema validation." +
                     "\nFor full details try opening the profile in a json schema-enabled IDE." +
-                    "\nSee https://github.com/finos/datahelix/blob/master/docs/UserGuide.md\n");
+                    "\nSee https://github.com/finos/datahelix/blob/master/docs/GettingStarted.md#Profile-Validation\n");
 
             throw new ValidationException(errorMessages);
         }


### PR DESCRIPTION
### Description
Fix link in Schema validation error messege.
Now correctly links to https://github.com/finos/datahelix/blob/master/docs/GettingStarted.md#Profile-Validation

