### PR TITLE
Add unit tests for atomic constraints

### DIFF
--- a/orchestrator/build.gradle
+++ b/orchestrator/build.gradle
@@ -58,6 +58,25 @@ dependencies {
     testCompile project(':core').sourceSets.test.output
 
     testImplementation("org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}")
+
+    implementation('org.jetbrains.kotlin:kotlin-stdlib') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
+    implementation('org.jetbrains.kotlin:kotlin-stdlib-common') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
+    implementation('org.jetbrains.kotlin:kotlin-reflect') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
 }
 
 test {

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -44,6 +44,26 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${MOCKITO_JUNIT_JUPITER_VERSION}"
     testImplementation("org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}")
     testImplementation "org.threeten:threeten-extra:${THREE_TEN_VERSION}"
+
+    implementation('org.jetbrains.kotlin:kotlin-stdlib') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
+    implementation('org.jetbrains.kotlin:kotlin-stdlib-common') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
+    implementation('org.jetbrains.kotlin:kotlin-reflect') {
+        version {
+            strictly "1.3.30"
+        }
+        because "Security issue with 1.3.20"
+    }
+
 }
 
 test {

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/ConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/ConstraintValidatorTests.java
@@ -15,7 +15,6 @@
  */
 package com.scottlogic.datahelix.generator.profile.validators.profile;
 
-import com.scottlogic.datahelix.generator.common.profile.SpecificFieldType;
 import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
 import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
 import com.scottlogic.datahelix.generator.profile.creation.ConstraintDTOBuilder;
@@ -82,7 +81,7 @@ public class ConstraintValidatorTests
         // Assert
         assertFalse(validationResult.isSuccess);
     }
-    
+
     @Test
     public void validateAtomicConstraint_withEmptyField_fails()
     {

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/ConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/ConstraintValidatorTests.java
@@ -82,6 +82,8 @@ public class ConstraintValidatorTests
         // Assert
         assertFalse(validationResult.isSuccess);
     }
