### PR TITLE
fix(#1489): Fix equal to offset for whitelist

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToOffsetRelation.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToOffsetRelation.java
@@ -29,8 +29,7 @@ import com.scottlogic.datahelix.generator.core.restrictions.linear.LinearRestric
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpecRelation
-{
+public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpecRelation {
     private final Field main;
     private final Field other;
     private final Granularity<T> offsetGranularity;
@@ -48,18 +47,21 @@ public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpec
 
     @Override
     public FieldSpec createModifierFromOtherFieldSpec(FieldSpec otherFieldSpec) {
-        if (otherFieldSpec instanceof NullOnlyFieldSpec){
+        if (otherFieldSpec instanceof NullOnlyFieldSpec) {
             return FieldSpecFactory.nullOnly();
         }
         if (otherFieldSpec instanceof WhitelistFieldSpec) {
             WhitelistFieldSpec whitelistFieldSpec = (WhitelistFieldSpec) otherFieldSpec;
-            List<WeightedElement<T>> modified = whitelistFieldSpec.getWhitelist().distributedList().stream()
+            List<WeightedElement<T>> modified = whitelistFieldSpec
+                .getWhitelist()
+                .distributedList()
+                .stream()
                 .map(x -> new WeightedElement<>(offsetGranularity.getNext((T) x.element(), offset), x.weight()))
                 .collect(Collectors.toList());
             return FieldSpecFactory.fromList((DistributedList) new DistributedList<>(modified));
         }
 
-        LinearRestrictions<T> otherRestrictions = (LinearRestrictions)((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
+        LinearRestrictions<T> otherRestrictions = (LinearRestrictions) ((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();
 
         if (otherRestrictions.isContradictory()) {
             return FieldSpecFactory.nullOnly();

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToOffsetRelation.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToOffsetRelation.java
@@ -19,11 +19,15 @@ package com.scottlogic.datahelix.generator.core.fieldspecs.relations;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.FieldType;
 import com.scottlogic.datahelix.generator.common.profile.Granularity;
+import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
 import com.scottlogic.datahelix.generator.core.fieldspecs.*;
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
 import com.scottlogic.datahelix.generator.core.generation.databags.DataBagValue;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
 import com.scottlogic.datahelix.generator.core.restrictions.linear.LinearRestrictions;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpecRelation
 {
@@ -48,7 +52,11 @@ public class EqualToOffsetRelation<T extends Comparable<T>> implements FieldSpec
             return FieldSpecFactory.nullOnly();
         }
         if (otherFieldSpec instanceof WhitelistFieldSpec) {
-            throw new UnsupportedOperationException("cannot combine sets with equal to offset relation, Issue #1489");
+            WhitelistFieldSpec whitelistFieldSpec = (WhitelistFieldSpec) otherFieldSpec;
+            List<WeightedElement<T>> modified = whitelistFieldSpec.getWhitelist().distributedList().stream()
+                .map(x -> new WeightedElement<>(offsetGranularity.getNext((T) x.element(), offset), x.weight()))
+                .collect(Collectors.toList());
+            return FieldSpecFactory.fromList((DistributedList) new DistributedList<>(modified));
         }
 
         LinearRestrictions<T> otherRestrictions = (LinearRestrictions)((RestrictionsFieldSpec) otherFieldSpec).getRestrictions();

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/AfterRelationTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/AfterRelationTest.java
@@ -31,7 +31,7 @@ import java.time.temporal.ChronoUnit;
 import static com.scottlogic.datahelix.generator.common.util.Defaults.ISO_MAX_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AfterDateRelationTest {
+public class AfterRelationTest {
 
     private final Field a = new Field("a", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false, "", false, false, null);
     private final Field b = new Field("b", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false, "", false, false, null);

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/BeforeRelationTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/BeforeRelationTest.java
@@ -31,7 +31,7 @@ import java.time.temporal.ChronoUnit;
 import static com.scottlogic.datahelix.generator.common.util.Defaults.ISO_MIN_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BeforeDateRelationTest {
+public class BeforeRelationTest {
 
     private final Field a = new Field("a", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false, "", false, false, null);
     private final Field b = new Field("b", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false, "", false, false, null);

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToRelationTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/relations/EqualToRelationTest.java
@@ -30,7 +30,7 @@ import java.time.ZoneOffset;
 import static com.shazam.shazamcrest.MatcherAssert.assertThat;
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 
-class EqualToDateRelationTest {
+class EqualToRelationTest {
 
     private final Field a = new Field("a", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false ,"", false, false, null);
     private final Field b = new Field("b", StandardSpecificFieldType.DATETIME.toSpecificFieldType(), false, "", false, false, null);

--- a/examples/integerOffsetFromSet/README.md
+++ b/examples/integerOffsetFromSet/README.md
@@ -1,0 +1,3 @@
+Creates two integer fields, loaded from sets.
+
+The integers are linked by the condition that `Second` must be one greater than `First`.

--- a/examples/integerOffsetFromSet/profile.json
+++ b/examples/integerOffsetFromSet/profile.json
@@ -1,0 +1,24 @@
+{
+  "fields" : [ {
+    "name" : "First",
+    "type" : "integer",
+    "unique" : false,
+    "nullable" : false
+  }, {
+    "name" : "Second",
+    "type" : "integer",
+    "unique" : false,
+    "nullable" : false
+  } ],
+  "constraints" : [ {
+    "field" : "First",
+    "inSet" : [1, 2, 3]
+  }, {
+    "field" : "Second",
+    "inSet" : [3, 4, 5]
+  }, {
+    "field" : "Second",
+    "equalToField" : "First",
+    "offset": 1
+  }]
+}


### PR DESCRIPTION
### Description
Partial fix for the ticket #1489. This fixes the equal to case, but
doesn't address the before or after cases.

The reason for a partial fix is due to the difficulty comparing the two
different cases (equal vs before/after).

Equal to is simple because all of the values can be adjusted by the
offset, translating a set of values to a set of values.

Before/after are more complicated, as theoretically each of the values
must be translated to a range. This therefore means the result is a set
of restrictions. Unfortunately, the system isn't designed to be passing
around a set of restrictions at this time in the program. Therefore,
this will take further thought.

A possible solution is to take the most restrictive of the values. This
would ensure that whichever values are picked are permissable, but would
severely limit the number of values output.

### Issue
Related to #1489 
