### PR TITLE
1453 allow offset to be applied to before and after

### DIFF
--- a/common/src/main/java/com/scottlogic/deg/common/profile/DateTimeGranularity.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/DateTimeGranularity.java
@@ -78,9 +78,9 @@ public class DateTimeGranularity implements Granularity<OffsetDateTime> {
     }
 
     @Override
-    public OffsetDateTime getPrevious(OffsetDateTime value) {
+    public OffsetDateTime getPrevious(OffsetDateTime value, int amount) {
         if (isCorrectScale(value)){
-            return getNext(value, -1);
+            return getNext(value, -amount);
         }
 
         return trimToGranularity(value);

--- a/common/src/main/java/com/scottlogic/deg/common/profile/Granularity.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/Granularity.java
@@ -34,9 +34,9 @@ public interface Granularity<T> {
 
     default T getNext(T value){
         return getNext(value, 1);
-    };
+    }
 
-    default T getPrevious(T value) { return getPrevious(value, 1);};
+    default T getPrevious(T value) { return getPrevious(value, 1);}
 
     T getRandom(T min, T max, RandomNumberGenerator randomNumberGenerator);
 }

--- a/common/src/main/java/com/scottlogic/deg/common/profile/Granularity.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/Granularity.java
@@ -30,11 +30,13 @@ public interface Granularity<T> {
 
     T trimToGranularity(T value);
 
-    T getPrevious(T value);
+    T getPrevious(T value, int amount);
 
     default T getNext(T value){
         return getNext(value, 1);
     };
+
+    default T getPrevious(T value) { return getPrevious(value, 1);};
 
     T getRandom(T min, T max, RandomNumberGenerator randomNumberGenerator);
 }

--- a/common/src/main/java/com/scottlogic/deg/common/profile/NumericGranularity.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/NumericGranularity.java
@@ -88,21 +88,13 @@ public class NumericGranularity implements Granularity<BigDecimal> {
 
     @Override
     public BigDecimal getPrevious(BigDecimal value, int amount) {
-        if (!isCorrectScale(value)){
-            return trimToGranularity(value);
+        if (isCorrectScale(value)){
+            return value.subtract(BigDecimal.ONE.scaleByPowerOfTen(decimalPlaces * -1)
+                .multiply(BigDecimal.valueOf(amount)));
         }
 
-        return value.subtract(BigDecimal.ONE.scaleByPowerOfTen(decimalPlaces * -1)
-        .multiply(BigDecimal.valueOf(-amount)));
-    }
+        return trimToGranularity(value);
 
-    @Override
-    public BigDecimal getPrevious(BigDecimal value) {
-        if (!isCorrectScale(value)){
-            return trimToGranularity(value);
-        }
-
-        return value.subtract(BigDecimal.ONE.scaleByPowerOfTen(decimalPlaces * -1));
     }
 
     @Override

--- a/common/src/main/java/com/scottlogic/deg/common/profile/NumericGranularity.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/NumericGranularity.java
@@ -87,6 +87,16 @@ public class NumericGranularity implements Granularity<BigDecimal> {
     }
 
     @Override
+    public BigDecimal getPrevious(BigDecimal value, int amount) {
+        if (!isCorrectScale(value)){
+            return trimToGranularity(value);
+        }
+
+        return value.subtract(BigDecimal.ONE.scaleByPowerOfTen(decimalPlaces * -1)
+        .multiply(BigDecimal.valueOf(-amount)));
+    }
+
+    @Override
     public BigDecimal getPrevious(BigDecimal value) {
         if (!isCorrectScale(value)){
             return trimToGranularity(value);

--- a/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
+++ b/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.deg.common.util;
 
 import com.scottlogic.deg.common.profile.DateTimeGranularity;

--- a/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
+++ b/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
@@ -36,7 +36,7 @@ public class GranularityUtils {
                     : DateTimeDefaults.get().granularity();
 
             default:
-                return null;
+                throw new UnsupportedOperationException("Attempt to find granularity for an unsupported type");
         }
     }
 }

--- a/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
+++ b/common/src/main/java/com/scottlogic/deg/common/util/GranularityUtils.java
@@ -1,0 +1,26 @@
+package com.scottlogic.deg.common.util;
+
+import com.scottlogic.deg.common.profile.DateTimeGranularity;
+import com.scottlogic.deg.common.profile.FieldType;
+import com.scottlogic.deg.common.profile.Granularity;
+import com.scottlogic.deg.common.profile.NumericGranularity;
+import com.scottlogic.deg.common.util.defaults.DateTimeDefaults;
+import com.scottlogic.deg.common.util.defaults.NumericDefaults;
+
+public class GranularityUtils {
+    public static Granularity readGranularity(FieldType type, String offsetUnit) {
+        switch (type) {
+            case NUMERIC:
+                return offsetUnit != null
+                    ? NumericGranularity.create(offsetUnit)
+                    : NumericDefaults.get().granularity();
+            case DATETIME:
+                return offsetUnit != null
+                    ? DateTimeGranularity.create(offsetUnit)
+                    : DateTimeDefaults.get().granularity();
+
+            default:
+                return null;
+        }
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
@@ -1,0 +1,84 @@
+package com.scottlogic.deg.generator.fieldspecs.relations;
+
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.Granularity;
+import com.scottlogic.deg.common.util.defaults.LinearDefaults;
+import com.scottlogic.deg.generator.fieldspecs.*;
+import com.scottlogic.deg.generator.generation.databags.DataBagValue;
+import com.scottlogic.deg.generator.profile.constraints.Constraint;
+import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
+
+public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRelations {
+    private final Field main;
+    private final Field other;
+    private final boolean inclusive;
+    private final LinearDefaults<T> defaults;
+    private final Granularity<T> offsetGranularity;
+    private final int offset;
+
+    public AfterOffsetRelation(Field main, Field other, boolean inclusive, LinearDefaults<T> defaults, Granularity<T> offsetGranularity, int offset) {
+        this.main = main;
+        this.other = other;
+        this.inclusive = inclusive;
+        this.defaults = defaults;
+        this.offsetGranularity = offsetGranularity;
+        this.offset = offset;
+    }
+
+    @Override
+    public FieldSpec createModifierFromOtherFieldSpec(FieldSpec otherFieldSpec) {
+        if (otherFieldSpec instanceof NullOnlyFieldSpec) {
+            return FieldSpecFactory.nullOnly();
+        }
+        if (otherFieldSpec instanceof WhitelistFieldSpec) {
+            throw new UnsupportedOperationException("cannot combine sets with after relation, Issue #1489");
+        }
+
+        LinearRestrictions<T> otherRestrictions = (LinearRestrictions) ((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
+        T min = otherRestrictions.getMin();
+        T offsetMin = offsetGranularity.getNext(min, offset);
+
+        return createFromMin(offsetMin, otherRestrictions.getGranularity());
+    }
+
+    @Override
+    public FieldSpec createModifierFromOtherValue(DataBagValue otherFieldGeneratedValue) {
+        if (otherFieldGeneratedValue.getValue() == null) return FieldSpecFactory.fromType(main.getType());
+
+        T offsetValue = offsetGranularity.getNext((T) otherFieldGeneratedValue.getValue(), offset);
+        return createFromMin(offsetValue, defaults.granularity());
+    }
+
+    private FieldSpec createFromMin(T min, Granularity<T> granularity) {
+        if (!inclusive) {
+            min = granularity.getNext(min);
+        }
+
+        return FieldSpecFactory.fromRestriction(new LinearRestrictions<>(min, defaults.max(), granularity));
+    }
+
+    @Override
+    public Field main() {
+        return main;
+    }
+
+    @Override
+    public Field other() {
+        return other;
+    }
+
+    @Override
+    public FieldSpecRelations inverse() {
+        return new BeforeOffsetRelation(other, main, inclusive, defaults, offsetGranularity, -1 * offset);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s is after %s%s %s %s", main, inclusive ? "or equal to " : "", other, offset >= 0 ? "plus" : "minus", Math.abs(offset));
+    }
+
+    @Override
+    public Constraint negate() {
+        throw new UnsupportedOperationException("Negating relations with an offset is not supported");
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
@@ -8,6 +8,8 @@ import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import com.scottlogic.deg.generator.profile.constraints.Constraint;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 
+import static com.scottlogic.deg.common.util.GranularityUtils.readGranularity;
+
 public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRelations {
     private final Field main;
     private final Field other;
@@ -21,7 +23,7 @@ public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRe
         this.other = other;
         this.inclusive = inclusive;
         this.defaults = defaults;
-        this.offsetGranularity = offsetGranularity;
+        this.offsetGranularity = offsetGranularity != null ? offsetGranularity : readGranularity(main.getType(), null);
         this.offset = offset;
     }
 
@@ -36,10 +38,9 @@ public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRe
 
         LinearRestrictions<T> otherRestrictions = (LinearRestrictions) ((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
         T min = otherRestrictions.getMin();
-        Granularity<T> granularity = offsetGranularity != null ? offsetGranularity : otherRestrictions.getGranularity();
-        T offsetMin = granularity.getNext(min, offset);
+        T offsetMin = offsetGranularity.getNext(min, offset);
 
-        return createFromMin(offsetMin, otherRestrictions.getGranularity());
+        return createFromMin(offsetMin, offsetGranularity);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.deg.generator.fieldspecs.relations;
 
 import com.scottlogic.deg.common.profile.Field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
@@ -26,7 +26,7 @@ import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 
 import static com.scottlogic.deg.common.util.GranularityUtils.readGranularity;
 
-public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRelations {
+public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRelation {
     private final Field main;
     private final Field other;
     private final boolean inclusive;
@@ -88,7 +88,7 @@ public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRe
     }
 
     @Override
-    public FieldSpecRelations inverse() {
+    public FieldSpecRelation inverse() {
         return new BeforeOffsetRelation(other, main, inclusive, defaults, offsetGranularity, -1 * offset);
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterOffsetRelation.java
@@ -36,7 +36,8 @@ public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRe
 
         LinearRestrictions<T> otherRestrictions = (LinearRestrictions) ((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
         T min = otherRestrictions.getMin();
-        T offsetMin = offsetGranularity.getNext(min, offset);
+        Granularity<T> granularity = offsetGranularity != null ? offsetGranularity : otherRestrictions.getGranularity();
+        T offsetMin = granularity.getNext(min, offset);
 
         return createFromMin(offsetMin, otherRestrictions.getGranularity());
     }
@@ -45,7 +46,9 @@ public class AfterOffsetRelation<T extends Comparable<T>> implements FieldSpecRe
     public FieldSpec createModifierFromOtherValue(DataBagValue otherFieldGeneratedValue) {
         if (otherFieldGeneratedValue.getValue() == null) return FieldSpecFactory.fromType(main.getType());
 
-        T offsetValue = offsetGranularity.getNext((T) otherFieldGeneratedValue.getValue(), offset);
+        T offsetValue = offset > 0
+            ? offsetGranularity.getNext((T) otherFieldGeneratedValue.getValue(), offset)
+            : (T) otherFieldGeneratedValue.getValue();
         return createFromMin(offsetValue, defaults.granularity());
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
@@ -8,6 +8,8 @@ import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import com.scottlogic.deg.generator.profile.constraints.Constraint;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 
+import static com.scottlogic.deg.common.util.GranularityUtils.readGranularity;
+
 public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpecRelations {
     private final Field main;
     private final Field other;
@@ -21,7 +23,7 @@ public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpec
         this.other = other;
         this.inclusive = inclusive;
         this.defaults = defaults;
-        this.offsetGranularity = offsetGranularity;
+        this.offsetGranularity = offsetGranularity != null ? offsetGranularity : readGranularity(main.getType(), null);
         this.offset = offset;
     }
 
@@ -36,10 +38,9 @@ public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpec
 
         LinearRestrictions<T> otherRestrictions = (LinearRestrictions)((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
         T max = otherRestrictions.getMax();
-        Granularity<T> granularity = offsetGranularity != null ? offsetGranularity : otherRestrictions.getGranularity();
-        T offsetMax = granularity.getPrevious(max, offset);
+        T offsetMax = offsetGranularity.getPrevious(max, offset);
 
-        return createFromMax(offsetMax, otherRestrictions.getGranularity());
+        return createFromMax(offsetMax, offsetGranularity);
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
@@ -1,0 +1,84 @@
+package com.scottlogic.deg.generator.fieldspecs.relations;
+
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.Granularity;
+import com.scottlogic.deg.common.util.defaults.LinearDefaults;
+import com.scottlogic.deg.generator.fieldspecs.*;
+import com.scottlogic.deg.generator.generation.databags.DataBagValue;
+import com.scottlogic.deg.generator.profile.constraints.Constraint;
+import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
+
+public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpecRelations {
+    private final Field main;
+    private final Field other;
+    private final boolean inclusive;
+    private final LinearDefaults<T> defaults;
+    private final Granularity<T> offsetGranularity;
+    private final int offset;
+
+    public BeforeOffsetRelation(Field main, Field other, boolean inclusive, LinearDefaults<T> defaults, Granularity<T> offsetGranularity, int offset) {
+        this.main = main;
+        this.other = other;
+        this.inclusive = inclusive;
+        this.defaults = defaults;
+        this.offsetGranularity = offsetGranularity;
+        this.offset = offset;
+    }
+
+    @Override
+    public FieldSpec createModifierFromOtherFieldSpec(FieldSpec otherFieldSpec) {
+        if (otherFieldSpec instanceof NullOnlyFieldSpec){
+            return FieldSpecFactory.nullOnly();
+        }
+        if (otherFieldSpec instanceof WhitelistFieldSpec) {
+            throw new UnsupportedOperationException("cannot combine sets with before relation, Issue #1489");
+        }
+
+        LinearRestrictions<T> otherRestrictions = (LinearRestrictions)((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
+        T max = otherRestrictions.getMax();
+        T offsetMax = offsetGranularity.getPrevious(max, offset);
+
+        return createFromMax(offsetMax, otherRestrictions.getGranularity());
+    }
+
+    @Override
+    public FieldSpec createModifierFromOtherValue(DataBagValue otherFieldGeneratedValue) {
+        if (otherFieldGeneratedValue.getValue() == null) return FieldSpecFactory.fromType(main.getType());
+
+        T offsetValue = offsetGranularity.getPrevious((T) otherFieldGeneratedValue.getValue(), offset);
+        return  createFromMax(offsetValue, defaults.granularity());
+    }
+
+    private FieldSpec createFromMax(T max, Granularity<T> granularity) {
+        if (!inclusive){
+            max = granularity.getPrevious(max);
+        }
+
+        return FieldSpecFactory.fromRestriction(new LinearRestrictions<>(defaults.min(), max, granularity));
+    }
+
+    @Override
+    public Field main() {
+        return main;
+    }
+
+    @Override
+    public Field other() {
+        return other;
+    }
+
+    @Override
+    public FieldSpecRelations inverse() {
+         return new AfterOffsetRelation(other, main, inclusive, defaults, offsetGranularity,-1 * offset);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s is before %s%s %s %s", main, inclusive ? "or equal to " : "", other, offset >= 0 ? "plus" : "minus", Math.abs(offset));
+    }
+
+    @Override
+    public Constraint negate() {
+        throw new UnsupportedOperationException("Negating relations with an offset is not supported");
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
@@ -36,7 +36,8 @@ public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpec
 
         LinearRestrictions<T> otherRestrictions = (LinearRestrictions)((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
         T max = otherRestrictions.getMax();
-        T offsetMax = offsetGranularity.getPrevious(max, offset);
+        Granularity<T> granularity = offsetGranularity != null ? offsetGranularity : otherRestrictions.getGranularity();
+        T offsetMax = granularity.getPrevious(max, offset);
 
         return createFromMax(offsetMax, otherRestrictions.getGranularity());
     }
@@ -45,7 +46,10 @@ public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpec
     public FieldSpec createModifierFromOtherValue(DataBagValue otherFieldGeneratedValue) {
         if (otherFieldGeneratedValue.getValue() == null) return FieldSpecFactory.fromType(main.getType());
 
-        T offsetValue = offsetGranularity.getPrevious((T) otherFieldGeneratedValue.getValue(), offset);
+        T offsetValue = offset > 0
+            ? offsetGranularity.getPrevious((T) otherFieldGeneratedValue.getValue(), offset)
+            : (T) otherFieldGeneratedValue.getValue();
+
         return  createFromMax(offsetValue, defaults.granularity());
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
@@ -26,7 +26,7 @@ import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 
 import static com.scottlogic.deg.common.util.GranularityUtils.readGranularity;
 
-public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpecRelations {
+public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpecRelation {
     private final Field main;
     private final Field other;
     private final boolean inclusive;
@@ -89,7 +89,7 @@ public class BeforeOffsetRelation <T extends Comparable<T>> implements FieldSpec
     }
 
     @Override
-    public FieldSpecRelations inverse() {
+    public FieldSpecRelation inverse() {
          return new AfterOffsetRelation(other, main, inclusive, defaults, offsetGranularity,-1 * offset);
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeOffsetRelation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.deg.generator.fieldspecs.relations;
 
 import com.scottlogic.deg.common.profile.Field;

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
@@ -38,7 +38,8 @@ public class AfterDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNotNull_reducesToSpec() {
-        FieldSpecRelation afterDateRelations = new AfterRelation(a, b, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -57,7 +58,8 @@ public class AfterDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNotNullExclusive_reducesToSpec() {
-        FieldSpecRelation afterDateRelations = new AfterRelation(a, b, false, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 1);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -77,7 +79,8 @@ public class AfterDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNull_reducesToSpec() {
-        FieldSpecRelation afterDateRelations = new AfterRelation(a, b, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = null;
         DataBagValue generatedValue = new DataBagValue(value);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/AfterDateRelationTest.java
@@ -39,7 +39,7 @@ public class AfterDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNotNull_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
+        FieldSpecRelation afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -59,7 +59,7 @@ public class AfterDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNotNullExclusive_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 1);
+        FieldSpecRelation afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 1);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -80,7 +80,7 @@ public class AfterDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNull_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
+        FieldSpecRelation afterDateRelations = new AfterOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = null;
         DataBagValue generatedValue = new DataBagValue(value);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
@@ -39,7 +39,7 @@ public class BeforeDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNotNull_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
+        FieldSpecRelation beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -59,7 +59,7 @@ public class BeforeDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNotNullExclusive_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, false, DateTimeDefaults.get(), offsetGranularity, 0);
+        FieldSpecRelation beforeDateRelations = new BeforeOffsetRelation(a, b, false, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -80,7 +80,7 @@ public class BeforeDateRelationTest {
     @Test
     public void testReduceToFieldSpec_withNull_reducesToSpec() {
         DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
-        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
+        FieldSpecRelation beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = null;
         DataBagValue generatedValue = new DataBagValue(value);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/BeforeDateRelationTest.java
@@ -38,7 +38,8 @@ public class BeforeDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNotNull_reducesToSpec() {
-        FieldSpecRelation beforeDateRelations = new BeforeRelation(a, b, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -57,7 +58,8 @@ public class BeforeDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNotNullExclusive_reducesToSpec() {
-        FieldSpecRelation beforeDateRelations = new BeforeRelation(a, b, false, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, false, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = OffsetDateTime.of(2000,
             1,
             1,
@@ -77,7 +79,8 @@ public class BeforeDateRelationTest {
 
     @Test
     public void testReduceToFieldSpec_withNull_reducesToSpec() {
-        FieldSpecRelation beforeDateRelations = new BeforeRelation(a, b, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        FieldSpecRelations beforeDateRelations = new BeforeOffsetRelation(a, b, true, DateTimeDefaults.get(), offsetGranularity, 0);
         OffsetDateTime value = null;
         DataBagValue generatedValue = new DataBagValue(value);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
@@ -52,7 +52,8 @@ class FieldSpecRelationTest
     @Test
     public void afterOrAt_exactValue_returnsBetween(){
         FieldSpec fieldSpec = forYears(2018, 2018);
-        AfterRelation relation = new AfterRelation(main, other, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        AfterOffsetRelation relation = new AfterOffsetRelation(main, other, true, DateTimeDefaults.get(), offsetGranularity, 0);
 
         FieldSpec actual = relation.createModifierFromOtherFieldSpec(fieldSpec);
         FieldSpec expected = fromMin(2018);
@@ -63,7 +64,8 @@ class FieldSpecRelationTest
     @Test
     public void afterOrAt_range_returnsFromMin(){
         FieldSpec fieldSpec = forYears(2018, 2020);
-        AfterRelation relation = new AfterRelation(main, other, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        AfterOffsetRelation relation = new AfterOffsetRelation(main, other, true, DateTimeDefaults.get(), offsetGranularity, 0);
 
         FieldSpec actual = relation.createModifierFromOtherFieldSpec(fieldSpec);
         FieldSpec expected = fromMin(2018);
@@ -75,7 +77,7 @@ class FieldSpecRelationTest
     public void after_range_returnsFromMin() {
         int minYear = 2018;
         FieldSpec fieldSpec = forYears(minYear, minYear + 4);
-        AfterRelation relation = new AfterRelation(main, other, false, DateTimeDefaults.get());
+        AfterOffsetRelation relation = new AfterRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0);
 
         RestrictionsFieldSpec actualFieldSpec = (RestrictionsFieldSpec) relation.createModifierFromOtherFieldSpec(fieldSpec);
         LinearRestrictions actualRestrictions = (LinearRestrictions) actualFieldSpec.getRestrictions();
@@ -93,7 +95,8 @@ class FieldSpecRelationTest
     @Test
     public void beforeOrAt_exactValue_returnsBetween(){
         FieldSpec fieldSpec = forYears(2018, 2018);
-        BeforeRelation relation = new BeforeRelation(main, other, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        BeforeOffsetRelation relation = new BeforeOffsetRelation(main, other, true, DateTimeDefaults.get(), offsetGranularity, 0);
 
         FieldSpec actual = relation.createModifierFromOtherFieldSpec(fieldSpec);
         FieldSpec expected = fromMax(2018);
@@ -104,7 +107,8 @@ class FieldSpecRelationTest
     @Test
     public void beforeOrAt_range_returnsFromMin(){
         FieldSpec fieldSpec = forYears(2018, 2020);
-        BeforeRelation relation = new BeforeRelation(main, other, true, DateTimeDefaults.get());
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
+        BeforeOffsetRelation relation = new BeforeOffsetRelation(main, other, true, DateTimeDefaults.get(), offsetGranularity, 0);
 
         FieldSpec actual = relation.createModifierFromOtherFieldSpec(fieldSpec);
         FieldSpec expected = fromMax(2020);
@@ -116,7 +120,7 @@ class FieldSpecRelationTest
     public void before_range_returnsFromMin(){
         int maxYear = 2020;
         FieldSpec fieldSpec = forYears(maxYear-3, maxYear);
-        BeforeRelation relation = new BeforeRelation(main, other, false, DateTimeDefaults.get());
+        BeforeRelation relation = new BeforeOffsetRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0));
 
         RestrictionsFieldSpec actualFieldSpec = (RestrictionsFieldSpec) relation.createModifierFromOtherFieldSpec(fieldSpec);
         LinearRestrictions actualRestrictions = (LinearRestrictions) actualFieldSpec.getRestrictions();

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
@@ -77,8 +77,9 @@ class FieldSpecRelationTest
 
     public void after_range_returnsFromMin() {
         int minYear = 2018;
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
         FieldSpec fieldSpec = forYears(minYear, minYear + 4);
-        AfterOffsetRelation relation = new AfterRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0);
+        AfterOffsetRelation relation = new AfterOffsetRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0);
 
         RestrictionsFieldSpec actualFieldSpec = (RestrictionsFieldSpec) relation.createModifierFromOtherFieldSpec(fieldSpec);
         LinearRestrictions actualRestrictions = (LinearRestrictions) actualFieldSpec.getRestrictions();
@@ -120,8 +121,9 @@ class FieldSpecRelationTest
     @Test
     public void before_range_returnsFromMin(){
         int maxYear = 2020;
+        DateTimeGranularity offsetGranularity = DateTimeGranularity.create("MILLIS");
         FieldSpec fieldSpec = forYears(maxYear-3, maxYear);
-        BeforeRelation relation = new BeforeOffsetRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0));
+        BeforeOffsetRelation relation = new BeforeOffsetRelation(main, other, false, DateTimeDefaults.get(), offsetGranularity, 0);
 
         RestrictionsFieldSpec actualFieldSpec = (RestrictionsFieldSpec) relation.createModifierFromOtherFieldSpec(fieldSpec);
         LinearRestrictions actualRestrictions = (LinearRestrictions) actualFieldSpec.getRestrictions();

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/FieldSpecRelationTest.java
@@ -74,6 +74,7 @@ class FieldSpecRelationTest
     }
 
     @Test
+
     public void after_range_returnsFromMin() {
         int minYear = 2018;
         FieldSpec fieldSpec = forYears(minYear, minYear + 4);

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
@@ -31,6 +31,22 @@ Feature: running datetimes related to otherfield datetimes
       | 2018-09-01T00:00:00.002Z | 2018-09-01T00:00:00.003Z |
       | 2018-09-01T00:00:00.003Z | 2018-09-01T00:00:00.003Z |
 
+  Scenario: Running an "afterField" constraint allows one date to be always later than another with a positive offset
+    Given the generator can generate at most 1 rows
+    And foo is after 2000-01-01T00:00:00.000Z
+    And there is a constraint:
+      """
+        {
+          "field": "bar",
+          "afterField": "foo",
+          "offset": 3,
+          "offsetUnit": "days"
+        }
+      """
+    Then the following data should be generated:
+      | foo                      | bar                      |
+      | 2000-01-01T00:00:00.001Z | 2000-01-04T00:00:00.002Z |
+
   Scenario: Running a "beforeField" constraint allows one date to be always earlier than another
     Given the generator can generate at most 3 rows
     And bar is before 0001-01-01T00:00:00.003Z

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
@@ -53,6 +53,24 @@ Feature: running datetimes related to otherfield datetimes
       | 0001-01-01T00:00:00.001Z | 0001-01-01T00:00:00.002Z |
       | 0001-01-01T00:00:00.002Z | 0001-01-01T00:00:00.002Z |
 
+
+  Scenario: Running an "beforeField" constraint allows one date to be always earlier than another with a positive offset
+    Given the generator can generate at most 1 rows
+    And foo is after 2000-01-01T00:00:00.000Z
+    And bar is after 1999-12-27T23:59:59.999Z
+    And there is a constraint:
+      """
+        {
+          "field": "bar",
+          "beforeField": "foo",
+          "offset": 3,
+          "offsetUnit": "days"
+        }
+      """
+    Then the following data should be generated:
+      | foo                      | bar                      |
+      | 2000-01-01T00:00:00.001Z | 1999-12-28T00:00:00.000Z |
+
   Scenario: Running an "equalToField" constraint allows one date to be always equal to another
     Given foo is equal to 2018-09-01T00:00:00.000Z
     And the generator can generate at most 1 rows

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/temporal/DateTimeOtherField.feature
@@ -31,21 +31,39 @@ Feature: running datetimes related to otherfield datetimes
       | 2018-09-01T00:00:00.002Z | 2018-09-01T00:00:00.003Z |
       | 2018-09-01T00:00:00.003Z | 2018-09-01T00:00:00.003Z |
 
-  Scenario: Running an "afterField" constraint allows one date to be always later than another with a positive offset
+  Scenario: Running an "afterOrAtField" constraint allows one date to be the same value as another date
     Given the generator can generate at most 1 rows
     And foo is after 2000-01-01T00:00:00.000Z
     And there is a constraint:
       """
         {
           "field": "bar",
-          "afterField": "foo",
+          "afterOrAtField": "foo",
           "offset": 3,
           "offsetUnit": "days"
         }
       """
     Then the following data should be generated:
       | foo                      | bar                      |
-      | 2000-01-01T00:00:00.001Z | 2000-01-04T00:00:00.002Z |
+      | 2000-01-01T00:00:00.001Z | 2000-01-01T00:00:00.001Z |
+
+  Scenario: Running an "afterField" constraint allows one date to be always later than another with a positive offset
+    Given the generator can generate at most 1 rows
+    And foo is after 2000-01-01T12:34:56.123Z
+    And foo is granular to "millis"
+    And bar is granular to "millis"
+    And there is a constraint:
+      """
+        {
+          "field": "bar",
+          "afterField": "foo",
+          "offset": 1,
+          "offsetUnit": "days"
+        }
+      """
+    Then the following data should be generated:
+      | foo                      | bar                      |
+      | 2000-01-01T12:34:56.124Z | 2000-01-02T12:34:56.124Z |
 
   Scenario: Running a "beforeField" constraint allows one date to be always earlier than another
     Given the generator can generate at most 3 rows

--- a/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/FieldSpecRelationFactory.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/FieldSpecRelationFactory.java
@@ -7,12 +7,15 @@ import com.scottlogic.deg.generator.fieldspecs.relations.*;
 import com.scottlogic.deg.profile.dtos.constraints.relations.EqualToFieldConstraintDTO;
 import com.scottlogic.deg.profile.dtos.constraints.relations.RelationalConstraintDTO;
 
+import static com.scottlogic.deg.common.util.GranularityUtils.readGranularity;
+
 public abstract class FieldSpecRelationFactory
 {
     public FieldSpecRelation createRelation(RelationalConstraintDTO dto, Fields fields)
     {
         Field main = fields.getByName(dto.field);
         Field other = fields.getByName(dto.getOtherField());
+        Granularity offsetGranularity = readGranularity(main.getType(), dto.offsetUnit);
         DateTimeDefaults dateTimeDefaults = DateTimeDefaults.get();
         NumericDefaults numericDefaults = NumericDefaults.get();
         switch (dto.getType())
@@ -20,21 +23,21 @@ public abstract class FieldSpecRelationFactory
             case EQUAL_TO_FIELD:
                 return createEqualToRelation((EqualToFieldConstraintDTO) dto, fields);
             case AFTER_FIELD:
-                return new AfterRelation(main, other, false, dateTimeDefaults);
+                return new AfterOffsetRelation(main, other, dto.offset > 0, dateTimeDefaults, offsetGranularity, dto.offset);
             case AFTER_OR_AT_FIELD:
-                return new AfterRelation(main, other, true, dateTimeDefaults);
+                return new AfterOffsetRelation(main, other, true, dateTimeDefaults, offsetGranularity, 0);
             case BEFORE_FIELD:
-                return new BeforeRelation(main, other, false, dateTimeDefaults);
+                return new BeforeOffsetRelation(main, other, dto.offset > 0, dateTimeDefaults, offsetGranularity, dto.offset);
             case BEFORE_OR_AT_FIELD:
-                return new BeforeRelation(main, other, true, dateTimeDefaults);
+                return new BeforeOffsetRelation(main, other, true, dateTimeDefaults, offsetGranularity, 0);
             case GREATER_THAN_FIELD:
-                return new AfterRelation(main, other, false, numericDefaults);
+                return new AfterOffsetRelation(main, other, false, numericDefaults, offsetGranularity, 0);
             case GREATER_THAN_OR_EQUAL_TO_FIELD:
-                return new AfterRelation(main, other, true, numericDefaults);
+                return new AfterOffsetRelation(main, other, true, numericDefaults, offsetGranularity, 0);
             case LESS_THAN_FIELD:
-                return new BeforeRelation(main, other, false, numericDefaults);
+                return new BeforeOffsetRelation(main, other, false, numericDefaults, offsetGranularity, 0);
             case LESS_THAN_OR_EQUAL_TO_FIELD:
-                return new BeforeRelation(main, other, true, numericDefaults);
+                return new BeforeOffsetRelation(main, other, true, numericDefaults, offsetGranularity, 0);
             default:
                 throw new IllegalStateException("Unexpected relation type: " + dto.getType());
         }


### PR DESCRIPTION
### Description
Allow beforeOffset and afterOffset relations.

E.g. foo is 3 days before bar, where bar is also a variable with its own constraints.

### Changes
Change the behaviour of granulairity and constraints to allow finding previous values as well as next values.

Add the beforeOffsetRelation

### Issue
Resolves #1453