### PR TITLE
Add test building to master branch job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,22 @@ jobs:
           fingerprints:
             - "3f:0d:d9:6c:36:06:da:f4:1b:77:22:b9:b7:b5:ab:93"
       - checkout
-      - run: gradle fatJar
+      - run: gradle fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
       - run: gradle release -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password
-
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit
+      - codecov/upload:
+          file: schemas/target/jacoco-reports/jacoco.xml
+      - codecov/upload:
+          file: generator/target/jacoco-reports/jacoco.xml
 
 workflows:
   version: 2


### PR DESCRIPTION
### Description
Run the tests during the release job. This ensures the time taken for every master build on CircleCI accounts for the test suite.

### Additional notes
Next actions, once we have verified the test results are being stored, is to check if Cucumber tests are working.

### Issue
Related to #1248 
