### PR TITLE
chore(#0): added cucumber hooks for all constraints with typing

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InMap.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/InMap.feature
@@ -6,7 +6,7 @@ Feature: User can specify that a field value belongs to a set of predetermined o
 ### inMap alone ###
   Scenario: Running an 'inMap'
     Given the following fields exist:
-      |Home Nation |
+      |HomeNation  |
       |Capital     |
     And the file "testFile" contains the following data:
       |Country           |Capital    |
@@ -14,12 +14,12 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       |Northern Ireland  |Belfast    |
       |Scotland          |Edinburgh  |
       |Wales             |Cardiff    |
-    And Home Nation has type "string"
+    And HomeNation has type "string"
     And Capital has type "string"
-    And Home Nation is from Country in testFile
+    And HomeNation is from Country in testFile
     And Capital is from Capital in testFile
     Then the following data should be generated:
-      |Home Nation         |Capital      |
+      |HomeNation          |Capital      |
       |"England"           |"London"     |
       |"Northern Ireland"  |"Belfast"    |
       |"Scotland"          |"Edinburgh"  |
@@ -27,7 +27,7 @@ Feature: User can specify that a field value belongs to a set of predetermined o
 
   Scenario: Running an 'inMap' with text a restriction
     Given the following fields exist:
-      |Home Nation |
+      |HomeNation  |
       |Capital     |
     And the file "testFile" contains the following data:
       |Country           |Capital    |
@@ -35,25 +35,25 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       |Northern Ireland  |Belfast    |
       |Scotland          |Edinburgh  |
       |Wales             |Cardiff    |
-    And Home Nation has type "string"
+    And HomeNation has type "string"
     And Capital has type "string"
-    And Home Nation is from Country in testFile
+    And HomeNation is from Country in testFile
     And Capital is from Capital in testFile
     When Capital is matching regex /^[BE].*/
-    When Home Nation is matching regex /^[S].*/
+    When HomeNation is matching regex /^[S].*/
     Then the following data should be generated:
-      |Home Nation         |Capital      |
+      |HomeNation         |Capital      |
       |"Scotland"          |"Edinburgh"  |
 
 
   Scenario: Running an 'inMap' multiple maps
     Given the following fields exist:
-      |Home Nation |
+      |HomeNation  |
       |Capital     |
       |Foo         |
       |Bar         |
     And the combination strategy is exhaustive
-    And Home Nation is anything but null
+    And HomeNation is anything but null
     And Capital is anything but null
     And Foo is anything but null
     And Bar is anything but null
@@ -67,11 +67,11 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       |Foo   |Bar  |
       |1     |one  |
       |2     |two  |
-    And Home Nation has type "string"
+    And HomeNation has type "string"
     And Capital has type "string"
     And Foo has type "decimal"
     And Bar has type "string"
-    And Home Nation is from Country in testFile
+    And HomeNation is from Country in testFile
     And Capital is from Capital in testFile
     And Foo is from Foo in testFile2
     And Bar is from Bar in testFile2

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
@@ -7,7 +7,7 @@ Feature: User can specify that data must be created to conform to each of multip
     Given there is a field foo
     And All Of the next 2 constraints
     And All Of the next 2 constraints
-      And foo is matching regex "[a-b]{2}"
+      And foo is matching regex /[a-b]{2}/
       And foo is of length 2
     And foo is shorter than 3
     And foo has type "string"
@@ -24,8 +24,8 @@ Feature: User can specify that data must be created to conform to each of multip
     And foo has type "string"
     And All Of the next 2 constraints
     And All Of the next 2 constraints
-      And foo is matching regex "[a-k]{3}"
-      And foo is matching regex "[1-5]{3}"
+      And foo is matching regex /[a-k]{3}/
+      And foo is matching regex /[1-5]{3}/
     And foo is longer than 4
     Then the following data should be generated:
       | foo  |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AnyOf.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AnyOf.feature
@@ -13,7 +13,7 @@ Feature: Values can be specified by using any of to set multiple constraints
       | "Test3" |
       | "Test4" |
       | "Test5" |
-    And foo is matching regex "[a-b]{4}"
+    And foo is matching regex /[a-b]{4}/
     And foo has type "string"
     And foo is anything but null
     Then the following data should be generated:
@@ -50,7 +50,7 @@ Feature: Values can be specified by using any of to set multiple constraints
         | "Test3" |
         | "Test4" |
         | "Test5" |
-      And foo is matching regex "[a-b]{4}"
+      And foo is matching regex /[a-b]{4}/
     And Any Of the next 2 constraints
     And foo is equal to "Test6"
     And foo is in set:

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/If.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/If.feature
@@ -529,7 +529,7 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "string"
     And bar has type "string"
     When If Then and Else are described below
-    And foo is matching regex "[a-z]{1}"
+    And foo is matching regex /[a-z]{1}/
     And bar is equal to "AA"
     And bar is equal to "10"
     Then the following data should be generated:
@@ -556,7 +556,7 @@ Feature: Values can be specified by using if, then and else constraints
     And bar has type "string"
     When If Then and Else are described below
     And foo is equal to "1"
-    And bar is matching regex "[A-Z]{2}"
+    And bar is matching regex /[A-Z]{2}/
     And bar is equal to "10"
     Then the following data should be generated:
       | foo | bar  |
@@ -584,7 +584,7 @@ Feature: Values can be specified by using if, then and else constraints
     When If Then and Else are described below
     And foo is equal to "1"
     And bar is equal to "AA"
-    And bar is matching regex "[0-9]{2}"
+    And bar is matching regex /[0-9]{2}/
     Then the following data should be generated:
       | foo | bar  |
       | "1" | "AA" |
@@ -611,7 +611,7 @@ Feature: Values can be specified by using if, then and else constraints
       | "BB" |
     And bar is anything but null
     When If Then and Else are described below
-    And foo is matching regex "[0-9]{2}"
+    And foo is matching regex /[0-9]{2}/
     And bar is equal to "AA"
     And bar is equal to "10"
     Then the following data should be generated:
@@ -638,7 +638,7 @@ Feature: Values can be specified by using if, then and else constraints
     And bar has type "string"
     When If Then and Else are described below
     And foo is equal to "a"
-    And bar is matching regex "C"
+    And bar is matching regex /C/
     And bar is equal to "10"
     Then the following data should be generated:
       | foo | bar  |
@@ -664,7 +664,7 @@ Feature: Values can be specified by using if, then and else constraints
     When If Then and Else are described below
     And foo is equal to "a"
     And bar is equal to "BB"
-    And bar is matching regex "WRONG"
+    And bar is matching regex /WRONG/
     Then the following data should be generated:
       | foo | bar  |
       | "a" | "BB" |
@@ -685,7 +685,7 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "string"
     And bar has type "string"
     When If Then and Else are described below
-    And foo is containing regex "[1]{1}"
+    And foo is containing regex /[1]{1}/
     And bar is equal to "AA"
     And bar is equal to "10"
     Then the following data should be generated:
@@ -712,7 +712,7 @@ Feature: Values can be specified by using if, then and else constraints
     And bar is anything but null
     When If Then and Else are described below
     And foo is equal to "1"
-    And bar is containing regex "[0]{1}"
+    And bar is containing regex /[0]{1}/
     And bar is equal to "AA"
     Then the following data should be generated:
       | foo  | bar  |
@@ -740,7 +740,7 @@ Feature: Values can be specified by using if, then and else constraints
     When If Then and Else are described below
     And foo is equal to "1"
     And bar is equal to "BB"
-    And bar is containing regex "[0]{1}"
+    And bar is containing regex /[0]{1}/
     Then the following data should be generated:
       | foo  | bar  |
       | "1"  | "BB" |
@@ -767,7 +767,7 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "string"
     And bar has type "string"
     When If Then and Else are described below
-    And foo is containing regex "[🚫]{1}"
+    And foo is containing regex /[🚫]{1}/
     And bar is equal to "AA"
     And bar is equal to "10"
     Then the following data should be generated:
@@ -794,7 +794,7 @@ Feature: Values can be specified by using if, then and else constraints
     And bar has type "string"
     When If Then and Else are described below
     And foo is equal to "1"
-    And bar is containing regex "[🚫]{1}"
+    And bar is containing regex /[🚫]{1}/
     And bar is equal to "10"
     Then the following data should be generated:
       | foo  | bar  |
@@ -820,7 +820,7 @@ Feature: Values can be specified by using if, then and else constraints
     When If Then and Else are described below
     And foo is equal to "1"
     And bar is equal to "10"
-    And bar is containing regex "[🚫]{1}"
+    And bar is containing regex /[🚫]{1}/
     Then the following data should be generated:
       | foo | bar  |
       | "1" | "10" |
@@ -1815,9 +1815,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is after "2018-01-02T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is after 2018-01-02T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-05T00:00:00.000Z |
@@ -1846,9 +1846,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-02-01T00:00:00.000Z"
-    And bar is after "2010-01-04T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
+    And foo is equal to 2018-02-01T00:00:00.000Z
+    And bar is after 2010-01-04T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -1877,9 +1877,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is after "2010-01-04T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is after 2010-01-04T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -1908,9 +1908,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is after "2020-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-04T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is after 2020-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-04T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-02-01T00:00:00.000Z | 2010-01-04T00:00:00.000Z |
@@ -1938,9 +1938,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is after "2020-01-01T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is after 2020-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -1964,9 +1964,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is after or at "2018-05-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
+    And foo is after or at 2018-05-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -1995,9 +1995,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-05-01T00:00:00.000Z"
-    And bar is after or at "2010-01-04T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
+    And foo is equal to 2018-05-01T00:00:00.000Z
+    And bar is after or at 2010-01-04T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2027,9 +2027,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-06-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is after or at "2010-01-04T00:00:00.000Z"
+    And foo is equal to 2018-06-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is after or at 2010-01-04T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-04T00:00:00.000Z |
@@ -2063,9 +2063,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is after or at "2020-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is after or at 2020-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-02-01T00:00:00.000Z | 2010-01-05T00:00:00.000Z |
@@ -2093,9 +2093,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is after or at "2020-01-05T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is after or at 2020-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2119,9 +2119,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is before "2018-02-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is before 2018-02-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2150,9 +2150,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is before "2010-01-03T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is before 2010-01-03T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2182,9 +2182,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
-    And bar is before "2010-01-03T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
+    And bar is before 2010-01-03T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-05T00:00:00.000Z |
@@ -2218,9 +2218,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is before "2010-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-03T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is before 2010-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-03T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-02-01T00:00:00.000Z | 2010-01-03T00:00:00.000Z |
@@ -2248,9 +2248,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is before "2010-01-01T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is before 2010-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2274,9 +2274,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is before or at "2018-02-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is before or at 2018-02-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2305,9 +2305,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is before or at "2010-01-03T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is before or at 2010-01-03T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |
@@ -2338,9 +2338,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-05T00:00:00.000Z"
-    And bar is before or at "2010-01-03T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-05T00:00:00.000Z
+    And bar is before or at 2010-01-03T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-05T00:00:00.000Z |
@@ -2379,9 +2379,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is before or at "2009-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-03T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is before or at 2009-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-03T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-02-01T00:00:00.000Z | 2010-01-03T00:00:00.000Z |
@@ -2409,9 +2409,9 @@ Feature: Values can be specified by using if, then and else constraints
     And foo has type "datetime"
     And bar has type "datetime"
     When If Then and Else are described below
-    And foo is equal to "2018-01-01T00:00:00.000Z"
-    And bar is equal to "2010-01-01T00:00:00.000Z"
-    And bar is before or at "2009-01-01T00:00:00.000Z"
+    And foo is equal to 2018-01-01T00:00:00.000Z
+    And bar is equal to 2010-01-01T00:00:00.000Z
+    And bar is before or at 2009-01-01T00:00:00.000Z
     Then the following data should be generated:
       | foo                      | bar                      |
       | 2018-01-01T00:00:00.000Z | 2010-01-01T00:00:00.000Z |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/GranularTo-Decimal.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/GranularTo-Decimal.feature
@@ -42,20 +42,6 @@ Feature: User can specify that decimal fields are granular to a certain number o
       | -0.9 |
       | -1   |
 
-  Scenario: User attempts to create a numeric field with data value that include a decimal value to one decimal point incorrectly using a string to set the granularity
-    Given foo is granular to "0.1"
-    And foo is greater than 0
-    And foo is less than 0.2
-    Then the following data should be generated:
-      | foo  |
-      | 0.1  |
-
-  Scenario: Running a 'granularTo' request that specifies null should be unsuccessful
-    Given foo is granular to null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
-
   Scenario: Running granularTo against a non contradicting granularTo should be successful
     Given foo is granular to 1
     And foo is granular to 1

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/LessThan.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/LessThan.feature
@@ -5,21 +5,6 @@ Feature: User can specify that a numeric value is lower than, but not equal to, 
     And there is a field foo
     And foo has type "decimal"
 
-  Scenario: Running a 'lessThan' request that specifies a string should be unsuccessful
-    Given foo is less than "bar"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Number but was a String with value `bar`"
-    And no data is created
-
-  Scenario: Running a 'lessThan' request that specifies an empty string should be unsuccessful
-    Given foo is less than ""
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Number but was a String with value ``"
-    And no data is created
-
-  Scenario: Running a 'lessThan' request that specifies null should be unsuccessful
-    Given foo is less than null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: lessThan run against a non contradicting not lessThan should be successful (lessThan 5 AND not lessThan 1)
     Given foo is less than 5
     And foo is anything but less than 1

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/LessThanOrEqualTo.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/numeric/LessThanOrEqualTo.feature
@@ -4,24 +4,6 @@ Feature: User can specify that a numeric value is lower than, or equal to, a spe
     Given the generation strategy is full
     And there is a field foo
 
-  Scenario: Running a 'lessThanOrEqualTo' request that includes a string should fail
-    Given foo is less than or equal to "Zero"
-    And foo has type "integer"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Number but was a String with value `Zero`"
-    And no data is created
-
-  Scenario: Running a 'lessThanOrEqualTo' request that includes an empty string should fail
-    Given foo is less than or equal to ""
-    And foo has type "integer"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Number but was a String with value ``"
-    And no data is created
-
-  Scenario: Running a 'lessThanOrEqualTo' request that specifies null should be unsuccessful
-    Given foo is less than or equal to null
-    And foo has type "integer"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: lessThanOrEqualTo run against a non contradicting not lessThanOrEqualToOrEqualTo should be successful
     Given foo is less than or equal to 5
     And foo is anything but less than or equal to 3

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ContainingRegex.feature
@@ -155,31 +155,6 @@ Feature: User can specify that contains a specified regex
       | null |
       | "a"  |
 
-  Scenario: Running a 'containingRegex' for a maximum length smaller than the minimum length should fail with an error
-    Given foo is containing regex /[a]{1,0}/
-    Then the profile is invalid because "Field \[foo\]: Illegal repetition range near index 7\r?\n\[a\]\{1,0\}\r?\n       \^"
-    And no data is created
-
-  Scenario: Running a 'containingRegex' for a minimum length of a decimal value should fail with an error
-    Given foo is containing regex /[a]{1.1}/
-    Then the profile is invalid because "Field \[foo\]: Unclosed counted closure near index 5\r?\n\[a\]\{1.1\}\r?\n     \^"
-    And no data is created
-
-  Scenario: Running a 'containingRegex' for a minimum length that is less zero should fail with an error message
-    Given foo is containing regex /[a]{-1}/
-    Then the profile is invalid because "Field \[foo\]: Illegal repetition near index [24]\r?\n\[a\]\{-1\}\r?\n {2,4}\^"
-    And no data is created
-
-  Scenario: Running a 'containingRegex' for an empty value should fail with an error message
-    Given foo is containing regex /[]{}/
-    Then the profile is invalid because "Field \[foo\]: Unclosed character class near index 3\r?\n\[\]\{\}\r?\n   \^"
-    And no data is created
-
-  Scenario: Running a 'containingRegex' request with the value property set to a null entry (null) should throw an error
-    Given foo is containing regex null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: containingRegex run against a non contradicting containingRegex should be successful
     Given foo is containing regex /[b]{2}/
     And foo is containing regex /[a-z]{1,3}/

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/LongerThan.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/LongerThan.feature
@@ -31,31 +31,6 @@ Feature: User can specify that a string length is longer than, a specified numbe
     Then the profile is invalid because "Field \[foo\]: longerThan constraint must have an operand/value >= 0, currently is -5"
     And no data is created
 
-  Scenario: 'longerThan' a decimal number with an non-zero mantissa should fail with an error message
-    Given foo is longer than 1.1
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an integer but was a decimal with value `1.1`"
-    And no data is created
-
-  Scenario: 'longerThan' a string should fail with an error message
-    Given foo is longer than "Test"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value `Test`"
-    And no data is created
-
-  Scenario: 'longerThan' an empty string should fail with an error message
-    Given foo is longer than ""
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value ``"
-    And no data is created
-
-  Scenario: 'longerThan' whitespace should fail with an error message
-    Given foo is longer than " "
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value ` `"
-    And no data is created
-
-  Scenario: 'longerThan' null should fail with an error message
-    Given foo is longer than null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: Multiple non-contradictory 'longerThan' requests should be successful
     Given foo is longer than 2
     And foo is longer than 1

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/MatchingRegex.feature
@@ -184,26 +184,6 @@ Feature: User can specify that a value either matches or contains a specified re
       | ""   |
       | "a"  |
 
-  Scenario: Running a 'matchingRegex' for a maximum length smaller than the minimum length should fail with an error
-    Given foo is matching regex /[a]{1,0}/
-    Then the profile is invalid because "Field \[foo\]: Illegal repetition range near index 7\r?\n\[a\]\{1,0\}\r?\n       \^"
-    And no data is created
-
-  Scenario: Running a 'matchingRegex' for a minimum length of a decimal value should fail with an error
-    Given foo is matching regex /[a]{1.1}/
-    Then the profile is invalid because "Field \[foo\]: Unclosed counted closure near index 5\r?\n\[a\]\{1.1\}\r?\n     \^"
-    And no data is created
-
-  Scenario: Running a 'matchingRegex' for a minimum length that is less zero should fail with an error message
-    Given foo is matching regex /[a]{-1}/
-    Then the profile is invalid because "Field \[foo\]: Illegal repetition near index [24]\r?\n\[a\]\{-1\}\r?\n {2,4}\^"
-    And no data is created
-
-  Scenario: Running a 'matchingRegex' with an empty regex should fail with an error message
-    Given foo is matching regex /[]{}/
-    Then the profile is invalid because "Field \[foo\]: Unclosed character class near index 3\r?\n\[\]\{\}\r?\n   \^"
-    And no data is created
-
   Scenario: User using matchingRegex operator to provide an exact set of values
     Given foo is matching regex /[a]{1,3}/
     And foo is anything but null

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/OfLength.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/OfLength.feature
@@ -68,35 +68,6 @@ Feature: User can specify the length of generated string data using 'ofLength'
       | 1.000000001 |
       | 1.9         |
 
-  Scenario Outline: Running an 'ofLength' request that includes a value that is not a valid number should fail with an error
-    Given foo is of length <length>
-    And foo is in set:
-      | "a" |
-    Then the profile is invalid because "(Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value `.*`)|(Field \[foo\]: Cannot create an StringHasLengthConstraint for field 'foo' with a a negative length.)|(Field \[foo\]: ofLength constraint must have an operand/value >= 0, currently is -?\d+)"
-    And no data is created
-    Examples:
-      | length                    |
-      | -1                        |
-      | "1"                       |
-      | "1.1"                     |
-      | "1,000"                   |
-      | "100,00"                  |
-      | "010"                     |
-      | "£1.00"                   |
-      | "-1"                      |
-      | "+1"                      |
-      | "Infinity"                |
-      | "NaN"                     |
-      | "nil"                     |
-      | "$1.00"                   |
-      | "1E+02"                   |
-      | "001 000"                 |
-      | "2010-01-01T00:00:00.000" |
-      | "2010-01-01T00:00"        |
-      | "1st Jan 2010"            |
-      | "a"                       |
-      | ""                        |
-
 # COMBINATION OF CONSTRAINTS #
 
   Scenario: ofLength run against a non contradicting ofLength should be successful

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ShorterThan.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/string/ShorterThan.feature
@@ -27,26 +27,6 @@ Feature: User can specify that a string length is lower than, a specified number
     Then the profile is invalid because "Field \[foo\]: shorterThan constraint must have an operand/value >= 0, currently is -1"
     And no data is created
 
-  Scenario: Running a 'shorterThan' request using a number (decimal number) to specify a the length of a generated string should fail with an error message
-    Given foo is shorter than 1.1
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an integer but was a decimal with value `1.1`"
-    And no data is created
-
-  Scenario: Running a 'shorterThan' request using a string (number) to specify a the length of a generated string should fail with an error message
-    Given foo is shorter than "5"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value `5`"
-    And no data is created
-
-  Scenario: Running a 'shorterThan' request using an empty string "" to specify a the length of a generated string field should fail with an error message
-    Given foo is shorter than ""
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be an Integer but was a String with value ``"
-    And no data is created
-
-  Scenario: Running a 'shorterThan' request using null to specify a the length of a generated string field should fail with an error message
-    Given foo is shorter than null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: shorterThan run against a non contradicting shorterThan should be successful
     Given foo is shorter than 4
     And foo is shorter than 3

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/Before.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/Before.feature
@@ -93,11 +93,6 @@ Feature: User can specify that a datetime date is lower than, but not equal to, 
       | foo  |
       | null |
 
-  Scenario: Running a 'before' request that specifies null should be unsuccessful
-    Given foo is before null
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
-    And no data is created
-
   Scenario: Running a 'before' request that specifies the highest valid system date should be unsuccessful
     Given foo is before 0000-01-01T00:00:00.000Z
     Then the profile is invalid because "Field \[foo\]: Dates must be between 0001-01-01T00:00:00.000Z and 9999-12-31T23:59:59.999Z"

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/validation/CorrectConstraintTypes.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/validation/CorrectConstraintTypes.feature
@@ -40,8 +40,8 @@ Feature: Correct Constraint Types, validation exceptions should be raised if the
 
       | decimal | granularTo            | DATETIME  | granular to "seconds"             | NUMERIC   |
 
-      | decimal | matchingRegex         | STRING    | matching regex "ab"               | NUMERIC   |
-      | decimal | containingRegex       | STRING    | containing regex "ab"             | NUMERIC   |
+      | decimal | matchingRegex         | STRING    | matching regex /ab/               | NUMERIC   |
+      | decimal | containingRegex       | STRING    | containing regex /ab/             | NUMERIC   |
       | decimal | ofLength              | STRING    | of length 3                       | NUMERIC   |
       | decimal | shorterThan           | STRING    | shorter than 3                    | NUMERIC   |
       | decimal | longerThan            | STRING    | longer than 3                     | NUMERIC   |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/BooleanValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/BooleanValueStep.java
@@ -16,6 +16,8 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
+import com.scottlogic.deg.generator.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.When;
 
@@ -25,10 +27,11 @@ public class BooleanValueStep {
         this.state = state;
     }
 
-    @When("{fieldVar} is {operator} {boolean}")
-    public void whenFieldIsConstrainedByNumericValue(String fieldName, String constraintName, Boolean value) {
-        this.state.addConstraint(fieldName, constraintName, value);
+    @When("{fieldVar} is equal to {boolean}")
+    public void whenFieldIsConstrainedByNumericValue(String fieldName, Boolean value) {
+        this.state.addConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), value);
     }
