### PR TITLE
test(#1412): add tests for working days granularity

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/GranularTo-DateTime.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/GranularTo-DateTime.feature
@@ -91,6 +91,24 @@ Feature: User can specify that datetime fields are granular to a certain unit
       | foo                       |
       | 2000-01-01T00:00:01.000Z  |
 
+  @ignore #pending development of 1412 - Implement working days for datetimes and align offset with granularity
+  Scenario: The one where a user can specify after working day granularity
+    Given foo is granular to "working days"
+    And foo is after 2019-10-04T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo                       |
+      | 2019-10-07T00:00:00.000Z  |
+
+  @ignore #pending development of 1412 - Implement working days for datetimes and align offset with granularity
+  Scenario: The one where a user can specify before working day granularity
+    Given foo is granular to "working days"
+    And foo is before 2019-10-07T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo                       |
+      | 2019-10-04T00:00:00.000Z  |
+
 
   Scenario: Applying an invalid datetime granularTo constraint fails with an appropriate error
     Given foo is granular to "decades"


### PR DESCRIPTION
### Description
New functionality was added to allow for a granularity of 'working days'

### Changes
2 tests added - 1 for 'before' working days and 1 for 'after' working days.

### Additional notes
Both tests currently tagged with @ignore pending development

### Issue
Related to #1412 
