### PR TITLE
1569 update schema for faker support

### DIFF
--- a/profile/src/main/resources/profileschema/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/datahelix.schema.json
@@ -5,14 +5,10 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schemaVersion",
     "fields"
   ],
   "properties": {
     "additionalProperties": false,
-    "schemaVersion": {
-      "$ref": "#/definitions/schemaVersion"
-    },
     "description": {
       "title": "A description of what data the profile is modelling",
       "type": "string"
@@ -37,10 +33,6 @@
     }
   },
   "definitions": {
-    "schemaVersion": {
-      "title": "The version of the DataHelix profile schema",
-      "const": "0.18"
-    },
     "dataType": {
       "oneOf": [
         {

--- a/profile/src/main/resources/profileschema/datahelix.schema.json
+++ b/profile/src/main/resources/profileschema/datahelix.schema.json
@@ -152,6 +152,10 @@
         ]
       }
     },
+    "faker": {
+      "type": "string",
+      "pattern": "^faker.(w+.?)((w+).)*(w+)"
+    },
     "field": {
       "title": "The field definitions of a field to generate data for",
       "type": "object",
@@ -172,29 +176,29 @@
           "type": "string"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "decimal",
-            "integer",
-            "string",
-            "datetime",
-            "date",
-            "time",
-            "ISIN",
-            "SEDOL",
-            "CUSIP",
-            "RIC",
-            "firstname",
-            "lastname",
-            "fullname",
-            "faker.firstname",
-            "faker.lastname",
-            "faker.name",
-            "faker.bloodgroup",
-            "faker.username",
-            "faker.nameprefix",
-            "faker.phonenumber",
-            "faker.cellnumber"
+          "oneOf" : [
+            {
+              "type": "string",
+              "enum": [
+                "decimal",
+                "integer",
+                "string",
+                "datetime",
+                "date",
+                "time",
+                "ISIN",
+                "SEDOL",
+                "CUSIP",
+                "RIC",
+                "firstname",
+                "lastname",
+                "fullname"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^faker\\.(\\w+.?)((\\w+).)*(\\w+)"
+            }
           ]
         },
         "formatting": {


### PR DESCRIPTION
### Changes
Edits the Schema to remove dependency on schema version.
Edits the Schema to allow for any `faker.<--->.<--->` field to be allowed to be specified as a type.


### Additional notes

Tested on a few profiles

```
{"fields": [ { "name": "jobTitle", "type": "faker.job.title", "nullable": true } ] }
```
```
{"fields": [ { "name": "a", "type": "faker.b.c", "nullable": true } ] }
```

But there are currently no automated tests in this area

### Issue
Resolves #1569 