+
 
     @When("{fieldVar} is anything but {operator} {boolean}")
     public void whenFieldIsNotConstrainedByNumericValue(String fieldName, String constraintName, Boolean value) {

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateValueStep.java
@@ -17,6 +17,7 @@
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
 import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
+import com.scottlogic.deg.generator.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.GeneratorTestUtilities;
@@ -38,14 +39,64 @@ public class DateValueStep {
         this.helper = helper;
     }
 
-    @When("{fieldVar} is {operator} {date}")
-    public void whenFieldIsConstrainedByDateValue(String fieldName, String constraintName, String value) {
-        state.addConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is equal to ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void equalToDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), value);
     }
 
-    @When("{fieldVar} is anything but {operator} {date}")
-    public void whenFieldIsNotConstrainedByDateValue(String fieldName, String constraintName, String value) {
-        state.addNotConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is after ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void afterDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_AFTER_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is after or at ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void afterOrAtDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_AFTER_OR_EQUAL_TO_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is before ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void beforeDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_BEFORE_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is before or at ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void beforeOrAtDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_BEFORE_OR_EQUAL_TO_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is granular to \"(.*)\"$")
+    public void granularToDateValue(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_GRANULAR_TO.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but equal to ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void notEqualToDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but after ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void notAfterDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_AFTER_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but after or at ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void notAfterOrAtDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_AFTER_OR_EQUAL_TO_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but before ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void notBeforeDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_BEFORE_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but before or at ([0-9]{4,5}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z?)$")
+    public void notBeforeOrAtDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_BEFORE_OR_EQUAL_TO_CONSTANT_DATE_TIME.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is anything but granular to \"(.*)\"$")
+    public void notGranularToDateValue(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_GRANULAR_TO.getText(), value);
     }
 
     @And("^(.+) is after field ([A-z0-9]+)$")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NullValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NullValueStep.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.Then;
