### PR TITLE
1377 csv commas fix

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -34,7 +34,7 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertOnOutputs(collectedOutput, "\"Generation successful\"", "");
+        assertOnOutputs(collectedOutput, "Generation successful", "");
     }
 
     @Test
@@ -44,7 +44,7 @@ public class JarExecuteTests {
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
         assertOnOutputs(collectedOutput,
-            "\"Generated successfully from file\"",
+            "Generated successfully from file",
             "Either load from file no longer works, or ");
     }
 

--- a/output/src/main/java/com/scottlogic/deg/output/writer/csv/CsvDataSetWriter.java
+++ b/output/src/main/java/com/scottlogic/deg/output/writer/csv/CsvDataSetWriter.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 class CsvDataSetWriter implements DataSetWriter {
     private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
     private static final CSVFormat writerFormat = CSVFormat.RFC4180;
-    private static final CSVFormat csvStringFormatter = writerFormat.withQuoteMode(QuoteMode.ALL);
 
     private final CSVPrinter csvPrinter;
     private final ProfileFields fieldOrder;

--- a/output/src/test/java/com/scottlogic/deg/output/writer/csv/CsvDataSetWriterTest.java
+++ b/output/src/test/java/com/scottlogic/deg/output/writer/csv/CsvDataSetWriterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.scottlogic.deg.output.writer.csv;
+
+import com.scottlogic.deg.common.output.GeneratedObject;
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.FieldType;
+import com.scottlogic.deg.common.profile.ProfileFields;
+import com.scottlogic.deg.output.writer.DataSetWriter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.fail;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CsvDataSetWriterTest {
+
+    private ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    private Field fieldOne = new Field("one", FieldType.STRING,false,null,false);
+    private Field fieldTwo = new Field("two", FieldType.STRING,false,null,false);
+
+    private ProfileFields profileFields = new ProfileFields(new ArrayList<>(Arrays.asList(
+        fieldOne, fieldTwo
+    )));
+
+    @Mock
+    GeneratedObject row;
+
+    @Test
+    public void open_createsCSVWriterThatCorrectlyOutputsCommasAndQuotes() {
+        DataSetWriter dataSetWriter;
+        Mockito.when(row.getFormattedValue(fieldOne)).thenReturn(",,");
+        Mockito.when(row.getFormattedValue(fieldTwo)).thenReturn(",\"");
+        try {
+            dataSetWriter = CsvDataSetWriter.open(outputStream, profileFields);
+            dataSetWriter.writeRow(row);
+            String output = outputStream.toString(StandardCharsets.UTF_8.toString());
+            Assert.assertEquals(
+                "If the actual and expected appear to be identical, check for null characters",
+                "one,two\r\n\",,\",\",\"\"\"\r\n",
+                output);
+        } catch (IOException e) {
+            fail(e.toString());
+        }
+    }
+}


### PR DESCRIPTION
### Description
Before this change null characters were used as "escape characters" to escape commas in csvs.
This is not desired behaviour.

### Changes
Use the "minimal" quote mode with CSV reader. (see https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/QuoteMode.html)

Note that this will change the behaviour of outputted csvs. It will now be more inline with the RFC4180 format (ie now strings will only have quotes around them if they contain quotes, linebreaks or commas).

### Issue
Resolves #1377 


### Possible additional work
Currently the formatter is tied to databag. It could be seperated out into a seperate class.
