### PR TITLE
test(#1425): added cucumber tests for multiple related date fields

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/FieldDependencies.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/FieldDependencies.feature
@@ -4,7 +4,7 @@ Feature:As a  User
 
   Background:
     Given the generation strategy is full
-    And the combination strategy is minimal
+    And the combination strategy is exhaustive
     And there is a field foo
     And foo has type "integer"
     And foo is greater than 0
@@ -17,50 +17,33 @@ Feature:As a  User
 ###Integer
   Scenario: The one where a user can specify that one number should be greater than another number
     Given bar is greater than 0
-    And the generator can generate at most 3 rows
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "greaterThan",
-          "otherField": "foo"
-        }
-      """
+    And bar is less than 4
+    And the generator can generate at most 5 rows
+    And bar is greater than field foo
     Then the following data should be generated:
       | foo| bar|
       | 1  | 2  |
+      | 1  | 3  |
       | 2  | 3  |
-      | 3  | 4  |
 
   Scenario: The one where a user can specify that one number should be greater than or equal to another number
     Given bar is greater than 0
-    And the generator can generate at most 3 rows
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "greaterThanOrEqualTo",
-          "otherField": "foo"
-        }
-      """
+    And bar is less than 4
+    And the generator can generate at most 5 rows
+    And bar is greater than or equal to field foo
     Then the following data should be generated:
       | foo| bar|
       | 1  | 1  |
+      | 1  | 2  |
+      | 1  | 3  |
       | 2  | 2  |
-      | 3  | 3  |
+      | 2  | 3  |
 
   Scenario: The one where a user can specify that one number should be less than another number
     Given foo is less than 3
     And bar is greater than 0
     And the generator can generate at most 3 rows
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "lessThan",
-          "otherField": "foo"
-        }
-      """
+    And bar is less than field foo
     Then the following data should be generated:
       | foo| bar|
       | 2  | 1  |
@@ -69,14 +52,7 @@ Feature:As a  User
     Given the combination strategy is exhaustive
     And foo is less than 3
     And bar is greater than 0
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "lessThanOrEqualTo",
-          "otherField": "foo"
-        }
-      """
+    And bar is less than or equal to field foo
     Then the following data should be generated:
       | foo| bar|
       | 1  | 1  |
@@ -86,14 +62,7 @@ Feature:As a  User
   Scenario: The one where a user can specify that one number should be equal to another number
     Given bar is greater than 0
     And the generator can generate at most 3 rows
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "equalTo",
-          "otherField": "foo"
-        }
-      """
+    And bar is equal to field foo
     Then the following data should be generated:
       | foo| bar|
       | 1  | 1  |
@@ -183,14 +152,7 @@ Feature:As a  User
     And bar is greater than 0
     And bar is less than 5
     And the generator can generate at most 6 rows
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "greaterThan",
-          "otherField": "foo"
-        }
-      """
+    And bar is greater than field foo
     Then the following data should be generated:
       | foo| bar|
       | 1  | 2  |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/GranularTo-Decimal.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/GranularTo-Decimal.feature
@@ -86,22 +86,22 @@ Feature: User can specify that decimal fields are granular to a certain number o
 
   Scenario: The one where a user can specify that one decimal number should be greater than another decimal number
     Given foo is granular to 0.1
+    And the combination strategy is exhaustive
     And foo is greater than or equal to 1
+    And foo is anything but null
+    And bar is anything but null
     And there is a field bar
     And bar has type "decimal"
     And bar is granular to 0.1
     And bar is less than 1.4
     And bar is greater than or equal to 1
-    And there is a constraint:
-      """
-        {
-          "field": "bar",
-          "is": "greaterThan",
-          "otherField": "foo"
-        }
-      """
+    And foo is less than 1.4
+    And bar is greater than field foo
     Then the following data should be generated:
       | foo | bar |
       | 1   | 1.1 |
+      | 1   | 1.2 |
+      | 1   | 1.3 |
       | 1.1 | 1.2 |
+      | 1.1 | 1.3 |
       | 1.2 | 1.3 |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