@@ -33,9 +34,9 @@ public class NullValueStep {
         this.helper = helper;
     }
 
-    @When("{fieldVar} is {operator} null")
-    public void whenFieldIsConstrainedByTextValue(String fieldName, String constraintName) {
-        state.addConstraint(fieldName, constraintName, null);
+    @When("{fieldVar} is equal to null")
+    public void whenFieldIsConstrainedByTextValue(String fieldName) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), null);
     }
 
     @When("{fieldVar} is anything but {operator} null")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NumericValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/NumericValueStep.java
@@ -21,12 +21,12 @@ import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTest
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
 
 import java.math.BigDecimal;
 import java.util.function.Function;
 
 import static com.scottlogic.deg.common.util.NumberUtils.coerceToBigDecimal;
+import static com.scottlogic.deg.common.util.NumberUtils.tryParse;
 
 public class NumericValueStep {
 
@@ -38,23 +38,73 @@ public class NumericValueStep {
         this.helper = helper;
     }
 
-    @When("{fieldVar} is {operator} {number}")
-    public void whenFieldIsConstrainedByNumericValue(String fieldName, String constraintName, Number value) {
-        state.addConstraint(fieldName, constraintName, value);
+    @And("^([A-z0-9]+) is equal to (-?[0-9\\.]+)$")
+    public void equalToNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), tryParse(value));
     }
 
