### PR TITLE
feat(#1596): Showcase examples in playground

### DIFF
--- a/playground/examples.json
+++ b/playground/examples.json
@@ -25,7 +25,7 @@
       "category": "Dates"
     },
     {
-      "profile": "datetimeAfter",
+      "profileDirectory": "datetimeAfter",
       "description": "After date",
       "category": "Dates"
     },
@@ -63,16 +63,6 @@
     {
       "profileDirectory": "formatting",
       "description": "Formatting",
-      "category": "Data Types"
-    },
-    {
-      "profileDirectory": "inMap",
-      "description": "In map",
-      "category": "Data Types"
-    },
-    {
-      "profileDirectory": "inSet",
-      "description": "In set",
       "category": "Data Types"
     },
     {

--- a/playground/index.html
+++ b/playground/index.html
@@ -20,10 +20,12 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-between">
   <a class="navbar-brand" href="..">DataHelix Generator</a>
   <div>
-    <button id="examplesButton" type="button" class="btn btn-secondary dropdown-toggle btn-success" data-toggle="dropdown">
-      Examples
-    </button>
-    <div id="examples" class="dropdown-menu"></div>
+    <div class="dropdown" style="display: inline-block;">
+      <button id="examplesButton" type="button" class="btn btn-secondary dropdown-toggle btn-success" data-toggle="dropdown">
+        Examples
+      </button>
+      <div id="examples" class="dropdown-menu dropdown-menu-right" aria-labelledby="examplesButton"></div>
+    </div>
     <button type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#shareModal">
       Share
     </button>
@@ -33,6 +35,7 @@
     <span id="spinner" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"
       style="display: none"></span>
   </div>
+
 </nav>
 
 <div id="content">

--- a/playground/index.html
+++ b/playground/index.html
@@ -14,7 +14,7 @@
   <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
   <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://unpkg.com/bootstrap@4.4.0/dist/js/bootstrap.min.js"></script>
-  <script src="https://unpkg.com/showdown/dist/showdown.min.js"></script>
+  <script src="https://unpkg.com/showdown@1.9.1/dist/showdown.min.js"></script>
 </head>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-between">

--- a/playground/index.html
+++ b/playground/index.html
@@ -20,10 +20,10 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-between">
   <a class="navbar-brand" href="..">DataHelix Generator</a>
   <div>
-    <button id="examplesButton" type="button" class="btn btn-outline-success">
+    <button id="examplesButton" type="button" class="btn btn-secondary dropdown-toggle btn-success" data-toggle="dropdown">
       Examples
     </button>
-    <div id="examples" class="examples-display"></div>
+    <div id="examples" class="dropdown-menu"></div>
     <button type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#shareModal">
       Share
     </button>

--- a/playground/index.js
+++ b/playground/index.js
@@ -10,6 +10,7 @@ const examplesButton = document.getElementById("examplesButton");
 const examplesRootUrl = "examples.json";
 const examplesContentUrl = "https://api.github.com/repos/finos/datahelix/contents/examples/";
 const markdownConverter = new showdown.Converter();
+const readmeBaseUrl = "https://github.com/finos/datahelix/tree/master/examples/";
 
 new ClipboardJS("#copyButton");
 
@@ -205,6 +206,7 @@ const loadExamples = () => {
           profileElement.className = "dropdown-item";
           profileElement.type = "button";
           profileElement.innerText = profileExample.description;
+          profileElement.setAttribute("data-profile-path", profileExample.profileDirectory);
           profileElement.addEventListener("click", () => {
               renderExample(profileExample);
           });
@@ -229,5 +231,30 @@ const loadExamples = () => {
     editor.setValue("Error requesting examples: " + requestErr)
   });
 };
+
+generatorOutput.addEventListener("click", (e) => {
+  if (e.target.tagName !== "A" || !e.target.getAttribute("href")) {
+    return;
+  }
+
+  const href = e.target.getAttribute("href");
+  if (href.indexOf("https://") !== 0 && href.indexOf("http://") !== 0) {
+    //link to another example?
+    const exampleName = href.replace(/[\.\/]/g, "");
+    if (exampleName) {
+      e.preventDefault();
+      renderExample({
+        profileDirectory: exampleName
+      });
+      return false;
+    }
+
+    e.target.setAttribute("href", readmeBaseUrl + "someExample/" + href);
+  }
+
+  if (href.indexOf("https://finos.github.io/datahelix/playground/#") !== 0) {
+    e.target.setAttribute("target", "_blank");
+  }
+})
 
 loadExamples();

--- a/playground/index.js
+++ b/playground/index.js
@@ -6,7 +6,6 @@ const editorPanel = document.getElementById("editor-panel");
 const spinner = document.getElementById("spinner");
 const shareUrl = document.getElementById("shareUrl");
 const examplesDisplay = document.getElementById("examples");
