### PR TITLE
Feature/improve online ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ DataHelix is a proud member of the [Fintech Open Source Foundation](https://www.
 * For a high level road map see [Road Map](docs/RoadMap.md).
 
 ## The Problem
-When performing a wide range of software development tasks - functional or load testing on a system, prototyping an API or pitching a service to a potential customer - sample data is a necessity, but generating and maintaining it can be difficult. The nature of the financial services industry makes it particularly difficult to cleanly manage data schemas, and sample datasets:
+When performing a wide range of software development tasks - functional or load testing on a system, prototyping an API or pitching a service to a potential customer - sample data is a necessity, but generating and maintaining it can be difficult. The nature of the some industries makes it particularly difficult to cleanly manage data schemas, and sample datasets:
 
 * Regulatory and methodological change often forces data schema changes.
-* It is often difficult to completely remove legacy data due to obligations to maintain deprecated financial products.  Because of this, schemas tend to be progressively complicated with special cases and exceptions.
+* It is often difficult to completely remove legacy data due to obligations to maintain deprecated products.  Because of this, schemas tend to be progressively complicated with special cases and exceptions.
 * Errors can be costly and reputation-damaging.
 * For legal and/or privacy reasons, it is normally impossible to include real data in samples.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![DataHelix logo](docs/logo.png)
 
-The generation of representative test and simulation data is a challenging and time-consuming task. DataHelix allows you to quickly create data for the purpose of testing and validation, based on a straightforward JSON data profile document.
+The generation of representative test and simulation data is a challenging and time-consuming task. Although DataHelix was created to address a specific challenge in the financial services industry, you will find it a useful tool for the generation of realistic data for simulation and testing, regardless of industry sector. All this from a straightforward JSON data profile document.
 
 DataHelix is a proud member of the [Fintech Open Source Foundation](https://www.finos.org/) and operates within the [FINOS Data Technologies Program](https://www.finos.org/dt).
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,3 +1,9 @@
+<div>
+    <a href="https://finos.github.io/datahelix/">
+        <img src="https://finos.github.io/datahelix/docs-header.png" />
+    </a>
+</div>
+
 # Introduction
 
 This guide outlines how to contribute to the project as well as the key concepts and structure of the DataHelix.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -58,7 +58,7 @@ Checklist before raising an issue:
 * [ ] Have you managed to isolate the issue to a simple profile or test case?
 
 ### Raising an Issue
-* Create your issue [here](https://github.com/finos/datahelix/issues/new) selecting the relevant issue template.
+* Use the [create your issue](https://github.com/finos/datahelix/issues/new) page and select the relevant issue template.
 
 * Please also tag the new issue with a relevant tag.
 * Please use [Markdown formatting](https://help.github.com/categories/writing-on-github/) liberally to assist in readability.
@@ -82,7 +82,7 @@ Our strategy is to ensure all aspects of the generator are tested through some f
 
 * If a change is made to existing class implementations and a test does not exist, then a test should be added
 
-[JUnit (Jupiter)](https://junit.org/junit5/docs/current/user-guide/) is used for unit and integration tests. An outline of how unit tests should be written within DataHelix can be found [here](./developer/JUnitCookbook.md).
+[JUnit (Jupiter)](https://junit.org/junit5/docs/current/user-guide/) is used for unit and integration tests. This document shows [an outline of how unit tests should be written within DataHelix](./developer/JUnitCookbook.md).
 
 [Cucumber](https://cucumber.io/) is used for behaviour driven development and testing, with [gherkin](https://docs.cucumber.io/gherkin/)-based tests.
 
@@ -103,7 +103,7 @@ Feature: the name of my feature
       | null |
 ```
 
-More examples can be seen in the [generator Cucumber features](https://github.com/finos/datahelix/tree/master/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber). An outline of how Cucumber is used within DataHelix can be found [here](./developer/CucumberCookbook.md).
+More examples can be seen in the [generator Cucumber features](https://github.com/finos/datahelix/tree/master/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber). This document shows [an outline of how Cucumber is used within DataHelix](./developer/CucumberCookbook.md).
 
 ## Contributing
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -47,7 +47,7 @@ We'll start by creating a simple profile containing a single field `username` wi
 }
 ```
 
-When manually writing profiles, we recommend using a text editor which can validate profiles using the datahelix schema. Instructions for how to setup automatic profile validation using VS Code can be found [here](user/ProfileValidation.md).
+When manually writing profiles, we recommend using a text editor which can validate profiles using the datahelix schema. Instructions for how to setup automatic profile validation using VS Code can be found in the [Profile Validation documentation](user/ProfileValidation.md).
 
 ## Running the generator
 
@@ -65,7 +65,7 @@ Use
 $ java -jar generator.jar --help
 ```
 
-or click [here](UserGuide.md#command-line-arguments) to find the full range of command line arguments.
+or see [the User Guide](UserGuide.md#command-line-arguments) to find the full range of command line arguments.
 
 Alternatively you can use the [datahelix playground](https://finos.github.io/datahelix/playground/) to get a feel for what it is like to run the profile without downloading the JAR. Although the playground supports almost all features, there are some it does not, and we don't intend it to be a substitute for downloading and running the Datahelix Generator yourself.
 
@@ -103,7 +103,7 @@ Update the JSON profile to the following:
     "constraints": [{ "field": "username", "matchingRegex": "[a-z]{1,10}" }]
 }
 ```
-Click [here](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFt7ICJuYW1lIjogInVzZXJuYW1lIiwgInR5cGUiOiAic3RyaW5nIiB9XSwKICAgICJjb25zdHJhaW50cyI6IFt7ICJmaWVsZCI6ICJ1c2VybmFtZSIsICJtYXRjaGluZ1JlZ2V4IjogIlthLXpdezEsMTB9IiB9XQp9IA%3D%3D) to open the profile in the datahelix playground.
+[Open this profile in the online playground](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFt7ICJuYW1lIjogInVzZXJuYW1lIiwgInR5cGUiOiAic3RyaW5nIiB9XSwKICAgICJjb25zdHJhaW50cyI6IFt7ICJmaWVsZCI6ICJ1c2VybmFtZSIsICJtYXRjaGluZ1JlZ2V4IjogIlthLXpdezEsMTB9IiB9XQp9IA%3D%3D).
 
 Re-running generation now creates a file containing random strings that match the simple regex `[a-z]{1,10}`:
 
@@ -131,7 +131,7 @@ The generator supports many different data types including:
 -   **string** - sequences of unicode characters up to a maximum length of 1000 characters
 -   **datetime** - specific moments in time, with values in the range 0001-01-01T00:00:00.000 to 9999-12-31T23:59:59.999, with an optional granularity / precision (from a maximum of one year to a minimum of one millisecond) that can be defined via a `granularTo` constraint.
 
-A full list of the supported data types can be found [here](UserGuide.md#type).
+A full list of the supported data types can be found in the [User Guide](UserGuide.md#type).
 
 We are going to use the `firstname` type to produce realistic looking names. Add a new field `firstname` with the `firstname` type.
 
@@ -144,7 +144,7 @@ The profile should look something like:
   "constraints": [{ "field": "username", "matchingRegex": "[a-z]{1,10}" }]
 }
 ```
-Click [here](https://finos.github.io/datahelix/playground/#ewogICJmaWVsZHMiOiBbeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgICAgICAgIHsgIm5hbWUiOiAiZmlyc3RuYW1lIiwgInR5cGUiOiAiZmlyc3RuYW1lIiB9XSwKICAiY29uc3RyYWludHMiOiBbeyAiZmllbGQiOiAidXNlcm5hbWUiLCAibWF0Y2hpbmdSZWdleCI6ICJbYS16XXsxLDEwfSIgfV0KfQ%3D%3D) to open the profile in the datahelix playground.
+[Open this profile in the online playground](https://finos.github.io/datahelix/playground/#ewogICJmaWVsZHMiOiBbeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgICAgICAgIHsgIm5hbWUiOiAiZmlyc3RuYW1lIiwgInR5cGUiOiAiZmlyc3RuYW1lIiB9XSwKICAiY29uc3RyYWludHMiOiBbeyAiZmllbGQiOiAidXNlcm5hbWUiLCAibWF0Y2hpbmdSZWdleCI6ICJbYS16XXsxLDEwfSIgfV0KfQ%3D%3D).
 
 Running the profile now gives a random list of usernames and first names.
 
@@ -178,7 +178,7 @@ First we'll expand the example profile to add a new `age` field, a not-null inte
 }
 ```
 
-Click [here](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgICAgeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgeyAibmFtZSI6ICJmaXJzdE5hbWUiLCAidHlwZSI6ICJmaXJzdG5hbWUiIH0sCiAgICAgIHsgIm5hbWUiOiAiYWdlIiwgInR5cGUiOiAiaW50ZWdlciIgfQogICAgXSwKICAgICJjb25zdHJhaW50cyI6IFsKICAgICAgICB7ICJmaWVsZCI6ICJ1c2VybmFtZSIsICJtYXRjaGluZ1JlZ2V4IjogIlthLXpdezEsMTB9IiB9LAogICAgICAgIHsgImZpZWxkIjogImFnZSIsICJncmVhdGVyVGhhbiI6IDAgfSwKICAgICAgICB7ICJmaWVsZCI6ICJhZ2UiLCAibGVzc1RoYW4iOiAxMDAgfQogICAgXQp9) to open the profile in the datahelix playground.
+[Open this profile in the online playground](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgICAgeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgeyAibmFtZSI6ICJmaXJzdE5hbWUiLCAidHlwZSI6ICJmaXJzdG5hbWUiIH0sCiAgICAgIHsgIm5hbWUiOiAiYWdlIiwgInR5cGUiOiAiaW50ZWdlciIgfQogICAgXSwKICAgICJjb25zdHJhaW50cyI6IFsKICAgICAgICB7ICJmaWVsZCI6ICJ1c2VybmFtZSIsICJtYXRjaGluZ1JlZ2V4IjogIlthLXpdezEsMTB9IiB9LAogICAgICAgIHsgImZpZWxkIjogImFnZSIsICJncmVhdGVyVGhhbiI6IDAgfSwKICAgICAgICB7ICJmaWVsZCI6ICJhZ2UiLCAibGVzc1RoYW4iOiAxMDAgfQogICAgXQp9).
 
 Next, we'll add some conditional logic to give some of our users a job. Let's add a `job` field to the profile. We can use [faker](UserGuide.md#faker) to generate realistic looking job titles. From looking at the [`job.java`](https://github.com/DiUS/java-faker/blob/master/src/main/java/com/github/javafaker/Job.java) class in the faker docs we can see that we need to call the `title` method. We add this to the profile by adding the `faker.job.title` type to a field.
 
@@ -220,7 +220,7 @@ Putting it all together will lead to a profile looking like this:
     ]
 }
 ```
-Click [here](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgICAgeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgeyAibmFtZSI6ICJmaXJzdE5hbWUiLCAidHlwZSI6ICJmaXJzdG5hbWUiIH0sCiAgICAgIHsgIm5hbWUiOiAiYWdlIiwgInR5cGUiOiAiaW50ZWdlciIgfSwKICAgICAgeyAibmFtZSI6ICJqb2JUaXRsZSIsICJ0eXBlIjogImZha2VyLmpvYi50aXRsZSIsICJudWxsYWJsZSI6IHRydWV9CiAgICBdLAogICAgImNvbnN0cmFpbnRzIjogWwogICAgICAgIHsgImZpZWxkIjogInVzZXJuYW1lIiwgIm1hdGNoaW5nUmVnZXgiOiAiW2Etel17MSwxMH0iIH0sCiAgICAgICAgeyAiZmllbGQiOiAiYWdlIiwgImdyZWF0ZXJUaGFuIjogMCB9LAogICAgICAgIHsgImZpZWxkIjogImFnZSIsICJsZXNzVGhhbiI6IDEwMCB9LAogICAgICAgIHsgImlmIjogICAgeyAiZmllbGQiOiAiYWdlIiwgImxlc3NUaGFuIjogMTcgfSwKICAgICAgICAgICJ0aGVuIjogIHsgImZpZWxkIjogImpvYlRpdGxlIiwgImlzTnVsbCI6IHRydWV9CiAgICAgICAgfQogICAgXQp9) to open the profile in the datahelix playground.
+[Open this profile in the online playground](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgICAgeyAibmFtZSI6ICJ1c2VybmFtZSIsICJ0eXBlIjogInN0cmluZyIgfSwKICAgICAgeyAibmFtZSI6ICJmaXJzdE5hbWUiLCAidHlwZSI6ICJmaXJzdG5hbWUiIH0sCiAgICAgIHsgIm5hbWUiOiAiYWdlIiwgInR5cGUiOiAiaW50ZWdlciIgfSwKICAgICAgeyAibmFtZSI6ICJqb2JUaXRsZSIsICJ0eXBlIjogImZha2VyLmpvYi50aXRsZSIsICJudWxsYWJsZSI6IHRydWV9CiAgICBdLAogICAgImNvbnN0cmFpbnRzIjogWwogICAgICAgIHsgImZpZWxkIjogInVzZXJuYW1lIiwgIm1hdGNoaW5nUmVnZXgiOiAiW2Etel17MSwxMH0iIH0sCiAgICAgICAgeyAiZmllbGQiOiAiYWdlIiwgImdyZWF0ZXJUaGFuIjogMCB9LAogICAgICAgIHsgImZpZWxkIjogImFnZSIsICJsZXNzVGhhbiI6IDEwMCB9LAogICAgICAgIHsgImlmIjogICAgeyAiZmllbGQiOiAiYWdlIiwgImxlc3NUaGFuIjogMTcgfSwKICAgICAgICAgICJ0aGVuIjogIHsgImZpZWxkIjogImpvYlRpdGxlIiwgImlzTnVsbCI6IHRydWV9CiAgICAgICAgfQogICAgXQp9).
 
 Running the above profile will produce something like:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,3 +1,9 @@
+<div>
+    <a href="https://finos.github.io/datahelix/">
+        <img src="https://finos.github.io/datahelix/docs-header.png" />
+    </a>
+</div>
+
 # Getting Started
 
 The following guide gives a short introduction to the datahelix via a practical example.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,8 +151,8 @@ These sections are combined to form the [complete profile](#Example-Profile).
     }
 ```
 * See the [datahelix playground](https://finos.github.io/datahelix/playground/#ICAgIHsKICAgICJmaWVsZHMiOiBbCiAgICAgICAgewogICAgICAgICAgICAibmFtZSI6ICJDb2x1bW4gMSIsCiAgICAgICAgICAgICJ0eXBlIjogInN0cmluZyIKICAgICAgICB9LAogICAgICAgIHsKICAgICAgICAgICAgIm5hbWUiOiAiQ29sdW1uIDIiLAogICAgICAgICAgICAidHlwZSI6ICJpbnRlZ2VyIgogICAgICAgIH0KICAgIF0sCiAgICAiY29uc3RyYWludHMiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgImZpZWxkIjogIkNvbHVtbiAxIiwKICAgICAgICAgICAgImVxdWFsVG8iOiAiZm9vIgogICAgICAgICAgICB9CiAgICAgICAgXQogICAgfQ%3D%3D) to run and edit this profile online.
-* For a larger profile example see [here](user/Schema.md)
-* Further examples can be found in the Examples folder [here](https://github.com/finos/datahelix/tree/master/examples)
+* For a larger profile example see [The schema documentation](user/Schema.md)
+* Further examples can be found in [the Examples folder](https://github.com/finos/datahelix/tree/master/examples)
 
 # Fields
 
@@ -398,7 +398,7 @@ Scotland, 3
 ...
 ```
 
-After loading the set from the file, this constraint behaves identically to the [inSet](#predicate-inset) constraint. This includes its behaviour when negated or violated. See [here](https://github.com/finos/datahelix/tree/master/examples/inSet) for an example showing the `inSet` constraint being used with a file.
+After loading the set from the file, this constraint behaves identically to the [inSet](#predicate-inset) constraint. This includes its behaviour when negated or violated. See [the inSet example](https://github.com/finos/datahelix/tree/master/examples/inSet) for an example showing the `inSet` constraint being used with a file.
 
 <div id="predicate-inmap"></div>
 
@@ -648,7 +648,7 @@ The syntax is slightly different depending on the type.
 ```
 
 Note that offsetUnit can be any of the [granularites](#DateTime-granularity) supported by datahelix.
-Additionally in the case that the field is a datetime then the `working days` offsetUnit can be used to specify an offset of working days. A profile showing this can be found [here](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAiZmlyc3QiLAogICAgICAidHlwZSI6ICJkYXRldGltZSIsCiAgICAgICJudWxsYWJsZSI6IGZhbHNlCiAgICB9LAogICAgewogICAgICAibmFtZSI6ICJzZWNvbmQiLAogICAgICAidHlwZSI6ICJkYXRldGltZSIsCiAgICAgICJudWxsYWJsZSI6IGZhbHNlCiAgICB9CiAgXSwKICAiY29uc3RyYWludHMiOiBbCiAgICB7CiAgICAgICJmaWVsZCI6ICJmaXJzdCIsCiAgICAgICJhZnRlciI6ICI4MDAxLTAyLTAzVDA0OjA1OjA2LjAwNyIKICAgIH0sCiAgICB7CiAgICAgICJmaWVsZCI6ICJzZWNvbmQiLAogICAgICAiZXF1YWxUb0ZpZWxkIjogImZpcnN0IiwKICAgICAgIm9mZnNldCI6IDMsCiAgICAgICJvZmZzZXRVbml0IjogImRheXMiCiAgICB9CiAgXQp9).
+Additionally in the case that the field is a datetime then the `working days` offsetUnit can be used to specify an offset of working days. See [an example of this in the online playground](https://finos.github.io/datahelix/playground/#ewogICAgImZpZWxkcyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAiZmlyc3QiLAogICAgICAidHlwZSI6ICJkYXRldGltZSIsCiAgICAgICJudWxsYWJsZSI6IGZhbHNlCiAgICB9LAogICAgewogICAgICAibmFtZSI6ICJzZWNvbmQiLAogICAgICAidHlwZSI6ICJkYXRldGltZSIsCiAgICAgICJudWxsYWJsZSI6IGZhbHNlCiAgICB9CiAgXSwKICAiY29uc3RyYWludHMiOiBbCiAgICB7CiAgICAgICJmaWVsZCI6ICJmaXJzdCIsCiAgICAgICJhZnRlciI6ICI4MDAxLTAyLTAzVDA0OjA1OjA2LjAwNyIKICAgIH0sCiAgICB7CiAgICAgICJmaWVsZCI6ICJzZWNvbmQiLAogICAgICAiZXF1YWxUb0ZpZWxkIjogImZpcnN0IiwKICAgICAgIm9mZnNldCI6IDMsCiAgICAgICJvZmZzZXRVbml0IjogImRheXMiCiAgICB9CiAgXQp9).
 
 
 # Grammatical constraints

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,3 +1,9 @@
+<div>
+    <a href="https://finos.github.io/datahelix/">
+        <img src="https://finos.github.io/datahelix/docs-header.png" />
+    </a>
+</div>
+
 # Table of Contents
 1. [Introduction](#Introduction)
 


### PR DESCRIPTION
### Description
Improve the documentation to provide an improved user experience within the documentation.

### Changes
- Expand link text from 'here' to a description of the resource
- Clarification that the DataHelix is not focused on the financial sector
- Inclusion of DataHelix header in GitHub documentation, which links back to the online playground

### Additional notes
This PR will be applied in **AFTER** with a PR to change gh-pages, where the header image is published

### Issue
Resolves #1593