-    @When("{fieldVar} is anything but {operator} {number}")
-    public void whenFieldIsNotConstrainedByNumericValue(String fieldName, String constraintName, Number value) {
-        state.addNotConstraint(fieldName, constraintName, value);
+    @And("^([A-z0-9]+) is greater than (-?[0-9\\.]+)$")
+    public void greaterThanNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_GREATER_THAN_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is greater than or equal to (-?[0-9\\.]+)$")
+    public void greaterThanOrEqualNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_GREATER_THAN_OR_EQUAL_TO_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is less than (-?[0-9\\.]+)$")
+    public void lessThanNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_LESS_THAN_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is less than or equal to (-?[0-9\\.]+)$")
+    public void lessThanOrEqualNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_LESS_THAN_OR_EQUAL_TO_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is granular to ([0-9\\.]+)$")
+    public void granularToNumber(String field, String value){
+        state.addConstraint(field, AtomicConstraintType.IS_GRANULAR_TO.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but equal to (-?[0-9\\.]+)$")
+    public void notEqualToNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but greater than (-?[0-9\\.]+)$")
+    public void notGreaterThanNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_GREATER_THAN_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but greater than or equal to (-?[0-9\\.]+)$")
+    public void notGreaterThanOrEqualNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_GREATER_THAN_OR_EQUAL_TO_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but less than (-?[0-9\\.]+)$")
+    public void notLessThanNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_LESS_THAN_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but less than or equal to (-?[0-9\\.]+)$")
+    public void notLessThanOrEqualNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_LESS_THAN_OR_EQUAL_TO_CONSTANT.getText(), tryParse(value));
+    }
+
+    @And("^([A-z0-9]+) is anything but granular to ([0-9\\.]+)$")
+    public void notGranularToNumber(String field, String value){
+        state.addNotConstraint(field, AtomicConstraintType.IS_GRANULAR_TO.getText(), tryParse(value));
     }
 
     @And("^(.+) is greater than field ([A-z0-9]+)$")
-    public void numericGreater(String field, String otherField){
+    public void numericGreater(String field, String otherField) {
         state.addRelationConstraint(field, AtomicConstraintType.IS_GREATER_THAN_CONSTANT.getText(), otherField);
     }
 
     @And("^(.+) is less than field ([A-z0-9]+)$")
-    public void numericLess(String field, String otherField){
+    public void numericLess(String field, String otherField) {
         state.addRelationConstraint(field, AtomicConstraintType.IS_LESS_THAN_CONSTANT.getText(), otherField);
     }
 
@@ -64,7 +114,7 @@ public class NumericValueStep {
     }
 
     @And("^(.+) is less than or equal to field ([A-z0-9]+)$")
-    public void numericLessEqual(String field, String otherField){
+    public void numericLessEqual(String field, String otherField) {
         state.addRelationConstraint(field, AtomicConstraintType.IS_LESS_THAN_OR_EQUAL_TO_CONSTANT.getText(), otherField);
     }
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/RegexValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/RegexValueStep.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.Then;
@@ -33,14 +34,24 @@ public class RegexValueStep {
         this.helper = helper;
     }
 
-    @When("{fieldVar} is {operator} {regex}")
-    public void whenFieldIsConstrainedByRegex(String fieldName, String constraintName, String value) throws Exception {
-        this.state.addConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is matching regex /(.+)/$")
+    public void matchingRegexString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.MATCHES_REGEX.getText(), Pattern.compile(value));
     }
 
-    @When("{fieldVar} is anything but {operator} {regex}")
-    public void whenFieldIsNotConstrainedByRegex(String fieldName, String constraintName, String value) throws Exception {
-        this.state.addNotConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is anything but matching regex /(.+)/$")
+    public void notMatchingRegexString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.MATCHES_REGEX.getText(), Pattern.compile(value));
+    }
+
+    @When("^([A-z0-9]+) is containing regex /(.+)/$")
+    public void containingRegexString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.CONTAINS_REGEX.getText(), Pattern.compile(value));
+    }
+
+    @When("^([A-z0-9]+) is anything but containing regex /(.+)/$")
+    public void notContainingRegexString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.CONTAINS_REGEX.getText(), Pattern.compile(value));
     }
 
     @Then("{fieldVar} contains strings matching {regex}")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/SetValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/SetValueStep.java
