### PR TITLE
chore(#0): Correct exception message for negating offset relations no…

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/EqualToOffsetRelation.java
@@ -81,6 +81,6 @@ public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpec
 
     @Override
     public Constraint negate() {
-        throw new UnsupportedOperationException("equalTo relations cannot currently be negated");
+        throw new UnsupportedOperationException("Negating relations with an offset is not supported");
     }
 }


### PR DESCRIPTION
Correct exception message for negating offset relations not being supported (equalTo offset can be negated)

