### PR TITLE
fix(#1187): String lengths are uniformly random

### DIFF
--- a/common/src/main/java/com/scottlogic/deg/common/util/Defaults.java
+++ b/common/src/main/java/com/scottlogic/deg/common/util/Defaults.java
@@ -32,6 +32,7 @@ public class Defaults {
 
     public static final BigDecimal NUMERIC_MAX = new BigDecimal("1e20");
     public static final BigDecimal NUMERIC_MIN = new BigDecimal("-1e20");
+
     public static final int MAX_STRING_LENGTH = 1000;
     public static final OffsetDateTime ISO_MAX_DATE = OffsetDateTime.of(9999, 12, 31, 23, 59, 59, 999_000_000, ZoneOffset.UTC);
     public static final OffsetDateTime ISO_MIN_DATE = OffsetDateTime.of(1, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/string/generators/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/string/generators/RegexStringGenerator.java
@@ -16,10 +16,13 @@
 
 package com.scottlogic.deg.generator.generation.string.generators;
 
+import com.scottlogic.deg.common.profile.FieldType;
+import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.generation.string.AutomatonUtils;
 import com.scottlogic.deg.generator.generation.string.iterators.FiniteStringAutomatonIterator;
 import com.scottlogic.deg.generator.generation.string.factorys.InterestingStringFactory;
 import com.scottlogic.deg.generator.generation.string.factorys.RandomStringFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
 import com.scottlogic.deg.generator.utils.RandomNumberGenerator;
 import dk.brics.automaton.Automaton;
 
@@ -38,6 +41,8 @@ public class RegexStringGenerator implements StringGenerator {
      * Cache of all containing regex automatons, keyed on their regex
      */
     private static final Map<String, Automaton> containingRegexAutomatonCache = new HashMap<>();
+
+    private static final RegexStringGenerator DEFAULT = (RegexStringGenerator) ((StringRestrictions) FieldSpecFactory.fromType(FieldType.STRING).getRestrictions()).createGenerator();
 
     private Automaton automaton;
     private final String regexRepresentation;
@@ -119,7 +124,7 @@ public class RegexStringGenerator implements StringGenerator {
     @Override
     public StringGenerator complement() {
         return new RegexStringGenerator(
-            this.automaton.clone().complement(),
+            this.automaton.clone().complement().intersection(DEFAULT.automaton),
             complementaryRepresentation(this.regexRepresentation));
     }
 
@@ -150,10 +155,7 @@ public class RegexStringGenerator implements StringGenerator {
     public Stream<String> generateRandomValues(RandomNumberGenerator randomNumberGenerator) {
         return Stream.generate(
             () -> randomStringFactory.createRandomString(
-                "",
                 automaton.getInitialState(),
-                1,
-                Integer.MAX_VALUE,
                 randomNumberGenerator));
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterConstantTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterConstantTimeConstraint.java
@@ -22,7 +22,7 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
-import com.scottlogic.deg.generator.utils.Defaults;
+import com.scottlogic.deg.generator.utils.GeneratorDefaults;
 
 import java.time.LocalTime;
 
@@ -50,7 +50,7 @@ public class AfterConstantTimeConstraint implements AtomicConstraint {
     public FieldSpec toFieldSpec() {
         final Limit<LocalTime> min = new Limit<>(referenceValue.getValue(), false);
         final LinearRestrictions<LocalTime> timeRestrictions =
-            LinearRestrictionsFactory.createTimeRestrictions(min, Defaults.TIME_MAX_LIMIT);
+            LinearRestrictionsFactory.createTimeRestrictions(min, GeneratorDefaults.TIME_MAX_LIMIT);
         return FieldSpecFactory.fromRestriction(timeRestrictions);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterConstraint.java
@@ -26,7 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
 
 public class AfterConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterOrAtConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterOrAtConstraint.java
@@ -27,7 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
 
 public class AfterOrAtConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterOrEqualToConstantTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/AfterOrEqualToConstantTimeConstraint.java
@@ -22,7 +22,7 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
-import com.scottlogic.deg.generator.utils.Defaults;
+import com.scottlogic.deg.generator.utils.GeneratorDefaults;
 
 import java.time.LocalTime;
 
@@ -50,7 +50,7 @@ public class AfterOrEqualToConstantTimeConstraint implements AtomicConstraint{
     public FieldSpec toFieldSpec() {
         final Limit<LocalTime> min = new Limit<>(referenceValue.getValue(), true);
         final LinearRestrictions<LocalTime> timeRestrictions =
-            LinearRestrictionsFactory.createTimeRestrictions(min, Defaults.TIME_MAX_LIMIT);
+            LinearRestrictionsFactory.createTimeRestrictions(min, GeneratorDefaults.TIME_MAX_LIMIT);
         return FieldSpecFactory.fromRestriction(timeRestrictions);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeConstantTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeConstantTimeConstraint.java
@@ -22,7 +22,7 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
-import com.scottlogic.deg.generator.utils.Defaults;
+import com.scottlogic.deg.generator.utils.GeneratorDefaults;
 
 import java.time.LocalTime;
 
@@ -51,7 +51,7 @@ public class BeforeConstantTimeConstraint implements AtomicConstraint {
 
         final Limit<LocalTime> max = new Limit<>(referenceValue.getValue(), false);
         final LinearRestrictions<LocalTime> timeRestriction =
-            LinearRestrictionsFactory.createTimeRestrictions(Defaults.TIME_MIN_LIMIT, max);
+            LinearRestrictionsFactory.createTimeRestrictions(GeneratorDefaults.TIME_MIN_LIMIT, max);
         if (timeRestriction.isContradictory()) {
             return FieldSpecFactory.nullOnly();
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeConstraint.java
@@ -26,7 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 
 public class BeforeConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeOrAtConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeOrAtConstraint.java
@@ -26,7 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 
 public class BeforeOrAtConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeOrEqualToConstantTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/BeforeOrEqualToConstantTimeConstraint.java
@@ -22,7 +22,7 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
-import com.scottlogic.deg.generator.utils.Defaults;
+import com.scottlogic.deg.generator.utils.GeneratorDefaults;
 
 import java.time.LocalTime;
 
@@ -49,7 +49,7 @@ public class BeforeOrEqualToConstantTimeConstraint implements AtomicConstraint {
     public FieldSpec toFieldSpec() {
         final Limit<LocalTime> max = new Limit<>(referenceValue.getValue(), true);
         final LinearRestrictions<LocalTime> timeRestriction =
-            LinearRestrictionsFactory.createTimeRestrictions(Defaults.TIME_MIN_LIMIT, max);
+            LinearRestrictionsFactory.createTimeRestrictions(GeneratorDefaults.TIME_MIN_LIMIT, max);
         return FieldSpecFactory.fromRestriction(timeRestriction);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GranularToDateConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GranularToDateConstraint.java
@@ -25,8 +25,8 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 
 public class GranularToDateConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GranularToTimeConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GranularToTimeConstraint.java
@@ -21,7 +21,7 @@ import com.scottlogic.deg.common.profile.TimeGranularity;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
-import com.scottlogic.deg.generator.utils.Defaults;
+import com.scottlogic.deg.generator.utils.GeneratorDefaults;
 
 public class GranularToTimeConstraint implements AtomicConstraint {
     public final TimeGranularity timeGranularity;
@@ -51,8 +51,8 @@ public class GranularToTimeConstraint implements AtomicConstraint {
     public FieldSpec toFieldSpec() {
         return FieldSpecFactory.fromRestriction(
             LinearRestrictionsFactory.createTimeRestrictions(
-                Defaults.TIME_MIN_LIMIT,
-                Defaults.TIME_MAX_LIMIT,
+                GeneratorDefaults.TIME_MIN_LIMIT,
+                GeneratorDefaults.TIME_MAX_LIMIT,
                 timeGranularity));
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GreaterThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GreaterThanConstraint.java
@@ -26,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
 
 public class GreaterThanConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GreaterThanOrEqualToConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/GreaterThanOrEqualToConstraint.java
@@ -26,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
 
 public class GreaterThanOrEqualToConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LessThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LessThanConstraint.java
@@ -26,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 
 public class LessThanConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LessThanOrEqualToConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LessThanOrEqualToConstraint.java
@@ -26,7 +26,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 
 public class LessThanOrEqualToConstraint implements AtomicConstraint {
     public final Field field;

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/LinearRestrictionsFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/linear/LinearRestrictionsFactory.java
@@ -22,7 +22,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
 import static com.scottlogic.deg.common.util.Defaults.*;
-import static com.scottlogic.deg.generator.utils.Defaults.*;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.*;
 
 public class LinearRestrictionsFactory {
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/GeneratorDefaults.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/GeneratorDefaults.java
@@ -24,7 +24,7 @@ import java.time.OffsetDateTime;
 
 import static com.scottlogic.deg.common.util.Defaults.*;
 
-public class Defaults {
+public class GeneratorDefaults {
 
     public static final Limit<BigDecimal> NUMERIC_MAX_LIMIT = new Limit<>(NUMERIC_MAX, true);
     public static final Limit<BigDecimal> NUMERIC_MIN_LIMIT= new Limit<>(NUMERIC_MIN, true);

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 import static com.scottlogic.deg.common.profile.FieldType.*;
 import static com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory.forMaxLength;
-import static com.scottlogic.deg.generator.utils.Defaults.*;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
@@ -33,9 +33,9 @@ import java.util.Optional;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDateTimeRestrictions;
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 import static org.mockito.Mockito.*;
 
 class RestrictionsMergeOperationTest {

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecGetFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecGetFieldValueSourceTests.java
@@ -37,8 +37,8 @@ import java.util.stream.Collectors;
 
 import static com.scottlogic.deg.common.profile.FieldType.*;
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 
 public class FieldSpecGetFieldValueSourceTests {
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.*;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
@@ -34,8 +34,8 @@ import java.util.*;
 
 import static com.scottlogic.deg.common.util.Defaults.ISO_MAX_DATE;
 import static com.scottlogic.deg.common.util.Defaults.ISO_MIN_DATE;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/string/RegexStringGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/string/RegexStringGeneratorTests.java
@@ -18,12 +18,14 @@ package com.scottlogic.deg.generator.generation.string;
 
 import com.scottlogic.deg.generator.generation.string.generators.RegexStringGenerator;
 import com.scottlogic.deg.generator.generation.string.generators.StringGenerator;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -155,7 +157,7 @@ class RegexStringGeneratorTests {
 
     @Test
     void shouldCorrectlySampleInfiniteResults() {
-        StringGenerator generator = new RegexStringGenerator("[a]+", false);
+        StringGenerator generator = StringRestrictionsFactory.forStringMatching(Pattern.compile("[a]+"), false).createGenerator();
 
         Stream<String> results = generator.generateRandomValues(new JavaUtilRandomNumberGenerator(0));
 
@@ -183,7 +185,8 @@ class RegexStringGeneratorTests {
 
     @Test
     void shouldProduceComplement() {
-        StringGenerator limitedRangeGenerator = new RegexStringGenerator("[a-m]", true);
+        StringGenerator limitedRangeGenerator =
+            StringRestrictionsFactory.forStringMatching(Pattern.compile("[a-m]"), false).createGenerator();
         StringGenerator complementedGenerator = limitedRangeGenerator.complement();
 
         String sampleValue = complementedGenerator

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
@@ -25,7 +25,7 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 
 import static com.scottlogic.deg.common.util.Defaults.ISO_MAX_DATE;
-import static com.scottlogic.deg.generator.utils.Defaults.*;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.*;
 import static java.time.temporal.ChronoUnit.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
@@ -28,8 +28,8 @@ import java.time.ZoneOffset;
 
 import static com.scottlogic.deg.common.util.Defaults.ISO_MAX_DATE;
 import static com.scottlogic.deg.common.util.Defaults.ISO_MIN_DATE;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.DATETIME_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.DATETIME_MIN_LIMIT;
 import static java.time.temporal.ChronoUnit.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.Optional;
 
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.Is.is;

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsTests.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MAX_LIMIT;
-import static com.scottlogic.deg.generator.utils.Defaults.NUMERIC_MIN_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
+import static com.scottlogic.deg.generator.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 


### PR DESCRIPTION
Previously string lengths would follow a geometric distribution between
the min and max, where each successive term would have a 3/10 chance of
being the terminal character added to the string.

Therefore in the previous case, regardless of the maximum (where the maximum is at
least 5 greater than the minimum), typically 50% of the values would be
within 2 characters of the minimum length.

This change instead generates up to the maximum length (our current
default is 1,000), and slices randomly between the min and max length.
This change appears to cut performance by about half for the example
given in shorter-than, at the advantage of giving a uniform
distribution. Note that this is for a single string (so the cost is likely to be greater for more strings), but also for a very extreme case where previously the actual result was _very_ different to what one would expect the result to be.

### Issue
Resolves #1187 