+    
+    @Test
     public void validateAtomicConstraint_withEmptyField_fails()
     {
         // Arrange

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/DateTimeGranularityValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/DateTimeGranularityValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.validators.ValidationResult;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/DateTimeGranularityValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/DateTimeGranularityValidatorTests.java
@@ -1,0 +1,50 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DateTimeGranularityValidatorTests {
+    
+    @Test
+    public void validateDateTimeGranularityConstraint_withValidChronoUnit_succeeds()
+    {
+        // Act
+        ValidationResult validationResult = new DateTimeGranularityValidator("errorInfo").validate("millis");
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateDateTimeGranularityConstraint_withWorkingDay_succeeds()
+    {
+        // Act
+        ValidationResult validationResult = new DateTimeGranularityValidator("errorInfo").validate("working days");
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateDateTimeGranularityConstraint_withEmptyValue_fails()
+    {
+         // Act
+        ValidationResult validationResult = new DateTimeGranularityValidator("errorInfo").validate("");
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateDateTimeGranularityConstraint_withInvalidValue_fails()
+    {
+        // Act
+        ValidationResult validationResult = new DateTimeGranularityValidator("errorInfo").validate("mills");
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/EqualToConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/EqualToConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/EqualToConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/EqualToConstraintValidatorTests.java
@@ -1,0 +1,96 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.EqualToConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EqualToConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("text", StandardSpecificFieldType.STRING.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateEqualToConstraint_withValidData_succeeds()
+    {
+        // Arrange
+        EqualToConstraintDTO dto = new EqualToConstraintDTO();
+        dto.field = "text";
+        dto.value = "test";
+
+        // Act
+        ValidationResult validationResult = new EqualToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateEqualToConstraint_withNullField_fails()
+    {
+        // Arrange
+        EqualToConstraintDTO dto = new EqualToConstraintDTO();
+        dto.field = null;
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new EqualToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateEqualToConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        EqualToConstraintDTO dto = new EqualToConstraintDTO();
+        dto.field = "";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new EqualToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateEqualToConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        EqualToConstraintDTO dto = new EqualToConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new EqualToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateEqualToConstraint_withIncorrectValueType_fails() {
+        // Arrange
+        EqualToConstraintDTO dto = new EqualToConstraintDTO();
+        dto.field = "text";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new EqualToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/GranularToConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/GranularToConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/GranularToConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/GranularToConstraintValidatorTests.java
@@ -1,0 +1,113 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.GranularToConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GranularToConstraintValidatorTests {
+    
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("text", StandardSpecificFieldType.STRING.toSpecificFieldType()),
+            FieldDTOBuilder.create("decimal", StandardSpecificFieldType.DECIMAL.toSpecificFieldType()),
+            FieldDTOBuilder.create("boolean", StandardSpecificFieldType.BOOLEAN.toSpecificFieldType())
+
+        );
+
+    @Test
+    public void validateGranularToConstraint_withValidNumericData_succeeds()
+    {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = "decimal";
+        dto.value = 0.1;
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateGranularToConstraint_withNullField_fails()
+    {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = null;
+        dto.value = 0.1;
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateGranularToConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = "";
+        dto.value = 0.1;
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateGranularToConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 0.1;
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateGranularToConstraint_withValueTypeBoolean_fails() {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = "boolean";
+        dto.value = true;
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateGranularToConstraint_withValueTypeString_fails() {
+        // Arrange
+        GranularToConstraintDTO dto = new GranularToConstraintDTO();
+        dto.field = "text";
+        dto.value = "test";
+
+        // Act
+        ValidationResult validationResult = new GranularToConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/LongerThanConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/LongerThanConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.FieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/LongerThanConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/LongerThanConstraintValidatorTests.java
@@ -1,0 +1,98 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.util.Defaults;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.integer.LongerThanConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LongerThanConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("integer", StandardSpecificFieldType.INTEGER.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateLongerThanConstraint_withValidData_succeeds()
+    {
+        // Arrange
+        LongerThanConstraintDTO dto = new LongerThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new LongerThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateLongerThanConstraint_withNullField_fails()
+    {
+        // Arrange
+        LongerThanConstraintDTO dto = new LongerThanConstraintDTO();
+        dto.field = null;
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new LongerThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateLongerThanConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        LongerThanConstraintDTO dto = new LongerThanConstraintDTO();
+        dto.field = "";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new LongerThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateLongerThanConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        LongerThanConstraintDTO dto = new LongerThanConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new LongerThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateLongerThanConstraint_withValueTooLarge_fails() {
+        // Arrange
+        LongerThanConstraintDTO dto = new LongerThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = Defaults.MAX_STRING_LENGTH + 1;
+
+        // Act
+        ValidationResult validationResult = new LongerThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/NumericConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/NumericConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.FieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/NumericConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/NumericConstraintValidatorTests.java
@@ -1,0 +1,128 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.util.Defaults;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.numeric.LessThanConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Float.NaN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NumericConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("integer", StandardSpecificFieldType.INTEGER.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateNumericConstraint_withValidData_succeeds()
+    {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withNullField_fails()
+    {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = null;
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withNullValue_fails() {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = null;
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withValueLessThanMin_fails() {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = Defaults.NUMERIC_MIN.subtract(new BigDecimal(1));
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateNumericConstraint_withValueGreaterThanMax_fails() {
+        // Arrange
+        LessThanConstraintDTO dto = new LessThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = Defaults.NUMERIC_MAX.add(new BigDecimal(1));
+
+        // Act
+        ValidationResult validationResult = new NumericConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/OfLengthConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/OfLengthConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.FieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/OfLengthConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/OfLengthConstraintValidatorTests.java
@@ -1,0 +1,112 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.util.Defaults;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.integer.OfLengthConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OfLengthConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("integer", StandardSpecificFieldType.INTEGER.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateOfLengthConstraint_withValidData_succeeds()
+    {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = "integer";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateOfLengthConstraint_withNullField_fails()
+    {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = null;
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateOfLengthConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = "";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateOfLengthConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateOfLengthConstraint_withValueLessThanMin_fails() {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = "integer";
+        dto.value = -1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateOfLengthConstraint_withValueGreaterThanMax_fails() {
+        // Arrange
+        OfLengthConstraintDTO dto = new OfLengthConstraintDTO();
+        dto.field = "integer";
+        dto.value = Defaults.MAX_STRING_LENGTH + 1;
+
+        // Act
+        ValidationResult validationResult = new OfLengthConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/RegexConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/RegexConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/RegexConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/RegexConstraintValidatorTests.java
@@ -1,0 +1,112 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.textual.ContainsRegexConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RegexConstraintValidatorTests {
+
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("text", StandardSpecificFieldType.STRING.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateRegexConstraint_withValidRegex_succeeds()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = "text";
+        dto.value = "/a{0,3}/";
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateRegexConstraint_withNullField_fails()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = null;
+        dto.value = "/a{0,3}/";
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateRegexConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = "";
+        dto.value = "/a{0,3}/";
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateRegexConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = "unknown";
+        dto.value = "/a{0,3}/";
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateRegexConstraint_withNullRegex_fails()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = "text";
+        dto.value = null;
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+    @Test
+    public void validateRegexConstraint_withInvalidRegex_fails()
+    {
+        // Arrange
+        ContainsRegexConstraintDTO dto = new ContainsRegexConstraintDTO();
+        dto.field = "text";
+        dto.value = "/*****/";
+
+        // Act
+        ValidationResult validationResult = new RegexConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/ShorterThanConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/ShorterThanConstraintValidatorTests.java
@@ -1,0 +1,98 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.util.Defaults;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.integer.ShorterThanConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShorterThanConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("integer", StandardSpecificFieldType.INTEGER.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateShorterThanConstraint_withValidData_succeeds()
+    {
+        // Arrange
+        ShorterThanConstraintDTO dto = new ShorterThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = Defaults.MAX_STRING_LENGTH + 1;
+
+        // Act
+        ValidationResult validationResult = new ShorterThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateShorterThanConstraint_withNullField_fails()
+    {
+        // Arrange
+        ShorterThanConstraintDTO dto = new ShorterThanConstraintDTO();
+        dto.field = null;
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new ShorterThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateShorterThanConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        ShorterThanConstraintDTO dto = new ShorterThanConstraintDTO();
+        dto.field = "";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new ShorterThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateShorterThanConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        ShorterThanConstraintDTO dto = new ShorterThanConstraintDTO();
+        dto.field = "unknown";
+        dto.value = 1;
+
+        // Act
+        ValidationResult validationResult = new ShorterThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateShorterThanConstraint_withValueLessThanMin_fails() {
+        // Arrange
+        ShorterThanConstraintDTO dto = new ShorterThanConstraintDTO();
+        dto.field = "integer";
+        dto.value = -1;
+
+        // Act
+        ValidationResult validationResult = new ShorterThanConstraintValidator(fields, FieldType.NUMERIC).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/ShorterThanConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/ShorterThanConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.FieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
 
 import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
@@ -1,0 +1,218 @@
+package com.scottlogic.datahelix.generator.profile.validators.profile.constraints.atomic;
+
+import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.profile.creation.FieldDTOBuilder;
+import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.atomic.temporal.AfterConstraintDTO;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TemporalConstraintValidatorTests {
+
+    private final List<FieldDTO> fields = Arrays.asList
+        (
+            FieldDTOBuilder.create("datetime", StandardSpecificFieldType.DATETIME.toSpecificFieldType()),
+            FieldDTOBuilder.create("time", StandardSpecificFieldType.TIME.toSpecificFieldType())
+        );
+
+    @Test
+    public void validateTemporalConstraint_withValidDatetime_succeeds()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = "0001-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withValidTime_succeeds()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "time";
+        dto.value = "00:00:00";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertTrue(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withNullField_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = null;
+        dto.value = "0001-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withEmptyField_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "";
+        dto.value = "0001-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withUndefinedField_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "unknown";
+        dto.value = "0001-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withUnspecifiedDatetime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = "";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withNullDatetime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = null;
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withUnspecifiedTime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "time";
+        dto.value = "";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withNullTime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "time";
+        dto.value = null;
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withInvalidDatetime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = "invalid";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withInvalidTime_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "time";
+        dto.value = "invalid";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withDatetimeBeforeMin_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = "0000-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+
+    @Test
+    public void validateTemporalConstraint_withDatetimeAfterMax_fails()
+    {
+        // Arrange
+        AfterConstraintDTO dto = new AfterConstraintDTO();
+        dto.field = "datetime";
+        dto.value = "10000-01-01T00:00:00.000Z";
+
+        // Act
+        ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
+
+        // Assert
+        assertFalse(validationResult.isSuccess);
+    }
+}

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/validators/profile/constraints/atomic/TemporalConstraintValidatorTests.java
@@ -162,7 +162,7 @@ public class TemporalConstraintValidatorTests {
         // Arrange
         AfterConstraintDTO dto = new AfterConstraintDTO();
         dto.field = "datetime";
-        dto.value = "invalid";
+        dto.value = "invalid datetime";
 
         // Act
         ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);
@@ -177,7 +177,7 @@ public class TemporalConstraintValidatorTests {
         // Arrange
         AfterConstraintDTO dto = new AfterConstraintDTO();
         dto.field = "time";
-        dto.value = "invalid";
+        dto.value = "invalid time";
 
         // Act
         ValidationResult validationResult = new TemporalConstraintValidator(fields).validate(dto);


### PR DESCRIPTION
### Description
 Previously atomic constraints were not individually unit tested. #1454 removed the cucumber tests that checked each constraints use with incorrect types or null values -- this PR recreates these tests at the unit level, in addition to testing other positive and negative cases.

### Changes
Unit tests added for the following classes:

- DateTimeGranularityValidator
- EqualToConstraintValidator
- GranularToConstraintValidator
- LongerThanConstraintValidator
- NumericConstraintValidator
- OfLengthConstraintValidator
- RegexConstraintValidator
- ShorterThanConstraintValidator
- TemporalConstraintValidator

A couple of fixes also made to ConstraintValidatorTests

### Notes

- Some tests are almost identically repeated across classes -- this is because the functionality is implemented in each class under test resulting in a fair bit of repeated code -- could be worth a refactor to make this more efficient?

### Issue
Resolves #1457 