@@ -29,12 +29,12 @@ public class SetValueStep {
         this.state = state;
     }
 
-    @When("{fieldVar} is in set:")
+    @When("^([A-z0-9]+) is in set:")
     public void whenFieldIsConstrainedBySetValue(String fieldName, List<Object> values) {
         this.state.addConstraint(fieldName, "in set", values);
     }
 
-    @When("{fieldVar} is anything but in set:")
+    @When("^([A-z0-9]+) is anything but in set:")
     public void whenFieldIsNotConstrainedBySetValue(String fieldName, List<Object> values) {
         this.state.addNotConstraint(fieldName, "in set", values);
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/SetValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/SetValueStep.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.When;
 
@@ -31,11 +32,11 @@ public class SetValueStep {
 
     @When("^([A-z0-9]+) is in set:")
     public void whenFieldIsConstrainedBySetValue(String fieldName, List<Object> values) {
-        this.state.addConstraint(fieldName, "in set", values);
+        this.state.addConstraint(fieldName, AtomicConstraintType.IS_IN_SET.getText(), values);
     }
 
     @When("^([A-z0-9]+) is anything but in set:")
     public void whenFieldIsNotConstrainedBySetValue(String fieldName, List<Object> values) {
-        this.state.addNotConstraint(fieldName, "in set", values);
+        this.state.addNotConstraint(fieldName, AtomicConstraintType.IS_IN_SET.getText(), values);
     }
 }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/StringValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/StringValueStep.java
@@ -16,12 +16,16 @@
 
 package com.scottlogic.deg.orchestrator.cucumber.testframework.steps;
 
+import com.scottlogic.deg.common.profile.constraintdetail.AtomicConstraintType;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestHelper;
 import com.scottlogic.deg.orchestrator.cucumber.testframework.utils.CucumberTestState;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
 import java.util.function.Function;
+
+import static com.scottlogic.deg.common.util.NumberUtils.tryParse;
+import static java.lang.Integer.parseInt;
 
 public class StringValueStep {
 
@@ -33,14 +37,44 @@ public class StringValueStep {
         this.helper = helper;
     }
 
-    @When("{fieldVar} is {operator} {string}")
-    public void whenFieldIsConstrainedByTextValue(String fieldName, String constraintName, String value) throws Exception {
-        state.addConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is equal to \"(.*)\"$")
+    public void equalToString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), value);
     }
 
