### PR TITLE
Boolean data types

### DIFF
--- a/common/src/main/java/com/scottlogic/deg/common/profile/FieldType.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/FieldType.java
@@ -20,5 +20,6 @@ public enum FieldType
 {
     NUMERIC,
     STRING,
-    DATETIME
+    DATETIME,
+    BOOLEAN
 }

--- a/common/src/main/java/com/scottlogic/deg/common/profile/SpecificFieldType.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/SpecificFieldType.java
@@ -33,7 +33,8 @@ public enum SpecificFieldType
     FULL_NAME("fullname", FieldType.STRING),
     STRING("string", FieldType.STRING),
     DATETIME("datetime", FieldType.DATETIME),
-    DATE("date",FieldType.DATETIME);
+    DATE("date",FieldType.DATETIME),
+    BOOLEAN("boolean", FieldType.BOOLEAN);
 
     @JsonValue
     private final String type;
@@ -69,6 +70,7 @@ public enum SpecificFieldType
             case "string": return STRING;
             case "datetime": return DATETIME;
             case "date": return DATE;
+            case "boolean": return BOOLEAN;
             default:
                 throw new IllegalStateException("No data types with type " + type);
         }

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -210,6 +210,7 @@ The data type of the field. See [Data types](#Data-Types) for more on how types 
 *  `firstname`
 *  `lastname`
 *  `fullname`
+*  `boolean`
 
  This is a required property.
 
@@ -250,6 +251,12 @@ Sets the field as unique. Unique fields can not be used within [grammatical cons
 
 
 # Data Types
+
+## Boolean
+
+Users can specify boolean data types which will take the values `true` and `false`.
+
+Currently these types are only supported with the `equalTo` and `equalToField` constraints, for example:
 
 ## Integer/Decimal
 
@@ -334,6 +341,8 @@ OR
 { "field": "type", "equalTo": 23 }
 OR
 { "field": "type", "equalTo": "2001-02-03T04:05:06.007" }
+OR
+{ "field": "type", "equalTo": true }
 ```
 
 Is satisfied if `field`'s value is equal to `value`

--- a/examples/boolean/README.md
+++ b/examples/boolean/README.md
@@ -1,0 +1,1 @@
+A profile that generates booleans.

--- a/examples/boolean/profile.json
+++ b/examples/boolean/profile.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "0.14",
+  "fields": [
+    {
+      "name": "alwaysTrue",
+      "type": "boolean",
+      "nullable": false
+    },
+    {
+      "name": "alwaysFalseOrNull",
+      "type": "boolean",
+      "nullable": true
+    }
+  ],
+  "rules": [
+    {
+      "constraints": [
+        {
+          "field": "alwaysTrue",
+          "equalTo": true
+        },
+        {
+          "not": {
+            "field": "alwaysFalseOrNull",
+            "equalToField": "alwaysTrue"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -20,6 +20,7 @@ import com.scottlogic.deg.common.profile.FieldType;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.generation.fieldvaluesources.FieldValueSource;
 import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
+import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictions;
 
 import java.util.Collections;
 import java.util.function.Function;
@@ -47,6 +48,8 @@ public class FieldSpecFactory {
                 return new RestrictionsFieldSpec(createDefaultDateTimeRestrictions(), true, Collections.emptySet());
             case STRING:
                 return new RestrictionsFieldSpec(forMaxLength(1000), true, Collections.emptySet());
+            case BOOLEAN:
+                return new RestrictionsFieldSpec(new BooleanRestrictions(), true, Collections.emptySet());
             default:
                 throw new IllegalArgumentException("Unable to create FieldSpec from type " + type.name());
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -24,7 +24,7 @@ import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
 import java.util.Collections;
 import java.util.function.Function;
 
-import static com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory.forMaxLength;
+import static com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory.forMaxLength;
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDefaultDateTimeRestrictions;
 import static com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory.createDefaultNumericRestrictions;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
 import com.scottlogic.deg.generator.utils.SetUtils;

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -18,6 +18,7 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.WeightedElement;
+import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class FieldSpecMerger {
     private final RestrictionsMergeOperation restrictionMergeOperation =
-        new RestrictionsMergeOperation(new LinearRestrictionsMerger(), new StringRestrictionsMerger());
+        new RestrictionsMergeOperation(new LinearRestrictionsMerger(), new StringRestrictionsMerger(), new BooleanRestrictionsMerger());
 
     /**
      * Null parameters are permitted, and are synonymous with an empty FieldSpec

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
@@ -18,6 +18,8 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.restrictions.*;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
 
 import java.util.Optional;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
@@ -17,6 +17,8 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.restrictions.*;
+import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
@@ -33,14 +35,16 @@ public class RestrictionsMergeOperation {
     }
 
     public Optional<TypedRestrictions> applyMergeOperation(TypedRestrictions left, TypedRestrictions right, boolean useFinestGranularityAvailable) {
-        return getMerger(left)
-            .merge(left, right, useFinestGranularityAvailable);
+        return getMerger(left).merge(left, right, useFinestGranularityAvailable);
     }
 
     private RestrictionsMerger getMerger(TypedRestrictions restrictions) {
         if (restrictions instanceof StringRestrictions) {
             return stringMerger;
         }
-        return linearMerger;
+        if (restrictions instanceof LinearRestrictions) {
+            return linearMerger;
+        }
+        return new BooleanRestrictionsMerger();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperation.java
@@ -17,6 +17,7 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.restrictions.*;
+import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictions;
 import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;
@@ -28,10 +29,12 @@ import java.util.Optional;
 public class RestrictionsMergeOperation {
     private final RestrictionsMerger linearMerger;
     private final RestrictionsMerger stringMerger;
+    private final RestrictionsMerger booleanMerger;
 
-    public RestrictionsMergeOperation(LinearRestrictionsMerger linearMerger, StringRestrictionsMerger stringMerger) {
+    public RestrictionsMergeOperation(LinearRestrictionsMerger linearMerger, StringRestrictionsMerger stringMerger, BooleanRestrictionsMerger booleanMerger) {
         this.linearMerger = linearMerger;
         this.stringMerger = stringMerger;
+        this.booleanMerger = booleanMerger;
     }
 
     public Optional<TypedRestrictions> applyMergeOperation(TypedRestrictions left, TypedRestrictions right, boolean useFinestGranularityAvailable) {
@@ -45,6 +48,9 @@ public class RestrictionsMergeOperation {
         if (restrictions instanceof LinearRestrictions) {
             return linearMerger;
         }
-        return new BooleanRestrictionsMerger();
+        if (restrictions instanceof BooleanRestrictions) {
+            return booleanMerger;
+        }
+        throw new IllegalStateException(restrictions.getClass() + " is an unsupported class");
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/BooleanFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/BooleanFieldValueSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.generator.generation.fieldvaluesources;
+
+import com.scottlogic.deg.generator.utils.RandomNumberGenerator;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class BooleanFieldValueSource implements FieldValueSource<Boolean>
+{
+    private final Set<Boolean> blacklist;
+
+    public BooleanFieldValueSource(Set<Boolean> blacklist) {
+        this.blacklist = blacklist;
+    }
+
+    @Override
+    public Stream<Boolean> generateAllValues() {
+        return Stream.of(true, false).filter(this::notInBlacklist);
+    }
+
+    @Override
+    public Stream<Boolean> generateInterestingValues() {
+        return generateAllValues();
+    }
+
+    @Override
+    public Stream<Boolean> generateRandomValues(RandomNumberGenerator randomNumberGenerator) {
+        return Stream.generate(() -> Math.random() < 0.5).filter(this::notInBlacklist);
+    }
+
+    private boolean notInBlacklist(Boolean b) {
+        return blacklist.stream().noneMatch(x -> x.equals(b));
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/BooleanFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/BooleanFieldValueSource.java
@@ -41,7 +41,7 @@ public class BooleanFieldValueSource implements FieldValueSource<Boolean>
 
     @Override
     public Stream<Boolean> generateRandomValues(RandomNumberGenerator randomNumberGenerator) {
-        return Stream.generate(() -> Math.random() < 0.5).filter(this::notInBlacklist);
+        return Stream.generate(() -> randomNumberGenerator.nextInt() % 2 == 0).filter(this::notInBlacklist);
     }
 
     private boolean notInBlacklist(Boolean b) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/ContainsRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/ContainsRegexConstraint.java
@@ -19,7 +19,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LongerThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/LongerThanConstraint.java
@@ -19,7 +19,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/MatchesRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/MatchesRegexConstraint.java
@@ -19,7 +19,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/MatchesStandardConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/MatchesStandardConstraint.java
@@ -20,7 +20,7 @@ import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.generation.string.generators.StringGenerator;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotContainsRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotContainsRegexConstraint.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotMatchesRegexConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotMatchesRegexConstraint.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotMatchesStandardConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotMatchesStandardConstraint.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotStringLengthConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/NotStringLengthConstraint.java
@@ -18,7 +18,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/OfLengthConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/OfLengthConstraint.java
@@ -19,7 +19,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/ShorterThanConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/profile/constraints/atomic/ShorterThanConstraint.java
@@ -19,7 +19,7 @@ package com.scottlogic.deg.generator.profile.constraints.atomic;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 
 import java.util.Objects;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/bool/BooleanRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/bool/BooleanRestrictions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.generator.restrictions.bool;
+
+import com.scottlogic.deg.generator.generation.fieldvaluesources.BooleanFieldValueSource;
+import com.scottlogic.deg.generator.generation.fieldvaluesources.FieldValueSource;
+import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
+
+import java.util.Set;
+
+public class BooleanRestrictions implements TypedRestrictions<Boolean>
+{
+    @Override
+    public boolean match(Boolean value) {
+        return true;
+    }
+
+    @Override
+    public FieldValueSource<Boolean> createFieldValueSource(Set<Boolean> blacklist) {
+        return new BooleanFieldValueSource(blacklist);
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/bool/BooleanRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/bool/BooleanRestrictionsMerger.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.deg.generator.restrictions.bool;
+
+import com.scottlogic.deg.generator.restrictions.RestrictionsMerger;
+
+import java.util.Optional;
+
+/**
+ * For a given combination of choices over the decision tree
+ * Details every column's atomic constraints
+ */
+public class BooleanRestrictionsMerger implements RestrictionsMerger<BooleanRestrictions>
+{
+    @Override
+    public Optional<BooleanRestrictions> merge(BooleanRestrictions left, BooleanRestrictions right, boolean useFinestGranularityAvailable) {
+        return Optional.of(new BooleanRestrictions());
+    }
+}
+

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictions.java
@@ -41,7 +41,7 @@ public class StringRestrictions implements TypedRestrictions<String>
     private final Set<Pattern> notContainingRegex;
     private StringGenerator generator;
 
-    StringRestrictions(
+    public StringRestrictions(
         Integer minLength,
         Integer maxLength,
         Set<Pattern> matchingRegex,

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictions.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.scottlogic.deg.generator.restrictions;
+package com.scottlogic.deg.generator.restrictions.string;
 
 import com.scottlogic.deg.generator.generation.fieldvaluesources.FieldValueSource;
 import com.scottlogic.deg.generator.generation.string.generators.NoStringsStringGenerator;
 import com.scottlogic.deg.generator.generation.string.generators.RegexStringGenerator;
 import com.scottlogic.deg.generator.generation.string.generators.StringGenerator;
+import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
 import com.scottlogic.deg.generator.utils.SetUtils;
 
 import java.util.*;
@@ -29,7 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-public class StringRestrictions implements TypedRestrictions<String> {
+public class StringRestrictions implements TypedRestrictions<String>
+{
     private final Integer minLength;
     private final Integer maxLength;
     private final Set<Integer> excludedLengths;

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictionsFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictionsFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.scottlogic.deg.generator.restrictions;
+package com.scottlogic.deg.generator.restrictions.string;
 
 import java.util.Collections;
 import java.util.regex.Pattern;

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/string/StringRestrictionsMerger.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.scottlogic.deg.generator.restrictions;
+package com.scottlogic.deg.generator.restrictions.string;
+
+import com.scottlogic.deg.generator.restrictions.RestrictionsMerger;
 
 import java.util.Optional;
 
@@ -22,7 +24,8 @@ import java.util.Optional;
  * For a given combination of choices over the decision tree
  * Details every column's atomic constraints
  */
-public class StringRestrictionsMerger implements RestrictionsMerger<StringRestrictions> {
+public class StringRestrictionsMerger implements RestrictionsMerger<StringRestrictions>
+{
 
     @Override
     public Optional<StringRestrictions> merge(StringRestrictions left, StringRestrictions right, boolean useFinestGranularityAvailable) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecTests.java
@@ -21,6 +21,7 @@ import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.generation.fieldvaluesources.FieldValueSource;
 import com.scottlogic.deg.generator.restrictions.*;
 import com.scottlogic.deg.generator.restrictions.linear.*;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ import java.util.Arrays;
 import java.util.Set;
 
 import static com.scottlogic.deg.common.profile.FieldType.*;
-import static com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory.forMaxLength;
+import static com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory.forMaxLength;
 import static com.scottlogic.deg.generator.utils.Defaults.*;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.scottlogic.deg.generator.restrictions.bool.BooleanRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
@@ -39,7 +40,8 @@ import static org.mockito.Mockito.*;
 
 class RestrictionsMergeOperationTest {
     private LinearRestrictionsMerger linearMerger;
-    private StringRestrictionsMerger StringMerger;
+    private StringRestrictionsMerger stringMerger;
+    private BooleanRestrictionsMerger booleanMerger;
     private RestrictionsMergeOperation operation;
     private static TypedRestrictions leftNumeric;
     private static TypedRestrictions rightNumeric;
@@ -69,8 +71,9 @@ class RestrictionsMergeOperationTest {
     @BeforeEach
     void beforeEach(){
         linearMerger = mock(LinearRestrictionsMerger.class);
-        StringMerger = mock(StringRestrictionsMerger.class);
-        operation = new RestrictionsMergeOperation(linearMerger, StringMerger);
+        stringMerger = mock(StringRestrictionsMerger.class);
+        booleanMerger = mock(BooleanRestrictionsMerger.class);
+        operation = new RestrictionsMergeOperation(linearMerger, stringMerger, booleanMerger);
     }
 
     @Test
@@ -83,7 +86,7 @@ class RestrictionsMergeOperationTest {
 
         Assert.assertEquals(expected, result);
         verify(linearMerger, times(1)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(0)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(0)).merge(any(), any(), anyBoolean());
     }
 
     @Test
@@ -96,33 +99,33 @@ class RestrictionsMergeOperationTest {
 
         Assert.assertEquals(expected, result);
         verify(linearMerger, times(1)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(0)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(0)).merge(any(), any(), anyBoolean());
     }
 
     @Test
     void applyMergeOperation_withStringRestrictions_shouldApplyRestriction(){
         Optional<TypedRestrictions> expected = Optional.of(leftString);
-        when(StringMerger.merge((StringRestrictions)leftString, (StringRestrictions)rightString, false))
+        when(stringMerger.merge((StringRestrictions)leftString, (StringRestrictions)rightString, false))
             .thenReturn(Optional.of((StringRestrictions)leftString));
 
         Optional<TypedRestrictions> result = operation.applyMergeOperation(leftString, rightString, false);
 
         Assert.assertEquals(expected, result);
         verify(linearMerger, times(0)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(1)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(1)).merge(any(), any(), anyBoolean());
     }
 
     @Test
     void applyMergeOperation_withContradictoryStringRestrictions_shouldPreventAnyValues(){
         Optional<TypedRestrictions> expected = Optional.empty();
-        when(StringMerger.merge((StringRestrictions)leftString, (StringRestrictions)rightString, false))
+        when(stringMerger.merge((StringRestrictions)leftString, (StringRestrictions)rightString, false))
             .thenReturn(Optional.empty());
 
         Optional<TypedRestrictions> result = operation.applyMergeOperation(leftString, rightString, false);
 
         Assert.assertEquals(expected, result);
         verify(linearMerger, times(0)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(1)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(1)).merge(any(), any(), anyBoolean());
     }
 
     @Test
@@ -135,7 +138,7 @@ class RestrictionsMergeOperationTest {
 
         Assert.assertEquals(result, result);
         verify(linearMerger, times(1)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(0)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(0)).merge(any(), any(), anyBoolean());
     }
 
     @Test
@@ -148,6 +151,6 @@ class RestrictionsMergeOperationTest {
 
         Assert.assertEquals(expected, result);
         verify(linearMerger, times(1)).merge(any(), any(), anyBoolean());
-        verify(StringMerger, times(0)).merge(any(), any(), anyBoolean());
+        verify(stringMerger, times(0)).merge(any(), any(), anyBoolean());
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/RestrictionsMergeOperationTest.java
@@ -16,9 +16,9 @@
 
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.generator.restrictions.StringRestrictions;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.TypedRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsMerger;

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/InMapIndexRelationTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/relations/InMapIndexRelationTest.java
@@ -20,7 +20,7 @@ import com.scottlogic.deg.common.profile.FieldType;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
-import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecGetFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/FieldSpecGetFieldValueSourceTests.java
@@ -23,8 +23,9 @@ import com.scottlogic.deg.generator.fieldspecs.whitelist.DistributedList;
 import com.scottlogic.deg.generator.generation.fieldvaluesources.NullAppendingValueSource;
 import com.scottlogic.deg.generator.generation.fieldvaluesources.FieldValueSource;
 import com.scottlogic.deg.generator.generation.fieldvaluesources.NullOnlySource;
-import com.scottlogic.deg.generator.restrictions.*;
 import com.scottlogic.deg.generator.restrictions.linear.*;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/RestrictionTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/RestrictionTest.java
@@ -19,6 +19,8 @@ package com.scottlogic.deg.generator.restrictions;
 import com.scottlogic.deg.generator.restrictions.linear.Limit;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictions;
 import com.scottlogic.deg.generator.restrictions.linear.LinearRestrictionsFactory;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsFactory;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/StringRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/StringRestrictionsMergerTests.java
@@ -16,6 +16,8 @@
 
 package com.scottlogic.deg.generator.restrictions;
 
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictionsMerger;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/TextualRestrictionsTests.java
@@ -18,6 +18,7 @@ package com.scottlogic.deg.generator.restrictions;
 
 import com.scottlogic.deg.generator.generation.string.generators.RegexStringGenerator;
 import com.scottlogic.deg.generator.generation.string.generators.StringGenerator;
+import com.scottlogic.deg.generator.restrictions.string.StringRestrictions;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/ExhaustiveCombination.feature
@@ -4,6 +4,19 @@ Feature: User can create data across multiple fields for all combinations availa
     Given the generation strategy is full
     And the combination strategy is exhaustive
 
+  Scenario: Running an exhaustive combination strategy with booleans should be successful
+    Given the following non nullable fields exist:
+      | foo |
+      | bar |
+    And foo has type "boolean"
+    And bar has type "boolean"
+    Then the following data should be generated:
+      | foo | bar |
+      | true | true |
+      | true | false |
+      | false | true |
+      | false | false |
+
   Scenario: Running an exhaustive combination strategy with roman alphabet character (a-z) strings should be successful
     Given the generation strategy is full
     And the combination strategy is exhaustive

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/general/EqualTo.feature
@@ -31,6 +31,15 @@ Feature: User can specify that a value is equalTo a required value
       | foo                      |
       | 2010-01-01T00:03:00.000Z |
 
+  Scenario: Running an 'equalTo' of a boolean should return only that boolean
+    Given there is a non nullable field foo
+    And foo has type "boolean"
+    And foo is anything but null
+    And foo is equal to boolean true
+    Then the following data should be generated:
+      | foo  |
+      | true |
+
   Scenario: Running an 'equalTo' of an empty string should return only the empty string
     Given there is a non nullable field foo
     And foo has type "string"

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateTimeValueStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/DateTimeValueStep.java
@@ -38,6 +38,11 @@ public class DateTimeValueStep {
         this.helper = helper;
     }
 
+    @When("^([A-z0-9]+) is equal to boolean true")
+    public void equalToTrue(String fieldName) {
+        state.addConstraint(fieldName, ConstraintType.EQUAL_TO, true);
+    }
+
     @When("^([A-z0-9]+) is equal to (\\d{4,5}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d+Z?)?)?)$")
     public void equalToDateTimeValue(String fieldName, String value) {
         state.addConstraint(fieldName, ConstraintType.EQUAL_TO, value);

--- a/profile/src/main/java/com/scottlogic/deg/profile/factories/constraint_factories/BooleanConstraintFactory.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/factories/constraint_factories/BooleanConstraintFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.scottlogic.deg.profile.factories.constraint_factories;
+
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.generator.profile.constraints.atomic.*;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.GranularToConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.integer.LongerThanConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.integer.OfLengthConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.integer.ShorterThanConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.numeric.GreaterThanConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.numeric.GreaterThanOrEqualToConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.numeric.LessThanConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.numeric.LessThanOrEqualToConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.temporal.AfterConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.temporal.AfterOrAtConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.temporal.BeforeConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.temporal.BeforeOrAtConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.textual.ContainsRegexConstraintDTO;
+import com.scottlogic.deg.profile.dtos.constraints.atomic.textual.MatchesRegexConstraintDTO;
+
+public class BooleanConstraintFactory extends AtomicConstraintFactory {
+
+    @Override
+    Object parseValue(Object value)
+    {
+        return value;
+    }
+
+    @Override
+    MatchesRegexConstraint createMatchesRegexConstraint(MatchesRegexConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    ContainsRegexConstraint createContainsRegexConstraint(ContainsRegexConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    OfLengthConstraint createOfLengthConstraint(OfLengthConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    ShorterThanConstraint createShorterThanConstraint(ShorterThanConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    LongerThanConstraint createLongerThanConstraint(LongerThanConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    GreaterThanConstraint createGreaterThanConstraint(GreaterThanConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    GreaterThanOrEqualToConstraint createGreaterThanOrEqualToConstraint(GreaterThanOrEqualToConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    LessThanConstraint createLessThanConstraint(LessThanConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    LessThanOrEqualToConstraint createLessThanOrEqualToConstraint(LessThanOrEqualToConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    AfterOrAtConstraint createAfterOrAtConstraint(AfterOrAtConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    AfterConstraint createAfterConstraint(AfterConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    BeforeOrAtConstraint createBeforeOrAtConstraint(BeforeOrAtConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    BeforeConstraint createBeforeConstraint(BeforeConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+
+    @Override
+    AtomicConstraint createGranularToConstraint(GranularToConstraintDTO dto, Field field)
+    {
+        return null;
+    }
+}

--- a/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/BooleanRelationFactory.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/BooleanRelationFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.scottlogic.deg.profile.factories.relation_factories;
+
+import com.scottlogic.deg.common.profile.Granularity;
+
+public class BooleanRelationFactory extends FieldSpecRelationFactory
+{
+    @Override
+    Granularity createGranularity(String offsetUnit)
+    {
+        return null;
+    }
+}
+
+

--- a/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/FieldSpecRelationFactory.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/factories/relation_factories/FieldSpecRelationFactory.java
@@ -20,6 +20,7 @@ import com.scottlogic.deg.common.profile.*;
 import com.scottlogic.deg.common.util.defaults.DateTimeDefaults;
 import com.scottlogic.deg.common.util.defaults.NumericDefaults;
 import com.scottlogic.deg.generator.fieldspecs.relations.*;
+import com.scottlogic.deg.profile.dtos.constraints.ConstraintType;
 import com.scottlogic.deg.profile.dtos.constraints.relations.EqualToFieldConstraintDTO;
 import com.scottlogic.deg.profile.dtos.constraints.relations.RelationalConstraintDTO;
 
@@ -31,13 +32,15 @@ public abstract class FieldSpecRelationFactory
     {
         Field main = fields.getByName(dto.field);
         Field other = fields.getByName(dto.getOtherField());
+        if(dto.getType() == ConstraintType.EQUAL_TO_FIELD)
+        {
+            return createEqualToRelation((EqualToFieldConstraintDTO) dto, fields);
+        }
         Granularity offsetGranularity = readGranularity(main.getType(), dto.offsetUnit);
         DateTimeDefaults dateTimeDefaults = DateTimeDefaults.get();
         NumericDefaults numericDefaults = NumericDefaults.get();
         switch (dto.getType())
         {
-            case EQUAL_TO_FIELD:
-                return createEqualToRelation((EqualToFieldConstraintDTO) dto, fields);
             case AFTER_FIELD:
                 return new AfterRelation(main, other, dto.offset > 0, dateTimeDefaults, offsetGranularity, dto.offset);
             case AFTER_OR_AT_FIELD:

--- a/profile/src/main/java/com/scottlogic/deg/profile/services/ConstraintService.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/services/ConstraintService.java
@@ -29,14 +29,8 @@ import com.scottlogic.deg.profile.dtos.constraints.atomic.AtomicConstraintDTO;
 import com.scottlogic.deg.profile.dtos.constraints.grammatical.*;
 import com.scottlogic.deg.profile.dtos.constraints.relations.InMapConstraintDTO;
 import com.scottlogic.deg.profile.dtos.constraints.relations.RelationalConstraintDTO;
-import com.scottlogic.deg.profile.factories.constraint_factories.AtomicConstraintFactory;
-import com.scottlogic.deg.profile.factories.constraint_factories.DateTimeConstraintFactory;
-import com.scottlogic.deg.profile.factories.constraint_factories.NumericConstraintFactory;
-import com.scottlogic.deg.profile.factories.constraint_factories.StringConstraintFactory;
-import com.scottlogic.deg.profile.factories.relation_factories.DateTimeRelationFactory;
-import com.scottlogic.deg.profile.factories.relation_factories.FieldSpecRelationFactory;
-import com.scottlogic.deg.profile.factories.relation_factories.NumericRelationFactory;
-import com.scottlogic.deg.profile.factories.relation_factories.StringRelationFactory;
+import com.scottlogic.deg.profile.factories.constraint_factories.*;
+import com.scottlogic.deg.profile.factories.relation_factories.*;
 
 import java.math.BigDecimal;
 import java.time.temporal.ChronoUnit;
@@ -58,11 +52,13 @@ public class ConstraintService
         atomicConstraintFactoryMap.put(FieldType.DATETIME, new DateTimeConstraintFactory());
         atomicConstraintFactoryMap.put(FieldType.NUMERIC, new NumericConstraintFactory());
         atomicConstraintFactoryMap.put(FieldType.STRING, new StringConstraintFactory());
+        atomicConstraintFactoryMap.put(FieldType.BOOLEAN, new BooleanConstraintFactory());
 
         relationFactoryMap = new EnumMap<>(FieldType.class);
         relationFactoryMap.put(FieldType.DATETIME, new DateTimeRelationFactory());
         relationFactoryMap.put(FieldType.NUMERIC, new NumericRelationFactory());
         relationFactoryMap.put(FieldType.STRING, new StringRelationFactory());
+        relationFactoryMap.put(FieldType.BOOLEAN, new BooleanRelationFactory());
     }
 
     Optional<Constraint> createSpecificTypeConstraint(Field field)

--- a/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/ConstraintValidator.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/ConstraintValidator.java
@@ -142,18 +142,15 @@ public abstract class ConstraintValidator<T extends ConstraintDTO> implements Va
     protected ValidationResult validateGranularity(T dto, String field, Object value)
     {
         FieldType fieldType = fields.stream().filter(f -> f.name.equals(field)).findFirst().get().type.getFieldType();
-
-        if(fieldType == FieldType.STRING)
+        switch (fieldType)
         {
-            return ValidationResult.failure("Granularity "+value+" is not supported for string fields" + getErrorInfo(dto));
+            case BOOLEAN:
+                return ValidationResult.failure("Granularity " + value + " is not supported for boolean fields" + getErrorInfo(dto));
+            case STRING:
+                return ValidationResult.failure("Granularity " + value + " is not supported for string fields" + getErrorInfo(dto));
+            case DATETIME:
+                return new DateTimeGranularityValidator(getErrorInfo(dto)).validate((String) value);
         }
-        if (fieldType == FieldType.DATETIME)
-        {
-            return new DateTimeGranularityValidator(getErrorInfo(dto)).validate((String) value);
-        }
-
         return ValidationResult.success();
     }
-
-
 }

--- a/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/constraints/atomic/AtomicConstraintValidator.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/constraints/atomic/AtomicConstraintValidator.java
@@ -63,7 +63,7 @@ abstract class AtomicConstraintValidator<T extends AtomicConstraintDTO> extends 
         {
             return ValidationResult.failure("Value " + value + " must be a number" + getErrorInfo(dto));
         }
-        if (!(value instanceof String) && fieldType != FieldType.NUMERIC)
+        if (value instanceof Number && fieldType != FieldType.NUMERIC)
         {
             return ValidationResult.failure("Value " + value + " must be a string" + getErrorInfo(dto));
         }

--- a/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/constraints/atomic/AtomicConstraintValidator.java
+++ b/profile/src/main/java/com/scottlogic/deg/profile/validators/profile/constraints/atomic/AtomicConstraintValidator.java
@@ -55,13 +55,17 @@ abstract class AtomicConstraintValidator<T extends AtomicConstraintDTO> extends 
             return ValidationResult.failure("Values must be specified" + getErrorInfo(dto));
         }
         FieldType fieldType = fields.stream().filter(f -> f.name.equals(dto.field)).findFirst().get().type.getFieldType();
+        if(value instanceof Boolean && fieldType != FieldType.BOOLEAN)
+        {
+            return ValidationResult.failure("Value " + value + " must be a boolean" + getErrorInfo(dto));
+        }
         if (!(value instanceof Number || value instanceof String && isNumber((String)value)) && fieldType == FieldType.NUMERIC)
         {
-            return ValidationResult.failure("Value " + value + " must be number for field type " + fieldType + getErrorInfo(dto));
+            return ValidationResult.failure("Value " + value + " must be a number" + getErrorInfo(dto));
         }
         if (!(value instanceof String) && fieldType != FieldType.NUMERIC)
         {
-            return ValidationResult.failure("Value " + value + " must be string for field type " + fieldType + getErrorInfo(dto));
+            return ValidationResult.failure("Value " + value + " must be a string" + getErrorInfo(dto));
         }
         return ValidationResult.success();
     }

--- a/profile/src/main/resources/profileschema/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/datahelix.schema.json
@@ -68,6 +68,9 @@
         },
         {
           "$ref": "#/definitions/numeric"
+        },
+        {
+          "$ref": "#/definitions/boolean"
         }
       ]
     },
@@ -94,6 +97,10 @@
       "minimum": -1e20,
       "maximum": 1e20,
       "default": 0
+    },
+    "boolean": {
+      "type": "boolean",
+      "default": false
     },
     "granularity": {
       "value": {

--- a/profile/src/test/java/com/scottlogic/deg/profile/FieldDeserialiserTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/FieldDeserialiserTests.java
@@ -164,7 +164,7 @@ public class FieldDeserialiserTests {
             deserialiseJsonString(json);
             Assert.fail("should have thrown an exception");
         } catch (InvalidFormatException e) {
-            String expectedMessage = "Cannot deserialize value of type `com.scottlogic.deg.common.profile.SpecificFieldType` from String \"intger\": value not one of declared Enum instance names: [string, CUSIP, fullname, datetime, RIC, date, SEDOL, decimal, firstname, integer, ISIN, lastname]\n at [Source: (String)\"{ \"name\": \"id\", \"type\": \"intger\" }\"; line: 1, column: 25] (through reference chain: com.scottlogic.deg.profile.dtos.FieldDTO[\"type\"])";
+            String expectedMessage = "Cannot deserialize value of type `com.scottlogic.deg.common.profile.SpecificFieldType` from String \"intger\": value not one of declared Enum instance names: [lastname, CUSIP, RIC, date, ISIN, string, fullname, firstname, integer, boolean, SEDOL, decimal, datetime]\n at [Source: (String)\"{ \"name\": \"id\", \"type\": \"intger\" }\"; line: 1, column: 25] (through reference chain: com.scottlogic.deg.profile.dtos.FieldDTO[\"type\"])";
             assertThat(e.getMessage(), sameBeanAs(expectedMessage));
         }
     }

--- a/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
+++ b/profile/src/test/java/com/scottlogic/deg/profile/ProfileSchemaImmutabilityTests.java
@@ -122,7 +122,7 @@ public class ProfileSchemaImmutabilityTests {
             "10dce72a089be2a68f1577adadabff74831d1c063b2e12028b16cbb371493062"));
         versionToHash.add(new VersionHash(
             "0.16",
-            "8a3863c467ba1b6b6e47618bb1f7c70e74acdf9825f10200a86e9fed599d60e5"));
+            "8c3ae6e97a534a264e9ef9b6061e80a53613ddf9cada6bbcb9532e9d6fd8b191"));
         return versionToHash;
     }
 


### PR DESCRIPTION
### Description
Added boolean data types for equal to and equal to field constraints

### Changes
* Added boolean type to schema
* Added boolean field type
* Updated equal to dto validation
* Added boolean typed restriction and field value source
* Added field type to field spec factory
* Added boolean restrictions merger
* Added boolean constraint and relation factories
* Added documentation and an example
* Added cucumber tests

### Issue
Resolves #1530