@@ -1,0 +1,134 @@
+Feature: running datetimes related to otherfield datetimes for multiple fields
+
+  Background:
+    Given the generation strategy is full
+    And there is a field foobar
+    And foobar has type "datetime"
+    And there is a field foo
+    And foo has type "datetime"
+    And there is a field bar
+    And bar has type "datetime"
+    And the combination strategy is exhaustive
+
+  Scenario: Running a "before" and "after" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is before field bar
+    And foobar is after field foo
+    Then the following data should be generated:
+      | foobar                   | foo                      | bar                      |
+      | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.002Z |
+
+  Scenario: Running a "before" and "equalTo" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is before field bar
+    And foobar is equal to field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z |
+
+  Scenario: Running an "after" and "equalTo" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is after field bar
+    And foobar is equal to field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z |
+
+  Scenario: Running two "after" constraints
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is after field bar
+    And foobar is after field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |
+
+  Scenario: Running two "before" constraints switched other field constraints
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And bar is before field foobar
+    And foo is before field foobar
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |
+
+  Scenario: Running two "before" constraints
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is before field bar
+    And foobar is before field foo
+    Then the following data should be generated:
+      | foobar                   | foo                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.001Z |
+
+  Scenario: Running two "after" switched other field constraints
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And bar is after field foobar
+    And foo is after field foobar
+    Then the following data should be generated:
+      | foobar                   | foo                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.001Z |
+
+  Scenario: Running linked "after" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is after field bar
+    And bar is after field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z |
+
+    @ignore # this hangs #1439 has been raised to resolve this
+  Scenario: Running linked "before" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is before field bar
+    And bar is before field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.001Z |
+
+  Scenario: Running linked "before" constraint with lower limit
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is before 2019-01-01T00:00:00.000Z
+    And foobar is before field bar
+    And bar is before field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.001Z |
+
+  Scenario: Running linked "equalTo" constraint
+    Given the generator can generate at most 1 rows
+    And foo is anything but null
+    And bar is anything but null
+    And foobar is anything but null
+    And foobar is equal to field bar
+    And bar is equal to field foo
+    Then the following data should be generated:
+      | foobar                   | for                      | bar                      |
+      | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
@@ -10,7 +10,6 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And bar has type "datetime"
     And the combination strategy is exhaustive
 
-  @ignore # this hangs #1439 has been raised to resolve this
   Scenario: Running a "before" and "after" constraint
     Given the generator can generate at most 1 rows
     And foo is anything but null
@@ -99,7 +98,6 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
       | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z |
 
-    @ignore # this hangs #1439 has been raised to resolve this
   Scenario: Running linked "before" constraint
     Given the generator can generate at most 1 rows
     And foo is anything but null

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
@@ -30,7 +30,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is before field bar
     And foobar is equal to field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z |
 
   Scenario: Running an "after" and "equalTo" constraint
@@ -41,7 +41,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is after field bar
     And foobar is equal to field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z |
 
   Scenario: Running two "after" constraints
@@ -52,7 +52,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is after field bar
     And foobar is after field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |
 
   Scenario: Running two "before" constraints switched other field constraints
@@ -63,7 +63,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And bar is before field foobar
     And foo is before field foobar
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |
 
   Scenario: Running two "before" constraints
@@ -96,7 +96,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is after field bar
     And bar is after field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.001Z |
 
     @ignore # this hangs #1439 has been raised to resolve this
@@ -108,7 +108,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is before field bar
     And bar is before field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.001Z |
 
   Scenario: Running linked "before" constraint with lower limit
@@ -120,7 +120,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is before field bar
     And bar is before field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.001Z |
 
   Scenario: Running linked "equalTo" constraint
@@ -131,5 +131,5 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And foobar is equal to field bar
     And bar is equal to field foo
     Then the following data should be generated:
-      | foobar                   | for                      | bar                      |
+      | foobar                   | foo                      | bar                      |
       | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z | 0001-01-01T00:00:00.000Z |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField-Multiple.feature
@@ -10,6 +10,7 @@ Feature: running datetimes related to otherfield datetimes for multiple fields
     And bar has type "datetime"
     And the combination strategy is exhaustive
 
+  @ignore # this hangs #1439 has been raised to resolve this
   Scenario: Running a "before" and "after" constraint
     Given the generator can generate at most 1 rows
     And foo is anything but null

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
@@ -48,12 +48,12 @@ public class DateValueStep {
         state.addNotConstraint(fieldName, constraintName, value);
     }
 
