### PR TITLE
1472 tidy up constraint types

### DIFF
--- a/profile/src/main/java/com/scottlogic/deg/profile/ConstraintDeserializer.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/ConstraintDeserializer.java
@@ -24,7 +24,7 @@ public class ConstraintDeserializer extends JsonDeserializer<ConstraintDTO> {
             .findFirst()
             .orElseThrow(() -> new InvalidProfileException("The constraint json object node" + fieldName +
                 " doesn't contain any of the expected keywords as " + "properties: " + node));
-        if (!node.hasNonNull(type.propertyName)) {
+        if (hasNull(node, type)) {
             throw new InvalidProfileException("The " + type.propertyName + " constraint has null value" + fieldName);
         }
         switch (type) {
@@ -98,5 +98,9 @@ public class ConstraintDeserializer extends JsonDeserializer<ConstraintDTO> {
             default:
                 throw new IllegalStateException("Unexpected value: " + type);
         }
+    }
+
+    private boolean hasNull(ObjectNode node, ConstraintType constraintType) {
+        return !node.hasNonNull(constraintType.propertyName);
     }
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/AtomicConstraintReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/AtomicConstraintReader.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.profile.reader;
+
+import com.google.inject.Inject;
+import com.scottlogic.deg.common.profile.*;
+import com.scottlogic.deg.common.util.NumberUtils;
+import com.scottlogic.deg.generator.fieldspecs.relations.InMapRelation;
+import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
+import com.scottlogic.deg.generator.profile.constraints.Constraint;
+import com.scottlogic.deg.generator.profile.constraints.atomic.*;
+import com.scottlogic.deg.profile.dtos.constraints.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class AtomicConstraintReader {
+
+    private final FileReader fileReader;
+
+    @Inject
+    public AtomicConstraintReader(FileReader fileReader) {
+        this.fileReader = fileReader;
+    }
+
+    public Constraint readAtomicConstraintDto(AtomicConstraintDTO dto, ProfileFields profileFields) {
+        Field field = profileFields.getByName(dto.field);
+        switch (dto.getType()) {
+            case EQUAL_TO:
+                return new EqualToConstraint(field, readAnyType(field, ((EqualToConstraintDTO) dto).value));
+            case IN_SET:
+                InSetConstraintDTO inSetConstraintDTO = (InSetConstraintDTO) dto;
+                return new IsInSetConstraint(field, prepareValuesForSet(inSetConstraintDTO, field));
+            case IN_MAP:
+                InMapConstraintDTO inMapConstraintDTO = (InMapConstraintDTO) dto;
+                return new InMapRelation(field, profileFields.getByName(inMapConstraintDTO.file),
+                    DistributedList.uniform(fileReader.listFromMapFile(inMapConstraintDTO.file, inMapConstraintDTO.key).stream()
+                        .map(value -> readAnyType(field, value))
+                        .collect(Collectors.toList())));
+            case MATCHES_REGEX:
+                return new MatchesRegexConstraint(field, readPattern(((MatchesRegexConstraintDTO) dto).value));
+            case CONTAINS_REGEX:
+                return new ContainsRegexConstraint(field, readPattern(((ContainsRegexConstraintDTO) dto).value));
+            case OF_LENGTH:
+                return new StringHasLengthConstraint(field, HelixStringLength.create(((OfLengthConstraintDTO) dto).value));
+            case SHORTER_THAN:
+                return new IsStringShorterThanConstraint(field, HelixStringLength.create(((ShorterThanConstraintDTO) dto).value));
+            case LONGER_THAN:
+                return new IsStringLongerThanConstraint(field, HelixStringLength.create(((LongerThanConstraintDTO) dto).value));
+            case GREATER_THAN:
+                return new IsGreaterThanConstantConstraint(field, HelixNumber.create(((GreaterThanConstraintDTO) dto).value));
+            case GREATER_THAN_OR_EQUAL_TO:
+                return new IsGreaterThanOrEqualToConstantConstraint(field, HelixNumber.create(((GreaterThanOrEqualToConstraintDTO) dto).value));
+            case LESS_THAN:
+                return new IsLessThanConstantConstraint(field, HelixNumber.create(((LessThanConstraintDTO) dto).value));
+            case LESS_THAN_OR_EQUAL_TO:
+                return new IsLessThanOrEqualToConstantConstraint(field, HelixNumber.create(((LessThanOrEqualToConstraintDTO) dto).value));
+            case AFTER:
+                return new IsAfterConstantDateTimeConstraint(field, HelixDateTime.create(((AfterConstraintDTO) dto).value));
+            case AFTER_OR_AT:
+                return new IsAfterOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((AfterOrAtConstraintDTO) dto).value));
+            case BEFORE:
+                return new IsBeforeConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeConstraintDTO) dto).value));
+            case BEFORE_OR_AT:
+                return new IsBeforeOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeOrAtConstraintDTO) dto).value));
+            case GRANULAR_TO:
+                GranularToConstraintDTO granularToConstraintDTO = (GranularToConstraintDTO) dto;
+                return granularToConstraintDTO.value instanceof Number
+                    ? new IsGranularToNumericConstraint(field, NumericGranularity.create(granularToConstraintDTO.value))
+                    : new IsGranularToDateConstraint(field, DateTimeGranularity.create((String) granularToConstraintDTO.value));
+            default:
+                throw new InvalidProfileException("Atomic constraint type not found: " + dto);
+        }
+    }
+
+    private DistributedList<Object> prepareValuesForSet(InSetConstraintDTO inSetConstraintDTO, Field field) {
+        return (inSetConstraintDTO instanceof InSetFromFileConstraintDTO
+            ? fileReader.setFromFile(((InSetFromFileConstraintDTO) inSetConstraintDTO).file)
+            : DistributedList.uniform(((InSetOfValuesConstraintDTO) inSetConstraintDTO).values.stream()
+            .distinct()
+            .map(o -> readAnyType(field, o))
+            .collect(Collectors.toList())));
+    }
+
+    @Nullable
+    private Object readAnyType(Field field, Object value) {
+        switch (field.getType()) {
+            case DATETIME:
+                return HelixDateTime.create((String) value).getValue();
+            case NUMERIC:
+                return NumberUtils.coerceToBigDecimal(value);
+            default:
+                return value;
+        }
+    }
+
+    private Pattern readPattern(Object value) {
+        if (value instanceof Pattern) return (Pattern) value;
+        try {
+            return Pattern.compile((String) value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidProfileException(e.getMessage());
+        }
+    }
+
+
+}

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
@@ -18,31 +18,27 @@ package com.scottlogic.deg.profile.reader;
 
 import com.google.inject.Inject;
 import com.scottlogic.deg.common.profile.*;
