### PR TITLE
1324 constraint node cleanup

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
@@ -24,29 +24,31 @@ import java.util.*;
 import java.util.function.Supplier;
 
 public class ConstraintNode implements Node {
-    private final Collection<AtomicConstraint> atomicConstraints;
-    private final Collection<FieldSpecRelations> relations;
+    private final Set<AtomicConstraint> atomicConstraints;
+    private final Set<FieldSpecRelations> relations;
     private final Collection<DecisionNode> decisions;
     private final Set<NodeMarking> nodeMarkings;
 
     private Optional<RowSpec> adaptedRowSpec = null;
 
-    public ConstraintNode(Collection<AtomicConstraint> atomicConstraints,
-                          Collection<FieldSpecRelations> relations,
+
+    public ConstraintNode(Set<AtomicConstraint> atomicConstraints,
+                          Set<FieldSpecRelations> relations,
                           Collection<DecisionNode> decisions,
                           Set<NodeMarking> nodeMarkings) {
-        this.atomicConstraints = Collections.unmodifiableCollection(atomicConstraints);
-        this.relations = Collections.unmodifiableCollection(relations);
+        this.atomicConstraints = Collections.unmodifiableSet(atomicConstraints);
+        this.relations = Collections.unmodifiableSet(relations);
         this.decisions = Collections.unmodifiableCollection(decisions);
         this.nodeMarkings = Collections.unmodifiableSet(nodeMarkings);
     }
 
-    public Collection<AtomicConstraint> getAtomicConstraints() {
-        return new HashSet<>(atomicConstraints);
+    public Set<AtomicConstraint> getAtomicConstraints() {
+        return atomicConstraints;
     }
 
-    public Collection<FieldSpecRelations> getRelations() {
-        return new HashSet<>(relations);
+
+    public Set<FieldSpecRelations> getRelations() {
+        return relations;
     }
 
     public Collection<DecisionNode> getDecisions() {
@@ -120,8 +122,8 @@ public class ConstraintNode implements Node {
     }
 
     static ConstraintNode merge(Iterator<ConstraintNode> constraintNodeIterator) {
-        Collection<AtomicConstraint> atomicConstraints = new ArrayList<>();
-        Collection<FieldSpecRelations> delayedAtomicConstraints = new ArrayList<>();
+        Set<AtomicConstraint> atomicConstraints = new HashSet<>();
+        Set<FieldSpecRelations> delayedAtomicConstraints = new HashSet<>();
         Collection<DecisionNode> decisions = new ArrayList<>();
         Set<NodeMarking> markings = new HashSet<>();
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
@@ -47,7 +47,7 @@ public class ConstraintNode implements Node {
         return relations;
     }
 
-    public Collection<DecisionNode> getDecisions() {
+    public Set<DecisionNode> getDecisions() {
         return decisions;
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
@@ -21,16 +21,12 @@ import com.scottlogic.deg.generator.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 public class ConstraintNode implements Node {
     private final Set<AtomicConstraint> atomicConstraints;
     private final Set<FieldSpecRelations> relations;
     private final Set<DecisionNode> decisions;
     private final Set<NodeMarking> nodeMarkings;
-
-    private Optional<RowSpec> adaptedRowSpec = null;
-
 
     public ConstraintNode(Set<AtomicConstraint> atomicConstraints,
                           Set<FieldSpecRelations> relations,
@@ -53,15 +49,6 @@ public class ConstraintNode implements Node {
 
     public Collection<DecisionNode> getDecisions() {
         return decisions;
-    }
-
-    public Optional<RowSpec> getOrCreateRowSpec(Supplier<Optional<RowSpec>> createRowSpecFunc) {
-        if (adaptedRowSpec != null) {
-            return adaptedRowSpec;
-        }
-
-        adaptedRowSpec = createRowSpecFunc.get();
-        return adaptedRowSpec;
     }
 
     public String toString() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 public class ConstraintNode implements Node {
     private final Set<AtomicConstraint> atomicConstraints;
     private final Set<FieldSpecRelations> relations;
-    private final Collection<DecisionNode> decisions;
+    private final Set<DecisionNode> decisions;
     private final Set<NodeMarking> nodeMarkings;
 
     private Optional<RowSpec> adaptedRowSpec = null;
@@ -34,11 +34,11 @@ public class ConstraintNode implements Node {
 
     public ConstraintNode(Set<AtomicConstraint> atomicConstraints,
                           Set<FieldSpecRelations> relations,
-                          Collection<DecisionNode> decisions,
+                          Set<DecisionNode> decisions,
                           Set<NodeMarking> nodeMarkings) {
         this.atomicConstraints = Collections.unmodifiableSet(atomicConstraints);
         this.relations = Collections.unmodifiableSet(relations);
-        this.decisions = Collections.unmodifiableCollection(decisions);
+        this.decisions = Collections.unmodifiableSet(decisions);
         this.nodeMarkings = Collections.unmodifiableSet(nodeMarkings);
     }
 
@@ -100,31 +100,21 @@ public class ConstraintNode implements Node {
         if (o == null || getClass() != o.getClass()) return false;
         ConstraintNode that = (ConstraintNode) o;
 
-        boolean atomicConstraintsEqual = atomicConstraints.containsAll(that.atomicConstraints) &&
-                that.atomicConstraints.containsAll(atomicConstraints);
-        boolean delayedAtomicConstraintsEqual = relations.containsAll(that.relations) &&
-            that.relations.containsAll(relations);
-        boolean decisionsEqual = decisions.containsAll(that.decisions) &&
-            that.decisions.containsAll(decisions);
-
-        return atomicConstraintsEqual &&
-            delayedAtomicConstraintsEqual &&
-            decisionsEqual;
+        return Objects.equals(atomicConstraints, that.atomicConstraints) &&
+            Objects.equals(relations, that.relations) &&
+            Objects.equals(decisions, that.decisions) &&
+            Objects.equals(nodeMarkings, that.nodeMarkings);
     }
 
     @Override
     public int hashCode() {
-        List<AtomicConstraint> atomicConstraintsList = new ArrayList<>(atomicConstraints);
-        List<FieldSpecRelations> delayedAtomicConstraintsList = new ArrayList<>(relations);
-        List<DecisionNode> decisionsList = new ArrayList<>(decisions);
-
-        return Objects.hash(atomicConstraintsList, delayedAtomicConstraintsList, decisionsList);
+        return Objects.hash(atomicConstraints, relations, decisions, nodeMarkings);
     }
 
     static ConstraintNode merge(Iterator<ConstraintNode> constraintNodeIterator) {
         Set<AtomicConstraint> atomicConstraints = new HashSet<>();
         Set<FieldSpecRelations> delayedAtomicConstraints = new HashSet<>();
-        Collection<DecisionNode> decisions = new ArrayList<>();
+        Set<DecisionNode> decisions = new HashSet<>();
         Set<NodeMarking> markings = new HashSet<>();
 
         while (constraintNodeIterator.hasNext()) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeBuilder.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeBuilder.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.generator.decisiontree;
 import com.scottlogic.deg.generator.fieldspecs.relations.FieldSpecRelations;
 import com.scottlogic.deg.generator.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.common.util.FlatMappingSpliterator;
+import com.scottlogic.deg.generator.utils.SetUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -14,13 +15,13 @@ import java.util.stream.Stream;
 import static java.util.stream.Stream.concat;
 
 public class ConstraintNodeBuilder {
-    private final Collection<AtomicConstraint> atomicConstraints;
-    private final Collection<FieldSpecRelations> relations;
+    private final Set<AtomicConstraint> atomicConstraints;
+    private final Set<FieldSpecRelations> relations;
     private final Collection<DecisionNode> decisions;
     private final Set<NodeMarking> nodeMarkings;
 
-    public ConstraintNodeBuilder(Collection<AtomicConstraint> atomicConstraints,
-                                 Collection<FieldSpecRelations> relations,
+    public ConstraintNodeBuilder(Set<AtomicConstraint> atomicConstraints,
+                                 Set<FieldSpecRelations> relations,
                                  Collection<DecisionNode> decisions,
                                  Set<NodeMarking> nodeMarkings) {
         this.atomicConstraints = atomicConstraints;
@@ -30,14 +31,14 @@ public class ConstraintNodeBuilder {
     }
 
     public ConstraintNodeBuilder() {
-        this(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptySet());
+        this(Collections.emptySet(), Collections.emptySet(), Collections.emptyList(), Collections.emptySet());
     }
 
-    public ConstraintNodeBuilder setAtomicConstraints(Collection<AtomicConstraint> newAtomicConstraints) {
+    public ConstraintNodeBuilder setAtomicConstraints(Set<AtomicConstraint> newAtomicConstraints) {
         return new ConstraintNodeBuilder(newAtomicConstraints, relations, decisions, nodeMarkings);
     }
 
-    public ConstraintNodeBuilder setRelations(Collection<FieldSpecRelations> newConstraints) {
+    public ConstraintNodeBuilder setRelations(Set<FieldSpecRelations> newConstraints) {
         return new ConstraintNodeBuilder(atomicConstraints, newConstraints, decisions, nodeMarkings);
     }
 
@@ -45,34 +46,34 @@ public class ConstraintNodeBuilder {
         return setAtomicConstraints(atomicConstraints
             .stream()
             .filter(constraint -> !constraint.equals(atomicConstraint))
-            .collect(Collectors.toList())
+            .collect(Collectors.toSet())
         );
     }
 
-    public ConstraintNodeBuilder addAtomicConstraints(Collection<AtomicConstraint> atomicConstraints) {
+    public ConstraintNodeBuilder addAtomicConstraints(Set<AtomicConstraint> atomicConstraints) {
         return setAtomicConstraints(
             concat(
                 this.atomicConstraints.stream(),
                 atomicConstraints.stream()
-            ).collect(Collectors.toList())
+            ).collect(Collectors.toSet())
         );
     }
 
     public ConstraintNodeBuilder addAtomicConstraints(AtomicConstraint... constraints) {
-        return addAtomicConstraints(Arrays.asList(constraints));
+        return addAtomicConstraints(Arrays.stream(constraints).collect(Collectors.toSet()));
     }
 
-    public ConstraintNodeBuilder addRelations(Collection<FieldSpecRelations> relations) {
+    public ConstraintNodeBuilder addRelations(Set<FieldSpecRelations> relations) {
         return setRelations(
             concat(
                 this.relations.stream(),
                 relations.stream())
-            .collect(Collectors.toList())
+            .collect(Collectors.toSet())
         );
     }
 
     public ConstraintNodeBuilder addRelations(FieldSpecRelations... constraints) {
-        return addRelations(Arrays.asList(constraints));
+        return addRelations(SetUtils.setOf(constraints));
     }
 
     public ConstraintNodeBuilder setDecisions(Collection<DecisionNode> newDecisions) {
@@ -80,26 +81,18 @@ public class ConstraintNodeBuilder {
     }
 
     public ConstraintNodeBuilder removeDecision(DecisionNode decisionNode) {
-        return setDecisions(
-            decisions.stream()
-                .filter(decision -> !decision.equals(decisionNode))
-                .collect(Collectors.toSet()));
+        return removeDecisions(Collections.singleton(decisionNode));
     }
 
     public ConstraintNodeBuilder removeDecisions(Collection<DecisionNode> decisionNodes) {
-        ConstraintNodeBuilder constraintNodeBuilder = this;
-        for (DecisionNode decisionNode : decisionNodes) {
-            constraintNodeBuilder = constraintNodeBuilder.removeDecision(decisionNode);
-        }
-        return constraintNodeBuilder;
+        return setDecisions(
+            decisions.stream()
+                .filter(decision -> !decisionNodes.contains(decision))
+                .collect(Collectors.toSet()));
     }
 
     public ConstraintNodeBuilder addDecision(DecisionNode decisionNode) {
-        return setDecisions(
-            concat(
-                decisions.stream(),
-                Stream.of(decisionNode)
-            ).collect(Collectors.toList()));
+        return addDecisions(Collections.singleton(decisionNode));
     }
 
     public ConstraintNodeBuilder addDecisions(Collection<DecisionNode> decisions) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeBuilder.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeBuilder.java
@@ -17,12 +17,12 @@ import static java.util.stream.Stream.concat;
 public class ConstraintNodeBuilder {
     private final Set<AtomicConstraint> atomicConstraints;
     private final Set<FieldSpecRelations> relations;
-    private final Collection<DecisionNode> decisions;
+    private final Set<DecisionNode> decisions;
     private final Set<NodeMarking> nodeMarkings;
 
     public ConstraintNodeBuilder(Set<AtomicConstraint> atomicConstraints,
                                  Set<FieldSpecRelations> relations,
-                                 Collection<DecisionNode> decisions,
+                                 Set<DecisionNode> decisions,
                                  Set<NodeMarking> nodeMarkings) {
         this.atomicConstraints = atomicConstraints;
         this.relations = relations;
@@ -31,7 +31,7 @@ public class ConstraintNodeBuilder {
     }
 
     public ConstraintNodeBuilder() {
-        this(Collections.emptySet(), Collections.emptySet(), Collections.emptyList(), Collections.emptySet());
+        this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
     }
 
     public ConstraintNodeBuilder setAtomicConstraints(Set<AtomicConstraint> newAtomicConstraints) {
@@ -76,7 +76,7 @@ public class ConstraintNodeBuilder {
         return addRelations(SetUtils.setOf(constraints));
     }
 
-    public ConstraintNodeBuilder setDecisions(Collection<DecisionNode> newDecisions) {
+    public ConstraintNodeBuilder setDecisions(Set<DecisionNode> newDecisions) {
         return new ConstraintNodeBuilder(atomicConstraints, relations, newDecisions, nodeMarkings);
     }
 
@@ -100,7 +100,7 @@ public class ConstraintNodeBuilder {
             concat(
                 this.decisions.stream(),
                 decisions.stream()
-            ).collect(Collectors.toList()));
+            ).collect(Collectors.toSet()));
     }
 
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionNode.java
@@ -17,6 +17,7 @@
 package com.scottlogic.deg.generator.decisiontree;
 
 import com.scottlogic.deg.common.util.FlatMappingSpliterator;
+import com.scottlogic.deg.generator.utils.SetUtils;
 
 import java.util.*;
 import java.util.Objects;
@@ -24,19 +25,19 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class DecisionNode implements Node {
-    private final Collection<ConstraintNode> options;
+    private final Set<ConstraintNode> options;
     private final Set<NodeMarking> nodeMarkings;
 
     public DecisionNode(ConstraintNode... options) {
-        this(Collections.unmodifiableCollection(Arrays.asList(options)));
+        this(Collections.unmodifiableSet(SetUtils.setOf(options)));
     }
 
-    public DecisionNode(Collection<ConstraintNode> options) {
+    public DecisionNode(Set<ConstraintNode> options) {
         this(options, Collections.emptySet());
     }
 
-    public DecisionNode(Collection<ConstraintNode> options, Set<NodeMarking> nodeMarkings) {
-        this.options = Collections.unmodifiableCollection(options);
+    public DecisionNode(Set<ConstraintNode> options, Set<NodeMarking> nodeMarkings) {
+        this.options = Collections.unmodifiableSet(options);
         this.nodeMarkings = Collections.unmodifiableSet(nodeMarkings);
     }
 
@@ -44,7 +45,7 @@ public final class DecisionNode implements Node {
         return options;
     }
 
-    public DecisionNode setOptions(Collection<ConstraintNode> options){
+    public DecisionNode setOptions(Set<ConstraintNode> options){
         return new DecisionNode(options);
     }
 
@@ -67,9 +68,7 @@ public final class DecisionNode implements Node {
             ? String.format("Options: %d", this.options.size())
             : String.format("Options [%d]: %s",
                 this.options.size(),
-                String.join(
-                    " OR ",
-                    this.options.stream().map(o -> o.toString()).collect(Collectors.toList())));
+            this.options.stream().map(ConstraintNode::toString).collect(Collectors.joining(" OR ")));
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionNode.java
@@ -41,7 +41,7 @@ public final class DecisionNode implements Node {
         this.nodeMarkings = Collections.unmodifiableSet(nodeMarkings);
     }
 
-    public Collection<ConstraintNode> getOptions() {
+    public Set<ConstraintNode> getOptions() {
         return options;
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
@@ -26,10 +26,7 @@ import com.scottlogic.deg.generator.profile.constraints.grammatical.ConditionalC
 import com.scottlogic.deg.generator.profile.constraints.grammatical.NegatedGrammaticalConstraint;
 import com.scottlogic.deg.generator.profile.constraints.grammatical.OrConstraint;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class DecisionTreeFactory {
@@ -128,9 +125,9 @@ public class DecisionTreeFactory {
         // OR(X, Y, Z) becomes a decision node
         Collection<Constraint> subConstraints = constraintToConvert.subConstraints;
 
-        List<ConstraintNode> options = subConstraints.stream()
+        Set<ConstraintNode> options = subConstraints.stream()
             .map(this::convertConstraint)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
 
         return asConstraintNode(new DecisionNode(options));
     }
@@ -156,7 +153,7 @@ public class DecisionTreeFactory {
     private static ConstraintNode asConstraintNode(AtomicConstraint constraint) {
         return new ConstraintNodeBuilder()
             .addAtomicConstraints(Collections.singleton(constraint))
-            .setDecisions(Collections.emptyList())
+            .setDecisions(Collections.emptySet())
             .build();
     }
 
@@ -170,7 +167,7 @@ public class DecisionTreeFactory {
     private static ConstraintNode asConstraintNode(FieldSpecRelations relation) {
         return new ConstraintNodeBuilder()
             .addRelations(relation)
-            .setDecisions(Collections.emptyList())
+            .setDecisions(Collections.emptySet())
             .build();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
@@ -144,7 +144,7 @@ public class DecisionTreeFactory {
         return convertOrConstraint(convertedConstraint);
     }
 
-    private static Collection<Constraint> negateEach(Collection<Constraint> constraints) {
+    private static List<Constraint> negateEach(Collection<Constraint> constraints) {
         return constraints.stream()
             .map(Constraint::negate)
             .collect(Collectors.toList());

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactory.java
@@ -162,7 +162,7 @@ public class DecisionTreeFactory {
 
     private static ConstraintNode asConstraintNode(DecisionNode decision) {
         return new ConstraintNodeBuilder()
-            .addAtomicConstraints(Collections.emptyList())
+            .addAtomicConstraints(Collections.emptySet())
             .setDecisions(Collections.singleton(decision))
             .build();
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeOptimiser.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeOptimiser.java
@@ -89,7 +89,7 @@ public class DecisionTreeOptimiser {
                     optimiseLevelOfTree(factorisingConstraintNode),
                     optimiseLevelOfTree(negatedFactorisingConstraintNode)),
                 otherOptions.stream())
-            .collect(Collectors.toList()));
+            .collect(Collectors.toSet()));
 
         return rootNode.builder()
             .removeDecisions(decisionsToRemove)
@@ -104,7 +104,7 @@ public class DecisionTreeOptimiser {
 
     private ConstraintNode addOptionsAsDecisionUnderConstraintNode(
         ConstraintNode newNode,
-        Collection<ConstraintNode> optionsToAdd) {
+        Set<ConstraintNode> optionsToAdd) {
         if (optionsToAdd.isEmpty()) {
             return newNode;
         }
@@ -212,7 +212,7 @@ public class DecisionTreeOptimiser {
         private void markOptionForFactorisation(
             AtomicConstraint factorisingConstraint,
             ConstraintNode node,
-            List<ConstraintNode> options,
+            Set<ConstraintNode> options,
             Set<AtomicConstraint> constraints) {
             ConstraintNode newOption = node.builder().removeAtomicConstraint(factorisingConstraint).build();
             if (!newOption.getAtomicConstraints().isEmpty()) {
@@ -223,8 +223,8 @@ public class DecisionTreeOptimiser {
     }
 
     static class DecisionAnalysisResult {
-        List<ConstraintNode> optionsToFactorise = new ArrayList<>();
-        List<ConstraintNode> negatedOptionsToFactorise = new ArrayList<>();
-        List<ConstraintNode> adjacentOptions = new ArrayList<>();
+        Set<ConstraintNode> optionsToFactorise = new HashSet<>();
+        Set<ConstraintNode> negatedOptionsToFactorise = new HashSet<>();
+        Set<ConstraintNode> adjacentOptions = new HashSet<>();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifier.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifier.java
@@ -87,12 +87,12 @@ public class DecisionTreeSimplifier {
                             Stream.concat(
                                 node1.getAtomicConstraints().stream(),
                                 node2.getAtomicConstraints().stream())
-                                .collect(Collectors.toList()))
+                                .collect(Collectors.toSet()))
                         .addRelations(
                             Stream.concat(
                                 node1.getRelations().stream(),
                                 node2.getRelations().stream())
-                                .collect(Collectors.toList()))
+                                .collect(Collectors.toSet()))
                         .setDecisions(Stream
                             .concat(
                                 node1.getDecisions().stream(),

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifier.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifier.java
@@ -32,14 +32,14 @@ public class DecisionTreeSimplifier {
             return node;
 
         ConstraintNode transformedNode = this.simplifySingleOptionDecisions(node);
-        Collection<DecisionNode> simplifiedDecisions = transformedNode.getDecisions().stream()
+        Set<DecisionNode> simplifiedDecisions = transformedNode.getDecisions().stream()
             .map(this::simplify)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
         return transformedNode.builder().setDecisions(simplifiedDecisions).build();
     }
 
     private DecisionNode simplify(DecisionNode decision) {
-        List<ConstraintNode> newNodes = new ArrayList<>();
+        Set<ConstraintNode> newNodes = new HashSet<>();
 
         for (ConstraintNode existingOption : decision.getOptions()) {
             ConstraintNode simplifiedNode = simplify(existingOption);
@@ -97,7 +97,7 @@ public class DecisionTreeSimplifier {
                             .concat(
                                 node1.getDecisions().stream(),
                                 node2.getDecisions().stream())
-                            .collect(Collectors.toList()))
+                            .collect(Collectors.toSet()))
                         .build());
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
@@ -41,8 +41,8 @@ public class ConstraintReducer {
     }
 
     public Optional<RowSpec> reduceConstraintsToRowSpec(ProfileFields fields, ConstraintNode node) {
-        Collection<AtomicConstraint> constraints = node.getAtomicConstraints();
-        Collection<FieldSpecRelations> relations = node.getRelations();
+        Set<AtomicConstraint> constraints = node.getAtomicConstraints();
+        Set<FieldSpecRelations> relations = node.getRelations();
 
         final Map<Field, List<AtomicConstraint>> fieldToConstraints = constraints.stream()
             .collect(

--- a/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
@@ -44,12 +44,12 @@ public class ConstraintReducer {
         Set<AtomicConstraint> constraints = node.getAtomicConstraints();
         Set<FieldSpecRelations> relations = node.getRelations();
 
-        final Map<Field, List<AtomicConstraint>> fieldToConstraints = constraints.stream()
+        final Map<Field, Set<AtomicConstraint>> fieldToConstraints = constraints.stream()
             .collect(
                 Collectors.groupingBy(
                     AtomicConstraint::getField,
                     Collectors.mapping(Function.identity(),
-                        Collectors.toList())));
+                        Collectors.toSet())));
 
         final Map<Field, Optional<FieldSpec>> fieldToFieldSpec = fields.stream()
             .collect(

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
@@ -68,10 +68,10 @@ public class ContradictionDecisionTreeValidator {
         if (node.getDecisions().isEmpty()) {
             return node;
         } else {
-            Collection<DecisionNode> decisions = node.getDecisions()
+            Set<DecisionNode> decisions = node.getDecisions()
                 .stream()
                 .map(d -> markContradictions(d, mergedRowSpecOpt.get(), profileFields))
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
             boolean nodeIsContradictory = decisions.stream().allMatch(this::isNodeContradictory);
             ConstraintNode transformed = node.builder().setDecisions(decisions).build();
             return nodeIsContradictory ? transformed.builder().markNode(NodeMarking.CONTRADICTORY).build() : transformed;
@@ -82,9 +82,9 @@ public class ContradictionDecisionTreeValidator {
         if (node.getOptions().isEmpty()){
             return node;
         }
-        Collection<ConstraintNode> options = node.getOptions().stream()
+        Set<ConstraintNode> options = node.getOptions().stream()
             .map(c -> markContradictions(c, accumulatedSpec, profileFields))
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
 
         boolean decisionIsContradictory = options.stream().allMatch(this::isNodeContradictory);
         DecisionNode transformed = node.setOptions(options);

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ContradictionDecisionTreeValidator.java
@@ -48,10 +48,10 @@ public class ContradictionDecisionTreeValidator {
     }
 
     private ConstraintNode markContradictions(ConstraintNode node, RowSpec accumulatedSpec, ProfileFields profileFields){
-        final Optional<RowSpec> nominalRowSpec = node.getOrCreateRowSpec(() -> constraintReducer.reduceConstraintsToRowSpec(
+        final Optional<RowSpec> nominalRowSpec = constraintReducer.reduceConstraintsToRowSpec(
             profileFields,
             node
-        ));
+        );
 
         if (!nominalRowSpec.isPresent()) {
             return node.builder().markNode(NodeMarking.CONTRADICTORY).build();

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolver.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolver.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.common.profile.ProfileFields;
 import com.scottlogic.deg.generator.profile.constraints.atomic.AtomicConstraint;
-import com.scottlogic.deg.common.util.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
@@ -15,9 +14,12 @@ import com.scottlogic.deg.generator.walker.pruner.Merged;
 import com.scottlogic.deg.generator.walker.pruner.TreePruner;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.scottlogic.deg.common.util.FlatMappingSpliterator.flatMap;
 
 public class RowSpecTreeSolver {
 
@@ -35,12 +37,13 @@ public class RowSpecTreeSolver {
     }
 
     public Stream<RowSpec> createRowSpecs(DecisionTree tree) {
-        return reduceToRowNodes(tree.rootNode)
-            .map(rootNode -> toRowspec(tree.fields, rootNode));
+        return flatMap(reduceToRowNodes(tree.rootNode),
+            rootNode -> toRowspec(tree.fields, rootNode));
     }
 
-    private RowSpec toRowspec(ProfileFields fields, ConstraintNode rootNode) {
-        return constraintReducer.reduceConstraintsToRowSpec(fields, rootNode).get();
+    private Stream<RowSpec> toRowspec(ProfileFields fields, ConstraintNode rootNode) {
+        Optional<RowSpec> result = constraintReducer.reduceConstraintsToRowSpec(fields, rootNode);
+        return result.map(Stream::of).orElseGet(Stream::empty);
     }
 
     /**
@@ -59,7 +62,7 @@ public class RowSpecTreeSolver {
             .filter(newNode -> !newNode.isContradictory())
             .map(Merged::get);
 
-        return FlatMappingSpliterator.flatMap(
+        return flatMap(
             rootOnlyConstraintNodes,
             this::reduceToRowNodes);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
@@ -24,22 +24,19 @@ import com.scottlogic.deg.generator.decisiontree.ConstraintNodeBuilder;
 import com.scottlogic.deg.generator.decisiontree.DecisionNode;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 class PrunedConstraintState {
 
-    private final Collection<AtomicConstraint> newAtomicConstraints;
-    private final Collection<FieldSpecRelations> newRelations;
+    private final Set<AtomicConstraint> newAtomicConstraints;
+    private final Set<FieldSpecRelations> newRelations;
     private final Collection<DecisionNode> newDecisionNodes = new ArrayList<>();
-    private final Collection<AtomicConstraint> pulledUpAtomicConstraints = new ArrayList<>();
-    private final Collection<FieldSpecRelations> pulledUpRelations = new ArrayList<>();
+    private final Set<AtomicConstraint> pulledUpAtomicConstraints = new HashSet<>();
+    private final Set<FieldSpecRelations> pulledUpRelations = new HashSet<>();
 
     PrunedConstraintState(ConstraintNode constraintNode){
-        newAtomicConstraints = new ArrayList<>(constraintNode.getAtomicConstraints());
-        newRelations = new ArrayList<>(constraintNode.getRelations());
+        newAtomicConstraints = new HashSet<>(constraintNode.getAtomicConstraints());
+        newRelations = new HashSet<>(constraintNode.getRelations());
     }
 
     void addPrunedDecision(DecisionNode prunedDecisionNode) {
@@ -57,7 +54,7 @@ class PrunedConstraintState {
     }
 
     boolean hasPulledUpDecisions() {
-        return !pulledUpAtomicConstraints.isEmpty();
+        return !(pulledUpAtomicConstraints.isEmpty() || pulledUpRelations.isEmpty());
     }
 
     ConstraintNode getNewConstraintNode() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
@@ -29,8 +29,13 @@ import java.util.*;
 class PrunedConstraintState {
 
     private final Set<AtomicConstraint> newAtomicConstraints;
+<<<<<<< HEAD
     private final Set<FieldSpecRelations> newRelations;
     private final Collection<DecisionNode> newDecisionNodes = new ArrayList<>();
+=======
+    private final Set<DelayedAtomicConstraint> newDelayedAtomicConstraints;
+    private final Set<DecisionNode> newDecisionNodes = new HashSet<>();
+>>>>>>> Decisions are now in a set instead of a list
     private final Set<AtomicConstraint> pulledUpAtomicConstraints = new HashSet<>();
     private final Set<FieldSpecRelations> pulledUpRelations = new HashSet<>();
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/PrunedConstraintState.java
@@ -29,13 +29,8 @@ import java.util.*;
 class PrunedConstraintState {
 
     private final Set<AtomicConstraint> newAtomicConstraints;
-<<<<<<< HEAD
     private final Set<FieldSpecRelations> newRelations;
-    private final Collection<DecisionNode> newDecisionNodes = new ArrayList<>();
-=======
-    private final Set<DelayedAtomicConstraint> newDelayedAtomicConstraints;
     private final Set<DecisionNode> newDecisionNodes = new HashSet<>();
->>>>>>> Decisions are now in a set instead of a list
     private final Set<AtomicConstraint> pulledUpAtomicConstraints = new HashSet<>();
     private final Set<FieldSpecRelations> pulledUpRelations = new HashSet<>();
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/TreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/pruner/TreePruner.java
@@ -80,7 +80,7 @@ public class TreePruner {
     }
 
     private Merged<DecisionNode> pruneDecisionNode(DecisionNode decisionNode,  Map<Field, FieldSpec> fieldSpecs) {
-        Collection<ConstraintNode> newConstraintNodes = new ArrayList<>();
+        Set<ConstraintNode> newConstraintNodes = new HashSet<>();
 
         for (ConstraintNode constraintNode : decisionNode.getOptions()) {
             pruneConstraintNode(constraintNode, fieldSpecs).ifPresent(newConstraintNodes::add);

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/TestConstraintNodeBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/TestConstraintNodeBuilder.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 public class TestConstraintNodeBuilder {
-    protected List<AtomicConstraint> constraints = new ArrayList<>();
+    protected Set<AtomicConstraint> constraints = new HashSet<>();
     private List<DecisionNode> decisionNodes = new ArrayList<>();
     private Set<NodeMarking> markings = new HashSet<>();
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/builders/TestConstraintNodeBuilder.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/builders/TestConstraintNodeBuilder.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public class TestConstraintNodeBuilder {
     protected Set<AtomicConstraint> constraints = new HashSet<>();
-    private List<DecisionNode> decisionNodes = new ArrayList<>();
+    private Set<DecisionNode> decisionNodes = new HashSet<>();
     private Set<NodeMarking> markings = new HashSet<>();
 
     protected TestConstraintNodeBuilder() {
@@ -46,7 +46,7 @@ public class TestConstraintNodeBuilder {
     }
 
     public TestConstraintNodeBuilder withDecision(TestConstraintNodeBuilder... constraintNodes) {
-        List<ConstraintNode> nodes = new ArrayList<>();
+        Set<ConstraintNode> nodes = new HashSet<>();
         for (TestConstraintNodeBuilder constraintNode : constraintNodes) {
             nodes.add(constraintNode.build());
         }

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/ConstraintNodeTest.java
@@ -23,14 +23,13 @@ import static com.scottlogic.deg.generator.builders.TestConstraintNodeBuilder.co
 import static org.junit.jupiter.api.Assertions.*;
 import static com.scottlogic.deg.common.profile.FieldBuilder.createField;
 
-
 class ConstraintNodeTest {
 
-    Field A = createField("A");
-    Field B = createField("B");
+    private static final Field A = createField("A");
+    private static final Field B = createField("B");
 
     @Test
-    public void equals_identicalConstraintNodesDifferentReferences_isTrue(){
+    public void equals_identicalConstraintNodesDifferentReferences_isTrue() {
         ConstraintNode constraintNode1 = constraintNode()
             .where(A).isInSet("a1", "a2")
             .where(B).isInSet("b1", "b2")
@@ -65,7 +64,7 @@ class ConstraintNodeTest {
     }
 
     @Test
-    public void hashCode_identicalConstraintNodesDifferentReferences_areEqual(){
+    public void hashCode_identicalConstraintNodesDifferentReferences_areEqual() {
         ConstraintNode constraintNode1 = constraintNode()
             .where(A).isInSet("a1", "a2")
             .where(B).isInSet("b1", "b2")
@@ -100,7 +99,7 @@ class ConstraintNodeTest {
     }
 
     @Test
-    public void equals_differentConstraintNodesDifferentReferences_isFalse(){
+    public void equals_differentConstraintNodesDifferentReferences_isFalse() {
         ConstraintNode constraintNode1 = constraintNode()
             .where(A).isInSet("a1", "a2")
             .where(B).isInSet("b1", "b2")
@@ -135,7 +134,7 @@ class ConstraintNodeTest {
     }
 
     @Test
-    public void hashCode_differentConstraintNodesDifferentReferences_areNotEqual(){
+    public void hashCode_differentConstraintNodesDifferentReferences_areNotEqual() {
         ConstraintNode constraintNode1 = constraintNode()
             .where(A).isInSet("a1", "a2")
             .where(B).isInSet("b1", "b2")

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactoryTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactoryTests.java
@@ -33,6 +33,7 @@ import com.scottlogic.deg.generator.decisiontree.testutils.*;
 import com.scottlogic.deg.generator.profile.RuleInformation;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
+import com.scottlogic.deg.generator.utils.SetUtils;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNull;
 import org.junit.Assert;
@@ -346,10 +347,10 @@ class DecisionTreeFactoryTests {
         Assert.assertTrue(isEquivalentTo(
             new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                 new DecisionNode(
-                    new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+                    new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA,
                         constraintB)).setDecisions(Collections.emptySet()).build(),
-                    new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+                    new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA.negate(),
                         constraintC
                     )).setDecisions(Collections.emptySet()).build()
@@ -375,10 +376,10 @@ class DecisionTreeFactoryTests {
 
         Assert.assertTrue(
             isEquivalentTo(
-                getResultingRootOption(), new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptyList()).setDecisions(Collections.singletonList(
+                getResultingRootOption(), new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                     new DecisionNode(
                         /* OPTION 1: AND(C, OR(A, B))  */
-                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singletonList(bGreaterThan20)).setDecisions(Collections.singleton(
+                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(bGreaterThan20)).setDecisions(Collections.singleton(
                             new DecisionNode(
                                 new ConstraintNodeBuilder().addAtomicConstraints(aEquals10).build(),
                                 new ConstraintNodeBuilder().addAtomicConstraints(aGreaterThan10).build()))).build(),
@@ -409,11 +410,11 @@ class DecisionTreeFactoryTests {
         Assert.assertTrue(isEquivalentTo(
             new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                 new DecisionNode(
-                    new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+                    new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA,
                         constraintB.negate()
                     )).setDecisions(Collections.emptySet()).build(),
-                    new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+                    new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA.negate(),
                         constraintC.negate()
                     )).setDecisions(Collections.emptySet()).build()
@@ -487,8 +488,8 @@ class DecisionTreeFactoryTests {
         Assert.assertTrue(isEquivalentTo(
             new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                 new DecisionNode(
-                    new ConstraintNodeBuilder().addAtomicConstraints(Collections.singletonList(constraintA.negate())).setDecisions(Collections.emptySet()).build(),
-                    new ConstraintNodeBuilder().addAtomicConstraints(Collections.singletonList(constraintB.negate())).setDecisions(Collections.emptySet()).build()
+                    new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(constraintA.negate())).setDecisions(Collections.emptySet()).build(),
+                    new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(constraintB.negate())).setDecisions(Collections.emptySet()).build()
                 )
             )).build(),
             outputRule.getRootNode())
@@ -510,7 +511,7 @@ class DecisionTreeFactoryTests {
         Assert.assertTrue(
             isEquivalentTo(
                 getResultingRootOption(),
-                new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptyList()).setDecisions(Collections.singletonList(
+                new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                     new DecisionNode(
                         new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build(),
                         new ConstraintNodeBuilder().addAtomicConstraints(constraintB).build(),

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactoryTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeFactoryTests.java
@@ -277,7 +277,7 @@ class DecisionTreeFactoryTests {
 
         Assert.assertThat("analyse() output is not null", outputRule, Is.is(IsNull.notNullValue()));
         Assert.assertTrue(isEquivalentTo(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(SetUtils.setOf(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build(),
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintB).build()
@@ -315,7 +315,7 @@ class DecisionTreeFactoryTests {
 
         Assert.assertThat("analyse() output is not null", outputRule, Is.is(IsNull.notNullValue()));
         Assert.assertTrue(isEquivalentTo(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(SetUtils.setOf(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build(),
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintC, constraintB).build()
@@ -345,7 +345,7 @@ class DecisionTreeFactoryTests {
 
         Assert.assertThat("analyse() output is not null", outputRule, Is.is(IsNull.notNullValue()));
         Assert.assertTrue(isEquivalentTo(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA,
@@ -376,7 +376,7 @@ class DecisionTreeFactoryTests {
 
         Assert.assertTrue(
             isEquivalentTo(
-                getResultingRootOption(), new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+                getResultingRootOption(), new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                     new DecisionNode(
                         /* OPTION 1: AND(C, OR(A, B))  */
                         new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(bGreaterThan20)).setDecisions(Collections.singleton(
@@ -408,7 +408,7 @@ class DecisionTreeFactoryTests {
 
         Assert.assertThat("analyse() output is not null", outputRule, Is.is(IsNull.notNullValue()));
         Assert.assertTrue(isEquivalentTo(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                         constraintA,
@@ -486,7 +486,7 @@ class DecisionTreeFactoryTests {
         Assert.assertThat("analyse() output is not null", outputRule, Is.is(IsNull.notNullValue()));
         // Result should be (NOT A) OR (NOT B)
         Assert.assertTrue(isEquivalentTo(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(constraintA.negate())).setDecisions(Collections.emptySet()).build(),
                     new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(constraintB.negate())).setDecisions(Collections.emptySet()).build()
@@ -511,7 +511,7 @@ class DecisionTreeFactoryTests {
         Assert.assertTrue(
             isEquivalentTo(
                 getResultingRootOption(),
-                new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+                new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                     new DecisionNode(
                         new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build(),
                         new ConstraintNodeBuilder().addAtomicConstraints(constraintB).build(),

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifierTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifierTests.java
@@ -47,12 +47,12 @@ class DecisionTreeSimplifierTests {
             new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                 new IsInSetConstraint(createField("Field 1"), setOf(1, 2)),
                 new IsNullConstraint(createField("Field 1")).negate()
-            )).setDecisions(Collections.singletonList(
+            )).setDecisions(Collections.singleton(
                 new DecisionNode(
-                    Collections.singletonList(
+                    Collections.singleton(
                         new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(
                             new IsInSetConstraint(createField("Field 1"), setOf(1, 2))
-                        )).setDecisions(Collections.emptyList()).build()
+                        )).setDecisions(Collections.emptySet()).build()
                     )
                 )
             )).build(),
@@ -74,12 +74,12 @@ class DecisionTreeSimplifierTests {
             new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                 new IsInSetConstraint(createField("Field 1"), setOf(1, 2)),
                 new IsNullConstraint(createField("Field 1")).negate()
-            )).setDecisions(Collections.singletonList(
+            )).setDecisions(Collections.singleton(
                 new DecisionNode(
-                    Collections.singletonList(
+                    Collections.singleton(
                         new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(
                             new IsInSetConstraint(createField("Field 2"), setOf("A", "B"))
-                        )).setDecisions(Collections.emptyList()).build()
+                        )).setDecisions(Collections.emptySet()).build()
                     )
                 )
             )).build(),

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifierTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/DecisionTreeSimplifierTests.java
@@ -23,6 +23,7 @@ import com.scottlogic.deg.generator.profile.constraints.atomic.IsInSetConstraint
 import com.scottlogic.deg.generator.profile.constraints.atomic.IsNullConstraint;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
+import com.scottlogic.deg.generator.utils.SetUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
@@ -43,13 +44,13 @@ class DecisionTreeSimplifierTests {
     @Test
     void simplify_decisionContainsSingleOptiontWithMatchingConstraintOnRootNode_doesNotSimplifyTree() {
         DecisionTree tree = new DecisionTree(
-            new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                 new IsInSetConstraint(createField("Field 1"), setOf(1, 2)),
                 new IsNullConstraint(createField("Field 1")).negate()
             )).setDecisions(Collections.singletonList(
                 new DecisionNode(
                     Collections.singletonList(
-                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singletonList(
+                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(
                             new IsInSetConstraint(createField("Field 1"), setOf(1, 2))
                         )).setDecisions(Collections.emptyList()).build()
                     )
@@ -70,13 +71,13 @@ class DecisionTreeSimplifierTests {
     @Test
     void simplify_decisionContainsSingleOptionWithDifferingConstraintOnRootNode_simplifiesDecision() {
         DecisionTree tree = new DecisionTree(
-            new ConstraintNodeBuilder().addAtomicConstraints(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(SetUtils.setOf(
                 new IsInSetConstraint(createField("Field 1"), setOf(1, 2)),
                 new IsNullConstraint(createField("Field 1")).negate()
             )).setDecisions(Collections.singletonList(
                 new DecisionNode(
                     Collections.singletonList(
-                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singletonList(
+                        new ConstraintNodeBuilder().addAtomicConstraints(Collections.singleton(
                             new IsInSetConstraint(createField("Field 2"), setOf("A", "B"))
                         )).setDecisions(Collections.emptyList()).build()
                     )

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
@@ -91,7 +91,7 @@ class ConstraintToFieldMapperTests {
         final AtomicConstraint constraintF = new IsInSetConstraint(createField("F"), whitelistOf("test-value"));
 
         final DecisionNode decisionABC = new DecisionNode(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(SetUtils.setOf(
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build()),
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintB).build()),
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintC).build())
@@ -99,7 +99,7 @@ class ConstraintToFieldMapperTests {
         );
 
         final DecisionNode decisionDEF = new DecisionNode(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singleton(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintD).build(),
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintE).build(),

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
@@ -26,6 +26,7 @@ import com.scottlogic.deg.generator.decisiontree.DecisionNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
+import com.scottlogic.deg.generator.utils.SetUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +91,7 @@ class ConstraintToFieldMapperTests {
         final AtomicConstraint constraintF = new IsInSetConstraint(createField("F"), whitelistOf("test-value"));
 
         final DecisionNode decisionABC = new DecisionNode(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptyList()).setDecisions(Arrays.asList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Arrays.asList(
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintA).build()),
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintB).build()),
                 new DecisionNode(new ConstraintNodeBuilder().addAtomicConstraints(constraintC).build())
@@ -98,7 +99,7 @@ class ConstraintToFieldMapperTests {
         );
 
         final DecisionNode decisionDEF = new DecisionNode(
-            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptyList()).setDecisions(Collections.singletonList(
+            new ConstraintNodeBuilder().addAtomicConstraints(Collections.emptySet()).setDecisions(Collections.singletonList(
                 new DecisionNode(
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintD).build(),
                     new ConstraintNodeBuilder().addAtomicConstraints(constraintE).build(),
@@ -114,23 +115,23 @@ class ConstraintToFieldMapperTests {
 
     @BeforeEach
     void beforeEach() {
-        constraintsList = new ArrayList<>();
-        decisionsList = new ArrayList<>();
+        constraintsSet = new HashSet<>();
+        decisionsSet = new HashSet<>();
         fields = new ProfileFields(Collections.emptyList());
         mappings = null;
     }
 
-    private List<AtomicConstraint> constraintsList;
-    private List<DecisionNode> decisionsList;
+    private Set<AtomicConstraint> constraintsSet;
+    private Set<DecisionNode> decisionsSet;
     private ProfileFields fields;
     private Map<RootLevelConstraint, Set<Field>> mappings;
 
     private void givenConstraints(AtomicConstraint... constraints) {
-        constraintsList = Arrays.asList(constraints);
+        constraintsSet = SetUtils.setOf(constraints);
     }
 
     private void givenDecisions(DecisionNode... decisions) {
-        decisionsList = Arrays.asList(decisions);
+        decisionsSet = SetUtils.setOf(decisions);
     }
 
     private void givenFields(String... fieldNames) {
@@ -143,7 +144,7 @@ class ConstraintToFieldMapperTests {
     private void getMappings() {
         mappings = new ConstraintToFieldMapper()
             .mapConstraintsToFields(new DecisionTree(
-                new ConstraintNodeBuilder().addAtomicConstraints(constraintsList).setDecisions(decisionsList).build(),
+                new ConstraintNodeBuilder().addAtomicConstraints(constraintsSet).setDecisions(decisionsSet).build(),
                 fields
             ));
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/TreePartitionerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/TreePartitionerTests.java
@@ -25,6 +25,7 @@ import com.scottlogic.deg.generator.decisiontree.testutils.*;
 import com.scottlogic.deg.generator.decisiontree.testutils.EqualityComparer;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
+import com.scottlogic.deg.generator.utils.SetUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -262,7 +263,7 @@ class TreePartitionerTests {
     private ConstraintNode constraint(String[] fieldNames, DecisionNode... decisions) {
         return new ConstraintNodeBuilder().addAtomicConstraints(Stream.of(fieldNames)
             .map(this::atomicConstraint)
-            .collect(Collectors.toSet())).setDecisions(Arrays.asList(decisions)).build();
+            .collect(Collectors.toSet())).setDecisions(SetUtils.setOf(decisions)).build();
     }
 
     private AtomicConstraint atomicConstraint(String fieldName) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/TreePartitionerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/decisiontree/treepartitioning/TreePartitionerTests.java
@@ -262,7 +262,7 @@ class TreePartitionerTests {
     private ConstraintNode constraint(String[] fieldNames, DecisionNode... decisions) {
         return new ConstraintNodeBuilder().addAtomicConstraints(Stream.of(fieldNames)
             .map(this::atomicConstraint)
-            .collect(Collectors.toList())).setDecisions(Arrays.asList(decisions)).build();
+            .collect(Collectors.toSet())).setDecisions(Arrays.asList(decisions)).build();
     }
 
     private AtomicConstraint atomicConstraint(String fieldName) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
@@ -28,6 +28,7 @@ import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
 import com.scottlogic.deg.generator.profile.constraints.atomic.*;
 import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
+import com.scottlogic.deg.generator.utils.SetUtils;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNull;
 import org.junit.Assert;
@@ -52,7 +53,7 @@ class ConstraintReducerTest {
         new FieldSpecMerger()
     );
 
-    private static ConstraintNode nodeFromConstraints(Collection<AtomicConstraint> constraints) {
+    private static ConstraintNode nodeFromConstraints(Set<AtomicConstraint> constraints) {
         return new ConstraintNodeBuilder().addAtomicConstraints(constraints).build();
     }
 
@@ -70,7 +71,7 @@ class ConstraintReducerTest {
             .map(string -> new WeightedElement<>((Object) string, 1.0F))
             .collect(Collectors.toList()));
 
-        final List<AtomicConstraint> constraints = Arrays.asList(
+        final Set<AtomicConstraint> constraints = SetUtils.setOf(
             new IsGreaterThanOrEqualToConstantConstraint(quantityField, BigDecimal.valueOf(0)),
             new IsGreaterThanConstantConstraint(quantityField, BigDecimal.valueOf(5)).negate(),
             new IsInSetConstraint(countryField, countryAmong));
@@ -118,7 +119,7 @@ class ConstraintReducerTest {
     void shouldReduceIsGreaterThanConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsGreaterThanOrEqualToConstantConstraint(field, BigDecimal.valueOf(5)));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -146,7 +147,7 @@ class ConstraintReducerTest {
     void shouldReduceNegatedIsGreaterThanConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsGreaterThanConstantConstraint(field, BigDecimal.valueOf(5)).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -172,7 +173,7 @@ class ConstraintReducerTest {
     void shouldReduceIsGreaterThanOrEqualToConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsGreaterThanOrEqualToConstantConstraint(field, BigDecimal.valueOf(5)));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -200,7 +201,7 @@ class ConstraintReducerTest {
     void shouldReduceNegatedIsGreaterThanOrEqualToConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsGreaterThanConstantConstraint(field, BigDecimal.valueOf(5)).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -226,7 +227,7 @@ class ConstraintReducerTest {
     void shouldReduceIsLessThanConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsLessThanOrEqualToConstantConstraint(field, BigDecimal.valueOf(5)));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -252,7 +253,7 @@ class ConstraintReducerTest {
     void shouldReduceNegatedIsLessThanConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsLessThanConstantConstraint(field, BigDecimal.valueOf(5)).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -278,7 +279,7 @@ class ConstraintReducerTest {
     void shouldReduceIsLessThanOrEqualToConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsLessThanOrEqualToConstantConstraint(field, BigDecimal.valueOf(5)));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -304,7 +305,7 @@ class ConstraintReducerTest {
     void shouldReduceNegatedIsLessThanOrEqualToConstantConstraint() {
         final Field field = createField("test0", NUMERIC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsLessThanConstantConstraint(field, BigDecimal.valueOf(5)).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -331,7 +332,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsAfterOrEqualToConstantDateTimeConstraint(field, testTimestamp));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -358,7 +359,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16,0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsAfterConstantDateTimeConstraint(field, testTimestamp).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -385,7 +386,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsAfterOrEqualToConstantDateTimeConstraint(field, testTimestamp));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -412,7 +413,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsAfterConstantDateTimeConstraint(field, testTimestamp).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -439,7 +440,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsBeforeOrEqualToConstantDateTimeConstraint(field, testTimestamp));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -466,7 +467,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsBeforeConstantDateTimeConstraint(field, testTimestamp).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -493,7 +494,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsBeforeOrEqualToConstantDateTimeConstraint(field, testTimestamp));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -520,7 +521,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0", DATETIME);
         final OffsetDateTime testTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 16, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsBeforeConstantDateTimeConstraint(field, testTimestamp).negate());
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -548,7 +549,7 @@ class ConstraintReducerTest {
         final OffsetDateTime startTimestamp = OffsetDateTime.of(2013, 11, 19, 10, 43, 12, 0, ZoneOffset.UTC);
         final OffsetDateTime endTimestamp = OffsetDateTime.of(2018, 2, 4, 23, 25, 8, 0, ZoneOffset.UTC);
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Arrays.asList(
+        Set<AtomicConstraint> constraints = SetUtils.setOf(
             new IsAfterOrEqualToConstantDateTimeConstraint(field, startTimestamp),
             new IsBeforeOrEqualToConstantDateTimeConstraint(field, endTimestamp));
 
@@ -578,7 +579,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0");
         String pattern = ".*\\..*";
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new MatchesRegexConstraint(field, Pattern.compile(pattern)));
 
         RowSpec testOutput = constraintReducer.reduceConstraintsToRowSpec(profileFields, nodeFromConstraints(constraints)).get();
@@ -599,7 +600,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0");
 
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsStringLongerThanConstraint(field, 5)
         );
 
@@ -621,7 +622,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0");
 
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new IsStringShorterThanConstraint(field, 5)
         );
 
@@ -643,7 +644,7 @@ class ConstraintReducerTest {
         final Field field = createField("test0");
 
         ProfileFields profileFields = new ProfileFields(Collections.singletonList(field));
-        List<AtomicConstraint> constraints = Collections.singletonList(
+        Set<AtomicConstraint> constraints = Collections.singleton(
             new StringHasLengthConstraint(field, 5)
         );
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolverTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/decisionbased/RowSpecTreeSolverTests.java
@@ -82,10 +82,10 @@ class RowSpecTreeSolverTests {
         DecisionTree tree = new DecisionTree(root, profileFields);
 
         //Act
-        List<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toList());
+        Set<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
 
         //Assert
-        List<RowSpec> expectedRowSpecs = new ArrayList<>();
+        Set<RowSpec> expectedRowSpecs = new HashSet<>();
         Map<Field, FieldSpec> option0 = new HashMap<>();
         option0.put(fieldA, FieldSpec.empty());
         option0.put(fieldB, FieldSpec.nullOnly());


### PR DESCRIPTION
### Description
Convert collections to sets around constraint node.
Fix logic in row spec decision solver around partial contradictions.
Performance is equivalent for a sample profile for 100,000 rows.
Duplicate constraints are still handled correctly.
Node markings are now considered for equality between constraints.

### Issue
Resolves #1324 
