### PR TITLE
Error on regex faker

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
@@ -72,6 +72,9 @@ public class RegexStringGenerator implements StringGenerator {
         if (regexPattern != null) {
             return regexPattern;
         }
+        if (regexRepresentation.contains("∩") || regexRepresentation.contains("∪")) {
+            throw new IllegalArgumentException("Faker generation does not support regexes");
+        }
         String firstStripped = regexRepresentation.charAt(0) == '/'
             ? regexRepresentation.substring(1)
             : regexRepresentation;


### PR DESCRIPTION
### Description
Previously any regex constraints, when combined with the faker type,
would run indefinitely. This occurs due to a bad assumption; that the
regex representation on the RegexStringGenerator are valid regexes. When
intersections occur, this is no longer the case. To avoid this, an error
is now thrown if an intersection or a union has occurred. This method is
only invoked from the Faker Generator.

### Issue
Resolves #1584 