-import com.scottlogic.deg.common.util.NumberUtils;
 import com.scottlogic.deg.common.util.defaults.DateTimeDefaults;
 import com.scottlogic.deg.common.util.defaults.NumericDefaults;
 import com.scottlogic.deg.generator.fieldspecs.relations.*;
-import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.profile.constraints.Constraint;
 import com.scottlogic.deg.generator.profile.constraints.atomic.*;
 import com.scottlogic.deg.generator.profile.constraints.grammatical.AndConstraint;
 import com.scottlogic.deg.generator.profile.constraints.grammatical.ConditionalConstraint;
 import com.scottlogic.deg.generator.profile.constraints.grammatical.OrConstraint;
 import com.scottlogic.deg.profile.dtos.constraints.*;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ConstraintReader {
 
-    private final FileReader fileReader;
+    private final AtomicConstraintReader atomicConstraintReader;
 
     @Inject
-    public ConstraintReader(FileReader fileReader) {
-        this.fileReader = fileReader;
+    public ConstraintReader(AtomicConstraintReader atomicConstraintReader) {
+        this.atomicConstraintReader = atomicConstraintReader;
     }
 
     public Set<Constraint> read(Collection<ConstraintDTO> constraints, ProfileFields fields) {
@@ -57,7 +53,7 @@ public class ConstraintReader {
         } else if (dto instanceof RelationalConstraintDTO) {
             return readRelationalConstraintDto((RelationalConstraintDTO) dto, profileFields);
         } else if (dto instanceof AtomicConstraintDTO)
-            return readAtomicConstraintDto((AtomicConstraintDTO) dto, profileFields);
+            return atomicConstraintReader.readAtomicConstraintDto((AtomicConstraintDTO) dto, profileFields);
         else {
             return readGrammaticalConstraintDto(dto, profileFields);
         }
@@ -93,66 +89,6 @@ public class ConstraintReader {
         }
     }
 
-    private Constraint readAtomicConstraintDto(AtomicConstraintDTO dto, ProfileFields profileFields) {
-        Field field = profileFields.getByName(dto.field);
-        switch (dto.getType()) {
-            case EQUAL_TO:
-                return new EqualToConstraint(field, readAnyType(field, ((EqualToConstraintDTO) dto).value));
-            case IN_SET:
-                InSetConstraintDTO inSetConstraintDTO = (InSetConstraintDTO) dto;
-                return new IsInSetConstraint(field, prepareValuesForSet(inSetConstraintDTO, field));
-            case IN_MAP:
-                InMapConstraintDTO inMapConstraintDTO = (InMapConstraintDTO) dto;
-                return new InMapRelation(field, profileFields.getByName(inMapConstraintDTO.file),
-                    DistributedList.uniform(fileReader.listFromMapFile(inMapConstraintDTO.file, inMapConstraintDTO.key).stream()
-                        .map(value -> readAnyType(field, value))
-                        .collect(Collectors.toList())));
-            case MATCHES_REGEX:
-                return new MatchesRegexConstraint(field, readPattern(((MatchesRegexConstraintDTO) dto).value));
-            case CONTAINS_REGEX:
-                return new ContainsRegexConstraint(field, readPattern(((ContainsRegexConstraintDTO) dto).value));
-            case OF_LENGTH:
-                return new StringHasLengthConstraint(field, HelixStringLength.create(((OfLengthConstraintDTO) dto).value));
-            case SHORTER_THAN:
-                return new IsStringShorterThanConstraint(field, HelixStringLength.create(((ShorterThanConstraintDTO) dto).value));
-            case LONGER_THAN:
-                return new IsStringLongerThanConstraint(field, HelixStringLength.create(((LongerThanConstraintDTO) dto).value));
-            case GREATER_THAN:
-                return new IsGreaterThanConstantConstraint(field, HelixNumber.create(((GreaterThanConstraintDTO) dto).value));
-            case GREATER_THAN_OR_EQUAL_TO:
-                return new IsGreaterThanOrEqualToConstantConstraint(field, HelixNumber.create(((GreaterThanOrEqualToConstraintDTO) dto).value));
-            case LESS_THAN:
-                return new IsLessThanConstantConstraint(field, HelixNumber.create(((LessThanConstraintDTO) dto).value));
-            case LESS_THAN_OR_EQUAL_TO:
-                return new IsLessThanOrEqualToConstantConstraint(field, HelixNumber.create(((LessThanOrEqualToConstraintDTO) dto).value));
-            case AFTER:
-                return new IsAfterConstantDateTimeConstraint(field, HelixDateTime.create(((AfterConstraintDTO) dto).value));
-            case AFTER_OR_AT:
-                return new IsAfterOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((AfterOrAtConstraintDTO) dto).value));
-            case BEFORE:
-                return new IsBeforeConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeConstraintDTO) dto).value));
-            case BEFORE_OR_AT:
-                return new IsBeforeOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeOrAtConstraintDTO) dto).value));
-            case GRANULAR_TO:
-                GranularToConstraintDTO granularToConstraintDTO = (GranularToConstraintDTO) dto;
-                return granularToConstraintDTO.value instanceof Number
-                    ? new IsGranularToNumericConstraint(field, NumericGranularity.create(granularToConstraintDTO.value))
-                    : new IsGranularToDateConstraint(field, DateTimeGranularity.create((String) granularToConstraintDTO.value));
-            default:
-                throw new InvalidProfileException("Atomic constraint type not found: " + dto);
-        }
-    }
-
-    private DistributedList<Object> prepareValuesForSet(InSetConstraintDTO inSetConstraintDTO, Field field) {
-        return (inSetConstraintDTO instanceof InSetFromFileConstraintDTO
-            ? fileReader.setFromFile(((InSetFromFileConstraintDTO) inSetConstraintDTO).file)
-            : DistributedList.uniform(((InSetOfValuesConstraintDTO) inSetConstraintDTO).values.stream()
-            .distinct()
-            .map(o -> readAnyType(field, o))
-            .collect(Collectors.toList())));
-    }
-
-
     private Constraint readGrammaticalConstraintDto(ConstraintDTO dto, ProfileFields profileFields) {
         switch (dto.getType()) {
             case ALL_OF:
@@ -172,27 +108,6 @@ public class ConstraintReader {
                 return new IsNullConstraint(profileFields.getByName(((NullConstraintDTO) dto).field));
             default:
                 throw new InvalidProfileException("Grammatical constraint type not found: " + dto);
-        }
-    }
-
-    @Nullable
-    private Object readAnyType(Field field, Object value) {
-        switch (field.getType()) {
-            case DATETIME:
-                return HelixDateTime.create((String) value).getValue();
-            case NUMERIC:
-                return NumberUtils.coerceToBigDecimal(value);
-            default:
-                return value;
-        }
-    }
-
-    private Pattern readPattern(Object value) {
-        if (value instanceof Pattern) return (Pattern) value;
-        try {
-            return Pattern.compile((String) value);
-        } catch (IllegalArgumentException e) {
-            throw new InvalidProfileException(e.getMessage());
         }
     }
 

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
@@ -100,13 +100,7 @@ public class ConstraintReader {
                 return new EqualToConstraint(field, readAnyType(field, ((EqualToConstraintDTO) dto).value));
             case IN_SET:
                 InSetConstraintDTO inSetConstraintDTO = (InSetConstraintDTO) dto;
-                DistributedList<Object> values = (inSetConstraintDTO instanceof InSetFromFileConstraintDTO
-                    ? fileReader.setFromFile(((InSetFromFileConstraintDTO) inSetConstraintDTO).file)
-                    : DistributedList.uniform(((InSetOfValuesConstraintDTO) inSetConstraintDTO).values.stream()
-                    .distinct()
-                    .map(o -> readAnyType(field, o))
-                    .collect(Collectors.toList())));
-                return new IsInSetConstraint(field, values);
+                return new IsInSetConstraint(field, prepareValuesForSet(inSetConstraintDTO, field));
             case IN_MAP:
                 InMapConstraintDTO inMapConstraintDTO = (InMapConstraintDTO) dto;
                 return new InMapRelation(field, profileFields.getByName(inMapConstraintDTO.file),
@@ -147,6 +141,15 @@ public class ConstraintReader {
             default:
                 throw new InvalidProfileException("Atomic constraint type not found: " + dto);
         }
+    }
+
+    private DistributedList<Object> prepareValuesForSet(InSetConstraintDTO inSetConstraintDTO, Field field) {
+        return (inSetConstraintDTO instanceof InSetFromFileConstraintDTO
+            ? fileReader.setFromFile(((InSetFromFileConstraintDTO) inSetConstraintDTO).file)
+            : DistributedList.uniform(((InSetOfValuesConstraintDTO) inSetConstraintDTO).values.stream()
+            .distinct()
+            .map(o -> readAnyType(field, o))
+            .collect(Collectors.toList())));
     }
 
 

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
@@ -52,12 +52,15 @@ public class ConstraintReader {
     }
 
     public Constraint read(ConstraintDTO dto, ProfileFields profileFields) {
-        if (dto == null) throw new InvalidProfileException("Constraint is null");
-        if (dto instanceof RelationalConstraintDTO)
+        if (dto == null) {
+            throw new InvalidProfileException("Constraint is null");
+        } else if (dto instanceof RelationalConstraintDTO) {
             return readRelationalConstraintDto((RelationalConstraintDTO) dto, profileFields);
-        return dto instanceof AtomicConstraintDTO
-            ? readAtomicConstraintDto((AtomicConstraintDTO) dto, profileFields)
-            : readGrammaticalConstraintDto(dto, profileFields);
+        } else if (dto instanceof AtomicConstraintDTO)
+            return readAtomicConstraintDto((AtomicConstraintDTO) dto, profileFields);
+        else {
+            return readGrammaticalConstraintDto(dto, profileFields);
+        }
     }
 
     private Constraint readRelationalConstraintDto(RelationalConstraintDTO dto, ProfileFields fields) {

--- a/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/reader/ConstraintReader.java
@@ -108,36 +108,36 @@ public class ConstraintReader {
                         .map(value -> readAnyType(field, value))
                         .collect(Collectors.toList())));
             case MATCHES_REGEX:
-                return new MatchesRegexConstraint(profileFields.getByName(dto.field), readPattern(((MatchesRegexConstraintDTO) dto).value));
+                return new MatchesRegexConstraint(field, readPattern(((MatchesRegexConstraintDTO) dto).value));
             case CONTAINS_REGEX:
-                return new ContainsRegexConstraint(profileFields.getByName(dto.field), readPattern(((ContainsRegexConstraintDTO) dto).value));
+                return new ContainsRegexConstraint(field, readPattern(((ContainsRegexConstraintDTO) dto).value));
             case OF_LENGTH:
-                return new StringHasLengthConstraint(profileFields.getByName(dto.field), HelixStringLength.create(((OfLengthConstraintDTO) dto).value));
+                return new StringHasLengthConstraint(field, HelixStringLength.create(((OfLengthConstraintDTO) dto).value));
             case SHORTER_THAN:
-                return new IsStringShorterThanConstraint(profileFields.getByName(dto.field), HelixStringLength.create(((ShorterThanConstraintDTO) dto).value));
+                return new IsStringShorterThanConstraint(field, HelixStringLength.create(((ShorterThanConstraintDTO) dto).value));
             case LONGER_THAN:
-                return new IsStringLongerThanConstraint(profileFields.getByName(dto.field), HelixStringLength.create(((LongerThanConstraintDTO) dto).value));
+                return new IsStringLongerThanConstraint(field, HelixStringLength.create(((LongerThanConstraintDTO) dto).value));
             case GREATER_THAN:
-                return new IsGreaterThanConstantConstraint(profileFields.getByName(dto.field), HelixNumber.create(((GreaterThanConstraintDTO) dto).value));
+                return new IsGreaterThanConstantConstraint(field, HelixNumber.create(((GreaterThanConstraintDTO) dto).value));
             case GREATER_THAN_OR_EQUAL_TO:
-                return new IsGreaterThanOrEqualToConstantConstraint(profileFields.getByName(dto.field), HelixNumber.create(((GreaterThanOrEqualToConstraintDTO) dto).value));
+                return new IsGreaterThanOrEqualToConstantConstraint(field, HelixNumber.create(((GreaterThanOrEqualToConstraintDTO) dto).value));
             case LESS_THAN:
-                return new IsLessThanConstantConstraint(profileFields.getByName(dto.field), HelixNumber.create(((LessThanConstraintDTO) dto).value));
+                return new IsLessThanConstantConstraint(field, HelixNumber.create(((LessThanConstraintDTO) dto).value));
             case LESS_THAN_OR_EQUAL_TO:
-                return new IsLessThanOrEqualToConstantConstraint(profileFields.getByName(dto.field), HelixNumber.create(((LessThanOrEqualToConstraintDTO) dto).value));
+                return new IsLessThanOrEqualToConstantConstraint(field, HelixNumber.create(((LessThanOrEqualToConstraintDTO) dto).value));
             case AFTER:
-                return new IsAfterConstantDateTimeConstraint(profileFields.getByName(dto.field), HelixDateTime.create(((AfterConstraintDTO) dto).value));
+                return new IsAfterConstantDateTimeConstraint(field, HelixDateTime.create(((AfterConstraintDTO) dto).value));
             case AFTER_OR_AT:
-                return new IsAfterOrEqualToConstantDateTimeConstraint(profileFields.getByName(dto.field), HelixDateTime.create(((AfterOrAtConstraintDTO) dto).value));
+                return new IsAfterOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((AfterOrAtConstraintDTO) dto).value));
             case BEFORE:
