### PR TITLE
chore(#760): Simplify issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,7 +7,10 @@ labels: bug
 
 ## Bug report
 
+Be sure to search existing issues since someone might have already raised this bug already.
+
 ### Description of the bug
+A short description of the bug.
 
 ### Steps to reproduce:
 Please include the command line and any supporting files (e.g. the profile, any other input files).

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: 🐛 Bug report
 about: If something isn't working as expected 🤔
+labels: bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,24 +1,27 @@
 ---
-name: 🐛 Bug Report
-about: If something isn't working as expected 🤔.
+name: 🐛 Bug report
+about: If something isn't working as expected 🤔
 
 ---
 
-## Bug Report
+## Bug report
 
-### Steps to Reproduce:
- 1. ...step 1 description...
- 2. ...step 2 description...
- 3. ...step 3 description...
+### Description of the bug
 
-### Expected Result:
-...description of what you expected to see...
+### Steps to reproduce:
+Please include the command line and any supporting files (e.g. the profile, any other input files).
 
-### Actual Result:
-...what actually happened, including full exceptions (please include the entire stack trace, including "caused by" entries), log entries, screen shots etc. where appropriate...
+ 1. step 1 ...
+ 2. step 2 ...
+ 3. step 3 ...
 
-### Environment:
-...version and build of the project, OS and runtime versions, virtualised environment (if any), etc. ...
+### Expected result:
+What did you expect to happen?
 
-### Additional Context:
-...add any other context about the problem here. If applicable, add screenshots to help explain...
+### Actual result:
+What actually happened, if possible include the output (or a screenshot as appropriate).
+
+### Additional context:
+- Which version of the generator?
+- Which version of Java are you using?
+- Any other information that may be relevant to reproduce & resolve the bug

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,8 +7,6 @@ labels: bug
 
 ## Bug report
 
-Be sure to search existing issues since someone might have already raised this bug already.
-
 ### Description of the bug
 A short description of the bug.
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -10,5 +10,3 @@ labels: enhancement
 What would you like the generator to be able to do (differently)?   
 Which groups of users would it benefit?   
 If you have any ideas, how it could be achieved?
-
-Be sure to search existing issues since someone might have already asked something similar.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: 🚀 Feature request
 about: I have a suggestion (and may want to implement it 🙂)
+labels: enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,21 +1,11 @@
 ---
-name: 🚀 Feature Request
-about: I have a suggestion (and may want to implement it 🙂)!
+name: 🚀 Feature request
+about: I have a suggestion (and may want to implement it 🙂)
 
 ---
 
-## Feature Request
+## Feature request
 
-#### Description of Problem
-
-#### Acceptance Criteria
-  - Will any cucumber tests be required?
-  - Will this require a documentation change?
-
-#### Tasks
-
-#### Estimate - *Fibonacci number sequence 1,2,3,5,8,13 etc*
-
-#### (Optional) Potential approaches to solution
-
-Please run through the [Definition of Done checklist](https://github.com/finos/datahelix/blob/master/docs/developer/DefinitionOfDone.md)
+What would you like the generator to be able to do (differently)?   
+Which groups of users would it benefit?   
+If you have any ideas, how it could be achieved?

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -10,3 +10,5 @@ labels: enhancement
 What would you like the generator to be able to do (differently)?   
 Which groups of users would it benefit?   
 If you have any ideas, how it could be achieved?
+
+Be sure to search existing issues since someone might have already asked something similar.

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,11 +1,10 @@
 ---
-name: 🤗 Support Question
-about: If you have a question about configuration, usage, etc. 💬
+name: 🤗 Question
+about: If you have a question 💬
 
 ---
 
-## Support Question
+## Question
 
-...ask your question here.
-
-...be sure to search existing issues since someone might have already asked something similar.
+Ask your question here.  
+If there are supporting documents, screenshots or text that can help clarify your question, please attach them too.

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -9,5 +9,3 @@ labels: question
 
 Ask your question here.  
 If there are supporting documents, screenshots or text that can help clarify your question, please attach them too.
-
-Be sure to search existing issues since someone might have already asked something similar.

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,6 +1,7 @@
 ---
 name: 🤗 Question
 about: If you have a question 💬
+labels: question
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -9,3 +9,5 @@ labels: question
 
 Ask your question here.  
 If there are supporting documents, screenshots or text that can help clarify your question, please attach them too.
+
+Be sure to search existing issues since someone might have already asked something similar.


### PR DESCRIPTION
### Description
The issue templates are overly verbose at present and should be simplified.

### Changes
- Change _question_ template to be more free-form
- Change _feature request_ template to be more free-form
- Change _bug report_ to be less structured
- Change each template to assign a label to each type of issue as they're created

### Issue
Resolves #760