-    @When("{fieldVar} is anything but {operator} {string}")
-    public void whenFieldIsNotConstrainedByTextValue(String fieldName, String constraintName, String value) throws Exception {
-        state.addNotConstraint(fieldName, constraintName, value);
+    @When("^([A-z0-9]+) is anything but equal to \"(.*)\"$")
+    public void notEqualToString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_EQUAL_TO_CONSTANT.getText(), value);
+    }
+
+    @When("^([A-z0-9]+) is shorter than (-?[0-9\\.]+)$")
+    public void shorterThanString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_STRING_SHORTER_THAN.getText(), parseInt(value));
+    }
+
+    @When("^([A-z0-9]+) is anything but shorter than (-?[0-9\\.]+)$")
+    public void notShorterThanString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_STRING_SHORTER_THAN.getText(), parseInt(value));
+    }
+
+    @When("^([A-z0-9]+) is longer than (-?[0-9\\.]+)$")
+    public void longerThanString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.IS_STRING_LONGER_THAN.getText(), parseInt(value));
+    }
+
+    @When("^([A-z0-9]+) is anything but longer than (-?[0-9\\.]+)$")
+    public void notLongerThanString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.IS_STRING_LONGER_THAN.getText(), tryParse(value));
+    }
+
+    @When("^([A-z0-9]+) is of length (-?[0-9\\.]+)$")
+    public void ofLengthString(String fieldName, String value) {
+        state.addConstraint(fieldName, AtomicConstraintType.HAS_LENGTH.getText(), tryParse(value));
+    }
+
+    @When("^([A-z0-9]+) is anything but of length (-?[0-9\\.]+)$")
+    public void notOfLengthString(String fieldName, String value) {
+        state.addNotConstraint(fieldName, AtomicConstraintType.HAS_LENGTH.getText(), tryParse(value));
     }
 
     @Then("{fieldVar} contains only string data")

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
@@ -122,7 +122,7 @@ public class CucumberTestState {
     private ConstraintDTO createConstraint(String fieldName, String constraintName, Object value) {
         ConstraintDTO dto = new ConstraintDTO();
         dto.field = fieldName;
-        dto.is = this.extractConstraint(constraintName);
+        dto.is = constraintName;
         if (value != null){
             if (value instanceof String) {
                 dto.value = value;
@@ -212,15 +212,6 @@ public class CucumberTestState {
                     break;
             }
         }
-    }
-
-    private String extractConstraint(String gherkinConstraint) {
-        List<String> allConstraints = Arrays.asList(gherkinConstraint.split(" "));
-        return allConstraints.get(0) + allConstraints
-            .stream()
-            .skip(1)
-            .map(value -> value.substring(0, 1).toUpperCase() + value.substring(1))
-            .collect(Collectors.joining());
     }
 
     private void addConstraintToList(ConstraintDTO constraintDTO) {


### PR DESCRIPTION
### Description

Updated cucumber hooks to be less permissive so a developer can go to the step when viewing a feature file. 

There is a new hook for each constraint that is typed so the type is correct when making the constraint. Due to this I've had to removed the tests that where testing for incorrect types on constraints, these should be recreated as unit tests.