-const examplesButton = document.getElementById("examplesButton");
 const examplesRootUrl = "examples.json";
 const examplesContentUrl = "https://api.github.com/repos/finos/datahelix/contents/examples/";
 const markdownConverter = new showdown.Converter();
@@ -136,7 +135,6 @@ const displayReadmeMarkdown = (markdown) => {
 const renderExample = (profileExample) => {
   hideAlert();
   isLoading(true);
-  window.location.hash = profileExample.profileDirectory;
 
   const profilePath = examplesContentUrl + profileExample.profileDirectory;
   const profileContentPath = profilePath + "/profile.json";
@@ -219,9 +217,7 @@ const loadExamples = () => {
         try {
           editor.setValue(atob(decodeURIComponent(encoded)));
         } catch (e) {
-          renderExample({
-            profileDirectory: encoded
-          });
+          showAlert("Error loading profile: " + err.message);
         }
       } else if (defaultExample) {
         defaultExample.click();

--- a/playground/index.js
+++ b/playground/index.js
@@ -139,6 +139,9 @@ const displayReadmeMarkdown = (markdown) => {
 }
 
 const renderExample = (profileExample) => {
+  hideAlert();
+  isLoading(true);
+
   const profilePath = examplesContentUrl + profileExample.profileDirectory;
   const profileContentPath = profilePath + "/profile.json";
   const readmeContentPath = profilePath + "/README.md";
@@ -159,6 +162,9 @@ const renderExample = (profileExample) => {
       })
     }, err => {
       editor.setValue("Error getting profile content." + err.message);
+    })
+    .then(() => {
+      isLoading(false);
     });
 
     fetch(readmeContentPath)

--- a/playground/index.js
+++ b/playground/index.js
@@ -122,21 +122,13 @@ const createCategory = (categoryName, categoryMap) => {
 
   examplesDisplay.appendChild(categoryElement);
 
-  const listElement = document.createElement("ol");
+  const listElement = document.createElement("div");
+  listElement.className = "example-category-group";
   categoryElement.appendChild(listElement);
 
   categoryMap[categoryName] = listElement;
   return listElement;
 }
-
-const showExamples = (show) =>
-  examplesDisplay.style.display = (examplesDisplay.style.display === "none" || show)
-    ? ""
-    : "none";
-
-
-const hideExamples = () =>
-  examplesDisplay.style.display = "none";
 
 const displayReadmeMarkdown = (markdown) => {
   const html = markdownConverter.makeHtml(markdown);
@@ -147,8 +139,6 @@ const displayReadmeMarkdown = (markdown) => {
 }
 
 const renderExample = (profileExample) => {
-  hideExamples();
-
   const profilePath = examplesContentUrl + profileExample.profileDirectory;
   const profileContentPath = profilePath + "/profile.json";
   const readmeContentPath = profilePath + "/README.md";
@@ -190,7 +180,6 @@ const renderExample = (profileExample) => {
 const loadExamples = () => {
   fetch(examplesRootUrl).then(response => {
     editor.setValue("Loading examples...");
-    hideExamples();
 
     response.json().then(profileExamples => {
       const categoryMap = {};
@@ -206,7 +195,9 @@ const loadExamples = () => {
       profileExamples.forEach(profileExample => {
           const category = categoryMap[profileExample.category] || createCategory(profileExample.category, categoryMap);
 
-          const profileElement = document.createElement("li");
+          const profileElement = document.createElement("button");
+          profileElement.className = "dropdown-item";
+          profileElement.type = "button";
           profileElement.innerText = profileExample.description;
           profileElement.addEventListener("click", () => {
               renderExample(profileExample);
@@ -222,11 +213,7 @@ const loadExamples = () => {
         defaultExample.click();
       }
 
-      if (profileExamples.length > 0) {
-        examplesButton.addEventListener("click", () => {
-          showExamples();
-        })
-      } else {
+      if (profileExamples.length === 0) {
         editor.setValue("No examples loaded.");
       }
     }, jsonErr => {

--- a/playground/index.js
+++ b/playground/index.js
@@ -186,7 +186,9 @@ const renderExample = (profileExample) => {
 
 const loadExamples = () => {
   fetch(examplesRootUrl).then(response => {
-    editor.setValue("Loading examples...");
+    if (!profileArea.value.trim()) {
+      editor.setValue("Loading examples...");
+    }
 
     response.json().then(profileExamples => {
       const categoryMap = {};
@@ -217,7 +219,7 @@ const loadExamples = () => {
           }
       });
 
-      if (defaultExample) {
+      if (defaultExample && !profileArea.value.trim()) {
         defaultExample.click();
       }
 

--- a/playground/index.js
+++ b/playground/index.js
@@ -14,12 +14,6 @@ const readmeBaseUrl = "https://github.com/finos/datahelix/tree/master/examples/"
 
 new ClipboardJS("#copyButton");
 
-// decode the hash into a profile
-if (window.location.hash) {
-  const encoded = window.location.href.split("#")[1];
-  profileArea.value = atob(decodeURIComponent(encoded));
-}
-
 // if the share button is pressed, encode the profile 
 $("#shareModal").on("show.bs.modal", () => {
   const baseUrl = window.location.href.split("#")[0];
@@ -142,6 +136,7 @@ const displayReadmeMarkdown = (markdown) => {
 const renderExample = (profileExample) => {
   hideAlert();
   isLoading(true);
+  window.location.hash = profileExample.profileDirectory;
 
   const profilePath = examplesContentUrl + profileExample.profileDirectory;
   const profileContentPath = profilePath + "/profile.json";
@@ -186,12 +181,11 @@ const renderExample = (profileExample) => {
 
 const loadExamples = () => {
   fetch(examplesRootUrl).then(response => {
-    if (!profileArea.value.trim()) {
-      editor.setValue("Loading examples...");
-    }
+    editor.setValue("Loading examples...");
 
     response.json().then(profileExamples => {
       const categoryMap = {};
+      const profileMap = {};
       let defaultExample = null;
 
       profileExamples.sort((a, b) => {
@@ -204,6 +198,7 @@ const loadExamples = () => {
       profileExamples.forEach(profileExample => {
           const category = categoryMap[profileExample.category] || createCategory(profileExample.category, categoryMap);
 
+          profileMap[profileExample.profileDirectory] = profileExample;
           const profileElement = document.createElement("button");
           profileElement.className = "dropdown-item";
           profileElement.type = "button";
@@ -219,7 +214,16 @@ const loadExamples = () => {
           }
       });
 
-      if (defaultExample && !profileArea.value.trim()) {
+      if (window.location.hash) {
+        const encoded = window.location.href.split("#")[1];
+        try {
+          editor.setValue(atob(decodeURIComponent(encoded)));
+        } catch (e) {
+          renderExample({
+            profileDirectory: encoded
+          });
+        }
+      } else if (defaultExample) {
         defaultExample.click();
       }
 

--- a/playground/index.js
+++ b/playground/index.js
@@ -129,15 +129,14 @@ const createCategory = (categoryName, categoryMap) => {
   return listElement;
 }
 
-const showExamples = show => {
+const showExamples = (show) =>
   examplesDisplay.style.display = (examplesDisplay.style.display === "none" || show)
     ? ""
     : "none";
-}
 
-function hideExamples() {
+
+const hideExamples = () =>
   examplesDisplay.style.display = "none";
-}
 
 const displayReadmeMarkdown = (markdown) => {
   const html = markdownConverter.makeHtml(markdown);

--- a/playground/style.css
+++ b/playground/style.css
@@ -49,23 +49,14 @@ nav .btn {
 }
 
 #examples {
-  position: absolute;
-  right: 25px;
-  left: unset;
-  z-index: 1;
   width: 675px;
-  margin-top: 2px;
 
   column-count: 3;
   column-rule: 1px solid gray;
   column-gap: 20px;
-
-  box-shadow: gray 2px 2px 5px;
-  border-radius: 4px;
-  padding: 5px;
 }
 
-.example-category-group {
+.example-category {
   -webkit-column-break-inside: avoid;
   overflow: hidden;
 }
@@ -74,4 +65,5 @@ nav .btn {
   font-weight: normal;
   text-decoration: underline;
   font-size: 20px;
+  padding-left: 5px;
 }

--- a/playground/style.css
+++ b/playground/style.css
@@ -48,39 +48,29 @@ nav .btn {
   height: 100% !important;
 }
 
-.examples-display {
+#examples {
   position: absolute;
   right: 25px;
+  left: unset;
   z-index: 1;
-  width: 785px;
+  width: 675px;
   margin-top: 2px;
-  background: #f8f9fa;
-  padding: 5px;
-  border: 1px solid gray;
 
   column-count: 3;
-  column-rule: gray;
-  column-gap: 40px;
+  column-rule: 1px solid gray;
+  column-gap: 20px;
 
   box-shadow: gray 2px 2px 5px;
   border-radius: 4px;
+  padding: 5px;
 }
 
-.examples-display li {
-  margin: 5px;
-  cursor: pointer;
-}
-
-.examples-display li:hover {
-  text-decoration: underline;
-}
-
-.example-category {
+.example-category-group {
   -webkit-column-break-inside: avoid;
   overflow: hidden;
 }
 
-.examples-display h4 {
+#examples h4 {
   font-weight: normal;
   text-decoration: underline;
   font-size: 20px;


### PR DESCRIPTION
### Description
Update Playground to use example profiles, and show more appropriate example by default.

### Changes
- Introduce a list of curated example profiles (examples.json)
- Update playground to show the examples
- Remove initial profile content (replace with first loaded example)

### Issue
Resolves #1596