-                return new IsBeforeConstantDateTimeConstraint(profileFields.getByName(dto.field), HelixDateTime.create(((BeforeConstraintDTO) dto).value));
+                return new IsBeforeConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeConstraintDTO) dto).value));
             case BEFORE_OR_AT:
-                return new IsBeforeOrEqualToConstantDateTimeConstraint(profileFields.getByName(dto.field), HelixDateTime.create(((BeforeOrAtConstraintDTO) dto).value));
+                return new IsBeforeOrEqualToConstantDateTimeConstraint(field, HelixDateTime.create(((BeforeOrAtConstraintDTO) dto).value));
             case GRANULAR_TO:
                 GranularToConstraintDTO granularToConstraintDTO = (GranularToConstraintDTO) dto;
                 return granularToConstraintDTO.value instanceof Number
-                    ? new IsGranularToNumericConstraint(profileFields.getByName(dto.field), NumericGranularity.create(granularToConstraintDTO.value))
-                    : new IsGranularToDateConstraint(profileFields.getByName(dto.field), DateTimeGranularity.create((String) granularToConstraintDTO.value));
+                    ? new IsGranularToNumericConstraint(field, NumericGranularity.create(granularToConstraintDTO.value))
+                    : new IsGranularToDateConstraint(field, DateTimeGranularity.create((String) granularToConstraintDTO.value));
             default:
                 throw new InvalidProfileException("Atomic constraint type not found: " + dto);
         }

