### PR TITLE
chore(#1301): Make fieldspecs strongly typed

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -27,33 +27,42 @@ import java.util.*;
  * if a fieldSpec can not be a type, it will not have any restrictions for that type
  * This is enforced during merging.
  */
-public class FieldSpec {
+public class FieldSpec<T> {
 
-    private static final DistributedList<Object> NO_VALUES = DistributedList.empty();
+    private static final DistributedList<?> NO_VALUES = DistributedList.empty();
 
-    public static FieldSpec fromList(DistributedList<Object> whitelist) {
-        return new FieldSpec(whitelist, null, true, Collections.emptySet());
+    private static final FieldSpec<?> EMPTY = new FieldSpec<>(null, null, true, Collections.emptySet());
+
+    private static final FieldSpec<?> NULL_ONLY = new FieldSpec<>(NO_VALUES, null, true, Collections.emptySet());
+
+    public static <T> FieldSpec<T> fromList(DistributedList<T> whitelist) {
+        return new FieldSpec<>(whitelist, null, true, Collections.emptySet());
     }
-    public static FieldSpec fromRestriction(TypedRestrictions restrictions) {
-        return new FieldSpec(null, restrictions, true, Collections.emptySet());
+    public static <T> FieldSpec<T> fromRestriction(TypedRestrictions<T> restrictions) {
+        return new FieldSpec<>(null, restrictions, true, Collections.emptySet());
     }
-    public static FieldSpec empty() {
-        return new FieldSpec(null, null, true, Collections.emptySet());
+
+    public static <T> FieldSpec<T> empty() {
+        @SuppressWarnings("unchecked")
+        FieldSpec<T> spec = (FieldSpec<T>) EMPTY;
+        return spec;
     }
-    public static FieldSpec nullOnly() {
-        return new FieldSpec(NO_VALUES, null, true, Collections.emptySet());
+    public static <T> FieldSpec nullOnly() {
+        @SuppressWarnings("unchecked")
+        FieldSpec<T> spec = (FieldSpec<T>) NULL_ONLY;
+        return spec;
     }
 
     private final boolean nullable;
-    private final DistributedList<Object> whitelist;
-    private final Set<Object> blacklist;
-    private final TypedRestrictions restrictions;
+    private final DistributedList<T> whitelist;
+    private final Set<T> blacklist;
+    private final TypedRestrictions<T> restrictions;
 
     private FieldSpec(
-        DistributedList<Object> whitelist,
-        TypedRestrictions restrictions,
+        DistributedList<T> whitelist,
+        TypedRestrictions<T> restrictions,
         boolean nullable,
-        Set<Object> blacklist) {
+        Set<T> blacklist) {
         this.whitelist = whitelist;
         this.restrictions = restrictions;
         this.nullable = nullable;
@@ -64,11 +73,11 @@ public class FieldSpec {
         return nullable;
     }
 
-    public DistributedList<Object> getWhitelist() {
+    public DistributedList<T> getWhitelist() {
         return whitelist;
     }
 
-    public Set<Object> getBlacklist() {
+    public Set<T> getBlacklist() {
         return blacklist;
     }
 
@@ -76,12 +85,12 @@ public class FieldSpec {
         return restrictions;
     }
 
-    public FieldSpec withBlacklist(Set<Object> blacklist) {
-        return new FieldSpec(whitelist, restrictions, nullable, blacklist);
+    public FieldSpec<T> withBlacklist(Set<T> blacklist) {
+        return new FieldSpec<>(whitelist, restrictions, nullable, blacklist);
     }
 
-    public FieldSpec withNotNull() {
-        return new FieldSpec(whitelist, restrictions, false, blacklist);
+    public FieldSpec<T> withNotNull() {
+        return new FieldSpec<>(whitelist, restrictions, false, blacklist);
     }
 
     @Override
@@ -101,7 +110,7 @@ public class FieldSpec {
     /**
      * Create a predicate that returns TRUE for all (and only) values permitted by this FieldSpec
      */
-    public boolean permits(Object value) {
+    public boolean permits(T value) {
         if (blacklist.contains(value)){
             return false;
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -50,13 +50,13 @@ public class FieldSpecMerger {
         return combineRestrictions(left, right);
     }
 
-    private static WeightedElement<Object> mergeElements(WeightedElement<Object> left,
-                                                         WeightedElement<Object> right) {
+    private static <T> WeightedElement<T> mergeElements(WeightedElement<T> left,
+                                                         WeightedElement<T> right) {
         return new WeightedElement<>(left.element(), left.weight() + right.weight());
     }
 
-    private Optional<FieldSpec> mergeSets(FieldSpec left, FieldSpec right) {
-        DistributedList<Object> set = new DistributedList<>(left.getWhitelist().distributedList().stream()
+    private static <T> Optional<FieldSpec<T>> mergeSets(FieldSpec<T> left, FieldSpec<T> right) {
+        DistributedList<T> set = new DistributedList<>(left.getWhitelist().distributedList().stream()
             .flatMap(leftHolder -> right.getWhitelist().distributedList().stream()
                 .filter(rightHolder -> elementsEqual(leftHolder, rightHolder))
                 .map(rightHolder -> mergeElements(leftHolder, rightHolder)))
@@ -70,8 +70,8 @@ public class FieldSpecMerger {
         return left.element().equals(right.element());
     }
 
-    private Optional<FieldSpec> combineSetWithRestrictions(FieldSpec set, FieldSpec restrictions) {
-        DistributedList<Object> newSet = new DistributedList<>(
+    private static <T> Optional<FieldSpec<T>> combineSetWithRestrictions(FieldSpec<T> set, FieldSpec<T> restrictions) {
+        DistributedList<T> newSet = new DistributedList<>(
             set.getWhitelist().distributedList().stream()
                 .filter(holder -> restrictions.permits(holder.element()))
                 .distinct()
@@ -80,7 +80,7 @@ public class FieldSpecMerger {
         return addNullable(set, restrictions, FieldSpec.fromList(newSet));
     }
 
-    private Optional<FieldSpec> addNullable(FieldSpec left, FieldSpec right, FieldSpec newFieldSpec) {
+    private static <T> Optional<FieldSpec<T>> addNullable(FieldSpec<T> left, FieldSpec<T> right, FieldSpec<T> newFieldSpec) {
         if (isNullable(left, right)) {
             return Optional.of(newFieldSpec);
         }
@@ -92,7 +92,7 @@ public class FieldSpecMerger {
         return Optional.of(newFieldSpec.withNotNull());
     }
 
-    private boolean noAllowedValues(FieldSpec fieldSpec) {
+    private static <T> boolean noAllowedValues(FieldSpec<T> fieldSpec) {
         return (fieldSpec.getWhitelist() != null && fieldSpec.getWhitelist().isEmpty());
     }
 
@@ -100,12 +100,12 @@ public class FieldSpecMerger {
         return fieldSpec.getWhitelist() != null;
     }
 
-    private boolean isNullable(FieldSpec left, FieldSpec right) {
+    private static <T> boolean isNullable(FieldSpec<T> left, FieldSpec<T> right) {
         return left.isNullable() && right.isNullable();
     }
 
-    private Optional<FieldSpec> combineRestrictions(FieldSpec left, FieldSpec right) {
-        FieldSpec merged = restrictionMergeOperation.applyMergeOperation(left, right);
+    private <T> Optional<FieldSpec<T>> combineRestrictions(FieldSpec<T> left, FieldSpec<T> right) {
+        FieldSpec<T> merged = restrictionMergeOperation.applyMergeOperation(left, right);
 
         merged = merged.withBlacklist(SetUtils.union(left.getBlacklist(), right.getBlacklist()));
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
@@ -16,7 +16,6 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.common.profile.Types;
 import com.scottlogic.deg.generator.restrictions.*;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecValueGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecValueGeneratorTests.java
@@ -46,7 +46,7 @@ class FieldSpecValueGeneratorTests {
 
     @Test
     void generate_fieldSpecMustContainRestrictionNullAndSetRestrictionsHasValues_returnsDataBagsWithValuesInSetRestrictions() {
-        FieldSpec fieldSpec = FieldSpec.fromList(DistributedList.uniform(Arrays.asList(10, 20, 30)))
+        FieldSpec<Integer> fieldSpec = FieldSpec.fromList(DistributedList.uniform(Arrays.asList(10, 20, 30)))
             .withNotNull();
         FieldSpecValueGenerator fieldSpecFulfiller = new FieldSpecValueGenerator(
             INTERESTING,


### PR DESCRIPTION
### Description
Make FieldSpecs use generic. Note: ultimately this will not be useful as we will require an enum to reference our types to get rid of the casting entirely (or at least outside of I/O), but it makes the fieldspec significantly nicer to work with.

### Issue
Resolves #1301