### PR TITLE
fix(#1566): Prevent different granularity on same field

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/FieldSpecGroup.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/FieldSpecGroup.java
@@ -18,10 +18,16 @@
 package com.scottlogic.datahelix.generator.core.fieldspecs;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.core.fieldspecs.relations.EqualToOffsetRelation;
+import com.scottlogic.datahelix.generator.core.fieldspecs.relations.EqualToRelation;
 import com.scottlogic.datahelix.generator.core.fieldspecs.relations.FieldSpecRelation;
+import com.scottlogic.datahelix.generator.core.restrictions.TypedRestrictions;
+import com.scottlogic.datahelix.generator.core.restrictions.linear.LinearRestrictions;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class FieldSpecGroup {
     private final Map<Field, FieldSpec> fieldSpecs;
@@ -29,8 +35,37 @@ public final class FieldSpecGroup {
     private final Collection<FieldSpecRelation> relations;
 
     public FieldSpecGroup(Map<Field, FieldSpec> fieldSpecs, Collection<FieldSpecRelation> relations) {
+        validateFieldSpecs(fieldSpecs, relations);
         this.fieldSpecs = fieldSpecs;
         this.relations = relations;
+    }
+
+    private void validateFieldSpecs(Map<Field, FieldSpec> fieldSpecs, Collection<FieldSpecRelation> relations) {
+        List<FieldSpecRelation> equalToRelations = relations.stream()
+            .filter(rel -> rel instanceof EqualToOffsetRelation || rel instanceof EqualToRelation)
+            .collect(Collectors.toList());
+
+        for (FieldSpecRelation relation : equalToRelations) {
+            Field left = relation.main();
+            Field right = relation.other();
+            FieldSpec leftSpec = fieldSpecs.get(left);
+            FieldSpec rightSpec = fieldSpecs.get(right);
+
+            if (leftSpec instanceof RestrictionsFieldSpec && rightSpec instanceof RestrictionsFieldSpec) {
+                RestrictionsFieldSpec leftCast = (RestrictionsFieldSpec) leftSpec;
+                RestrictionsFieldSpec rightCast = (RestrictionsFieldSpec) rightSpec;
+                TypedRestrictions<?> leftRestrictions = leftCast.getRestrictions();
+                TypedRestrictions<?> rightRestrictions = rightCast.getRestrictions();
+                if (leftRestrictions instanceof LinearRestrictions<?> && rightRestrictions instanceof LinearRestrictions<?>) {
+                    LinearRestrictions<?> leftRestrictionsCast = (LinearRestrictions) leftRestrictions;
+                    LinearRestrictions<?> rightRestrictionsCast = (LinearRestrictions) rightRestrictions;
+                    if (!leftRestrictionsCast.getGranularity().equals(rightRestrictionsCast.getGranularity())) {
+                        throw new IllegalArgumentException("Cannot have two related fields with different granularity."
+                        + " Consider using a format restriction instead.");
+                    }
+                }
+            }
+        }
     }
 
     public Map<Field, FieldSpec> fieldSpecs() {


### PR DESCRIPTION
### Description
If two (or more) fields had different granularities, they would
intermittently fail depending upon the order the fields are resolved.
This therefore would cause non-deterministic failures. To fix this, an
error is explicitly thrown if the user attempts to create a relation
between two fields of different granularities.

### Issue
Resolves #1566 