-    @And("^(.+) is after field (.+)$")
+    @And("^(.+) is after field ([A-z0-9]+)$")
     public void dateAfter(String field, String otherField){
         state.addRelationConstraint(field, AtomicConstraintType.IS_AFTER_CONSTANT_DATE_TIME.getText(), otherField);
     }
 
-    @And("^(.+) is before field (.+)$")
+    @And("^(.+) is before field ([A-z0-9]+)$")
     public void dateBefore(String field, String otherField){
         state.addRelationConstraint(field, AtomicConstraintType.IS_BEFORE_CONSTANT_DATE_TIME.getText(), otherField);
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
@@ -17,7 +17,6 @@
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
 import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
-import com.scottlogic.deg.generator.fieldspecs.relations.AfterDateRelation;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.GeneratorTestUtilities;

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
@@ -16,9 +16,12 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
+import com.scottlogic.deg.generator.fieldspecs.relations.AfterDateRelation;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.GeneratorTestUtilities;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
@@ -44,6 +47,16 @@ public class DateValueStep {
     @When("{fieldVar} is anything but {operator} {date}")
     public void whenFieldIsNotConstrainedByDateValue(String fieldName, String constraintName, String value) {
         state.addNotConstraint(fieldName, constraintName, value);
+    }
+
+    @And("^(.+) is after field (.+)$")
+    public void dateAfter(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_AFTER_CONSTANT_DATE_TIME.getText(), otherField);
+    }
+
+    @And("^(.+) is before field (.+)$")
+    public void dateBefore(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_BEFORE_CONSTANT_DATE_TIME.getText(), otherField);
     }
 
     @Then("{fieldVar} contains only datetime data")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
@@ -103,6 +103,11 @@ public class GeneralTestStep {
         this.state.setFieldUnique(fieldName);
     }
 
+    @And("^(.+) is equal to field (.+)$")
+    public void fieldEqualTo(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), otherField);
+    }
+
 
 
     @Then("^the profile should be considered valid$")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NumericValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NumericValueStep.java
@@ -16,8 +16,10 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
@@ -44,6 +46,26 @@ public class NumericValueStep {
     @When("{fieldVar} is anything but {operator} {number}")
     public void whenFieldIsNotConstrainedByNumericValue(String fieldName, String constraintName, Number value) {
         state.addNotConstraint(fieldName, constraintName, value);
+    }
+
+    @And("^(.+) is greater than field ([A-z0-9]+)$")
+    public void numericGreater(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_GREATER_THAN_CONSTANT.getText(), otherField);
+    }
+
+    @And("^(.+) is less than field ([A-z0-9]+)$")
+    public void numericLess(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_LESS_THAN_CONSTANT.getText(), otherField);
+    }
+
+    @And("^(.+) is greater than or equal to field ([A-z0-9]+)$")
+    public void numericGreaterEqual(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_GREATER_THAN_OR_EQUAL_TO_CONSTANT.getText(), otherField);
+    }
+
+    @And("^(.+) is less than or equal to field ([A-z0-9]+)$")
+    public void numericLessEqual(String field, String otherField){
+        state.addRelationConstraint(field, AtomicConstraintType.IS_LESS_THAN_OR_EQUAL_TO_CONSTANT.getText(), otherField);
     }
 
     @Then("{fieldVar} contains numeric data")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
@@ -64,6 +64,14 @@ public class CucumberTestState {
         this.addConstraintToList(dto);
     }
 
+    public void addRelationConstraint(String field, String relationType, String other) {
+        ConstraintDTO dto = new ConstraintDTO();
+        dto.field = field;
+        dto.is = relationType;
+        dto.otherField = other;
+        this.addConstraintToList(dto);
+    }
+
     public void addConstraint(String fieldName, String constraintName, Object value) {
         ConstraintDTO dto = this.createConstraint(fieldName, constraintName, value);
         this.addConstraintToList(dto);


### PR DESCRIPTION
### Description
Added cucumber tests for multiple related datetime fields.
Added new cucumber hooks for after field, before field, and equal to field.
Updated the function `findFirst` as if a field was related to more other fields but it was set via the `main` property then it wouldn't be run first. 

### Additional notes
#1439 has been raised to deal with the failing scenario

### Issue
Related to #1425 