### PR TITLE
fix(#1557): Fix distribution of large integers

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/utils/JavaUtilRandomNumberGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/utils/JavaUtilRandomNumberGenerator.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.core.utils;
 import com.scottlogic.datahelix.generator.common.RandomNumberGenerator;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Random;
 
 public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator
@@ -58,9 +59,26 @@ public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator
 
     @Override
     public BigDecimal nextBigDecimal(BigDecimal lowerInclusive, BigDecimal upperExclusive) {
-        return BigDecimal.valueOf(random.nextDouble())
-            .multiply(upperExclusive.subtract(lowerInclusive))
-            .add(lowerInclusive);
+        int lowerScale = lowerInclusive.scale();
+        int upperScale = upperExclusive.scale();
+        int greatestScale = Math.max(lowerScale, upperScale);
+        BigInteger lowerValue = adjustToScale(lowerInclusive, greatestScale);
+        BigInteger upperValue = adjustToScale(upperExclusive, greatestScale);
+
+        return new BigDecimal(nextBigInteger(lowerValue, upperValue), greatestScale);
+    }
+
+    private BigInteger adjustToScale(BigDecimal decimal, int scale) {
+        return decimal.unscaledValue().multiply(BigInteger.TEN.pow(scale - decimal.scale()));
+    }
+
+    private BigInteger nextBigInteger(BigInteger lowerInclusive, BigInteger upperExclusive) {
+        BigInteger range = upperExclusive.subtract(lowerInclusive);
+        BigInteger randomValue = null;
+        while (randomValue == null || randomValue.compareTo(range) >= 0) {
+            randomValue = new BigInteger(range.bitLength(), random);
+        }
+        return lowerInclusive.add(randomValue);
     }
 
 }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/FieldSpecGetFieldValueSourceTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/FieldSpecGetFieldValueSourceTests.java
@@ -36,6 +36,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.scottlogic.datahelix.generator.common.util.Defaults.NUMERIC_MAX;
+import static com.scottlogic.datahelix.generator.common.util.Defaults.NUMERIC_MIN;
 import static com.scottlogic.datahelix.generator.core.restrictions.linear.LinearRestrictionsFactory.createNumericRestrictions;
 import static com.scottlogic.datahelix.generator.core.utils.GeneratorDefaults.NUMERIC_MAX_LIMIT;
 import static com.scottlogic.datahelix.generator.core.utils.GeneratorDefaults.NUMERIC_MIN_LIMIT;
@@ -185,8 +187,8 @@ public class FieldSpecGetFieldValueSourceTests {
         }
 
         final List<BigDecimal> expectedValues = Arrays.asList(
-            new BigDecimal("-1E+20"),
-            new BigDecimal("1E+20")
+            NUMERIC_MIN,
+            NUMERIC_MAX
         );
         Assert.assertEquals(expectedValues, valuesFromResult);
     }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/utils/JavaUtilRandomNumberGeneratorTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/utils/JavaUtilRandomNumberGeneratorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.scottlogic.datahelix.generator.core.utils;
+
+import com.scottlogic.datahelix.generator.common.SetUtils;
+import com.scottlogic.datahelix.generator.common.util.Defaults;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JavaUtilRandomNumberGeneratorTest {
+
+    JavaUtilRandomNumberGenerator random = new JavaUtilRandomNumberGenerator();
+
+    @Test
+    void nextBigDecimal_withPositiveSameScale_works() {
+        BigDecimal lower = BigDecimal.ONE;
+        BigDecimal upper = BigDecimal.valueOf(3);
+
+        Set<BigDecimal> expected = SetUtils.setOf(BigDecimal.ONE, BigDecimal.valueOf(2));
+
+        assertTrue(Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .limit(10)
+            .allMatch(expected::contains));
+    }
+
+    @Test
+    void nextBigDecimal_withPositiveDifferentScales_work() {
+        BigDecimal lower = BigDecimal.valueOf(9);
+        BigDecimal upper = BigDecimal.valueOf(12);
+
+        Set<BigDecimal> expected = SetUtils.setOf(
+            BigDecimal.valueOf(9),
+            BigDecimal.valueOf(10),
+            BigDecimal.valueOf(11));
+
+        assertTrue(Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .limit(10)
+            .allMatch(expected::contains));
+    }
+
+    @Test
+    void nextBigDecimal_withNegativeSameScale_works() {
+        BigDecimal lower = new BigDecimal("0.1");
+        BigDecimal upper = new BigDecimal("0.4");
+
+        Set<BigDecimal> expected = SetUtils.setOf(lower, new BigDecimal("0.2"), new BigDecimal("0.3"));
+
+        assertTrue(Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .limit(10)
+            .allMatch(expected::contains));
+    }
+
+    @Test
+    void nextBigDecimal_withNegativeDifferentScales_work() {
+        BigDecimal lower = new BigDecimal("0.08");
+        BigDecimal upper = new BigDecimal("0.1");
+
+        Set<BigDecimal> expected = SetUtils.setOf(lower, new BigDecimal("0.09"));
+
+        assertTrue(Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .limit(10)
+            .allMatch(expected::contains));
+    }
+
+    @Test
+    void nextBigDecimal_withPositiveAndNegativeScales_works() {
+        BigDecimal lower = new BigDecimal("0.9");
+        BigDecimal upper = BigDecimal.TEN;
+
+        assertTrue(Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .limit(10)
+            .allMatch(x -> BigDecimal.TEN.compareTo(x) > 0 && lower.compareTo(x) <= 0));
+    }
+
+    @Test
+    void nextBigDecimal_withLargeNumbers_givesValuesWithHighPrecision() {
+        BigDecimal lower = Defaults.NUMERIC_MIN.setScale(20);
+        BigDecimal upper = Defaults.NUMERIC_MAX.setScale(20);
+
+        Stream<String> result = Stream.generate(() -> random.nextBigDecimal(lower, upper))
+            .map(BigDecimal::toPlainString)
+            .peek(System.out::println)
+            .map(this::lastFourLetters);
+
+        assertTrue(result.limit(10).noneMatch("0000"::equals));
+    }
+
+    private String lastFourLetters(String input) {
+        return input.substring(input.length() - 4);
+    }
+}


### PR DESCRIPTION
### Description
Large integers (eg. across the maximum permitted range) were being
generated by converting a random `float` to a `BigDecimal`. This resulted in
a loss of precision, which often caused `int`s of approximately 15+
digits to have a sequence of zeros on the end.

This commit fixes the bug by utilising the structure of `BigDecimal` - a
`BigInteger` value with an `int` scale. By decomposing the structure and
operating using a random `BigInteger`, we can generated uniform values
across the specified range.

### Issue
Resolves #1557 
