### PR TITLE
fix(#1417): added whitelist check to permits fucntion in fieldSpec

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -110,6 +110,10 @@ public class FieldSpec {
             return false;
         }
 
+        if (whitelist != null && !whitelist.list().contains(value)) {
+            return false;
+        }
+
         return true;
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -33,6 +33,7 @@ import static com.scottlogic.deg.generator.utils.Defaults.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class FieldSpecTests {
@@ -227,6 +228,20 @@ class FieldSpecTests {
         FieldSpec spec = FieldSpec.fromRestriction(string);
 
         assertFalse(spec.permits("Anything"));
+    }
+
+    @Test
+    void permits_whenNotInWhiteList_returnsFalse() {
+        FieldSpec spec = FieldSpec.fromList(DistributedList.singleton(10));
+
+        assertFalse(spec.permits(11));
+    }
+
+    @Test
+    void permits_whenInWhiteList_returnsTrue() {
+        FieldSpec spec = FieldSpec.fromList(DistributedList.singleton(10));
+
+        assertTrue(spec.permits(10));
     }
 
     private class MockedRestrictions implements TypedRestrictions {


### PR DESCRIPTION
### Description
Added a whitelist check to the permits function in fieldSpec as previously it would return true even if the value was not in the whitelist.

### Issue
Related to #1417