--- a/profile/src/main/java/com/scottlogic/deg/profile/serialisation/ProfileSerialiser.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/serialisation/ProfileSerialiser.java
@@ -21,18 +21,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scottlogic.deg.profile.dtos.ProfileDTO;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public class ProfileSerialiser implements Serialiser<ProfileDTO> {
-    public String serialise(ProfileDTO profile) throws IOException {
+    public String serialise(ProfileDTO profile) {
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(profile);
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(profile);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
-    public ProfileDTO deserialise(String json) throws IOException {
+    public ProfileDTO deserialise(String json) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.WRAP_EXCEPTIONS);
         mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
-        return mapper.readerFor(ProfileDTO.class).readValue(json);
+        try {
+            return mapper.readerFor(ProfileDTO.class).readValue(json);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }
 

--- a/profile/src/main/java/com/scottlogic/deg/profile/serialisation/Serialiser.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/serialisation/Serialiser.java
@@ -16,11 +16,9 @@
 
 package com.scottlogic.deg.profile.serialisation;
 
-import java.io.IOException;
+public interface Serialiser<T> {
+    String serialise(T dto);
 
-public interface Serialiser<TDto> {
-    String serialise(TDto dto) throws IOException;
-
-    TDto deserialise(String json) throws IOException;
+    T deserialise(String json);
 }
 

--- a/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/reader/JsonProfileReaderTests.java
@@ -77,7 +77,7 @@ public class JsonProfileReaderTests {
     private final String schemaVersion = "\"0.7\"";
     private String json;
 
-    private JsonProfileReader jsonProfileReader = new JsonProfileReader(null, new ConstraintReader(new MockFromFileReader()));
+    private JsonProfileReader jsonProfileReader = new JsonProfileReader(null, new ConstraintReader(new AtomicConstraintReader(new MockFromFileReader())));
 
 
 


### PR DESCRIPTION
### Description
Tidy up after #1460 

### Additional notes
Top three on the ticket were not done here. First and third are being addressed in different tickets (#1482, #1484), other I couldn't think of a cleaner solution due to the method signatures overlapping somewhat (`int` argument vs. `Object` argument, which would be ambiguous for `Integer`). The only solution in my opinion would be to extract it out as a static method to another class, but if that's the case I might as well leave it as is to avoid coupling in separate places.

### Issue
Resolves #1472 
