### PR TITLE
chore(#0) stop visualiser writing to files when running tests

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/visualiser/VisualiserWriterFactoryTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/visualiser/VisualiserWriterFactoryTest.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.generation.visualiser;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -10,12 +11,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class VisualiserWriterFactoryTest {
+    @TempDir
+    File tempDir;
 
     @Test
     void create_validPath_expectSuccess() throws Exception {
-        VisualiserWriterFactory writerFactory = new VisualiserWriterFactory(new File(".").toPath());
+        VisualiserWriterFactory writerFactory = new VisualiserWriterFactory(tempDir.toPath());
         Writer result = writerFactory.create("destination");
         assertNotNull(result);
+        result.close();
     }
 
     @Test


### PR DESCRIPTION
### Description
When running the tests, VisualiserWriterFactory was creating a file called `destination.dot` and not clearing up.  This PR uses a tempory directory to make sure the file is cleaned up.

### Changes
Use a temporary directory in the VisualiserWriterFactortyTests.


### Issue
Related to #1322

