### PR TITLE
Feature/faker refactor

### DIFF
--- a/.idea/runConfigurations/Example_generation__faker_.xml
+++ b/.idea/runConfigurations/Example_generation__faker_.xml
@@ -1,10 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Example generation (faker)" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
     <option name="MAIN_CLASS_NAME" value="com.scottlogic.datahelix.generator.orchestrator.App" />
     <module name="datahelix.generator.orchestrator.main" />
     <option name="PROGRAM_PARAMETERS" value="generate --profile-file=examples\faker\profile.json" />
-    <option name="VM_PARAMETERS" value="--add-opens java.base/java.lang=ALL-UNNAMED" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AllRegexPatterns.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AllRegexPatterns.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.string.generators;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AllRegexPatterns implements RegexPattern {
+    private final List<RegexPattern> andPatterns;
+
+    public AllRegexPatterns(List<RegexPattern> andPatterns) {
+        this.andPatterns = andPatterns;
+    }
+
+    @Override
+    public String getRepresentation() {
+        return "(" + andPatterns.stream().map(RegexPattern::getRepresentation).collect(Collectors.joining(" ∩ ")) + ")";
+    }
+
+    @Override
+    public boolean matches(String input) {
+        return andPatterns.stream().allMatch(p -> p.matches(input));
+    }
+
+    @Override
+    public RegexPattern complement() {
+        return new AnyRegexPatterns(
+            andPatterns.stream().map(RegexPattern::complement).collect(Collectors.toList())
+        );
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AnyRegexPatterns.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AnyRegexPatterns.java
@@ -28,12 +28,12 @@ public class AnyRegexPatterns implements RegexPattern {
 
     @Override
     public String getRepresentation() {
-        return anyPatterns.stream().map(RegexPattern::getRepresentation).collect(Collectors.joining(" AND "));
+        return anyPatterns.stream().map(RegexPattern::getRepresentation).collect(Collectors.joining(" ∪ "));
     }
 
     @Override
     public boolean matches(String input) {
-        return anyPatterns.stream().allMatch(p -> p.matches(input));
+        return anyPatterns.stream().anyMatch(p -> p.matches(input));
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AnyRegexPatterns.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/AnyRegexPatterns.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.string.generators;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AnyRegexPatterns implements RegexPattern {
+    private final List<RegexPattern> anyPatterns;
+
+    public AnyRegexPatterns(List<RegexPattern> anyPatterns) {
+        this.anyPatterns = anyPatterns;
+    }
+
+    @Override
+    public String getRepresentation() {
+        return anyPatterns.stream().map(RegexPattern::getRepresentation).collect(Collectors.joining(" AND "));
+    }
+
+    @Override
+    public boolean matches(String input) {
+        return anyPatterns.stream().allMatch(p -> p.matches(input));
+    }
+
+    @Override
+    public RegexPattern complement() {
+        return new AllRegexPatterns(
+            anyPatterns.stream().map(RegexPattern::complement).collect(Collectors.toList())
+        );
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/FakerGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/FakerGenerator.java
@@ -38,7 +38,7 @@ public class FakerGenerator implements StringGenerator {
 
     @Override
     public boolean matches(String string) {
-        return generateAllValues().anyMatch(fakerValue -> fakerValue.equals(string));
+        return false;
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/NegatedRegexPattern.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/NegatedRegexPattern.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.string.generators;
+
+public class NegatedRegexPattern implements  RegexPattern{
+    private final RegexPattern pattern;
+
+    public NegatedRegexPattern(RegexPattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public String getRepresentation() {
+        return "not(" + pattern.getRepresentation() + ")";
+    }
+
+    @Override
+    public boolean matches(String input) {
+        return !pattern.matches(input);
+    }
+
+    @Override
+    public RegexPattern complement() {
+        return pattern;
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexPattern.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexPattern.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.string.generators;
+
+public interface RegexPattern {
+    String getRepresentation();
+    boolean matches(String input);
+    RegexPattern complement();
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
@@ -72,7 +72,7 @@ public class RegexStringGenerator implements StringGenerator {
         if (regexPattern != null) {
             return regexPattern;
         }
-        if (regexRepresentation.contains("∩") || regexRepresentation.contains("∪")) {
+        if (regexRepresentation.contains("∩")) {
             throw new IllegalArgumentException("Faker generation does not support regexes");
         }
         String firstStripped = regexRepresentation.charAt(0) == '/'
@@ -98,10 +98,10 @@ public class RegexStringGenerator implements StringGenerator {
     }
 
     public static RegexStringGenerator createFromBlacklist(Set<String> blacklist) {
-        String[] blacklistStrings = blacklist.stream().toArray(String[]::new);
+        String[] blacklistStrings = blacklist.toArray(new String[0]);
         Automaton automaton = Automaton.makeStringUnion(blacklistStrings).complement();
 
-        return new RegexStringGenerator(automaton, String.format("NOT-IN %s", Objects.toString(blacklist)));
+        return new RegexStringGenerator(automaton, String.format("NOT-IN %s", blacklist));
     }
 
     @Override
@@ -128,16 +128,6 @@ public class RegexStringGenerator implements StringGenerator {
         return new RegexStringGenerator(merged, mergedRepresentation);
     }
 
-    RegexStringGenerator union(RegexStringGenerator otherGenerator) {
-        Automaton b = otherGenerator.automaton;
-        Automaton merged = automaton.union(b);
-        String mergedRepresentation = unionRepresentation(
-            this.regexRepresentation,
-            otherGenerator.regexRepresentation
-        );
-        return new RegexStringGenerator(merged, mergedRepresentation);
-    }
-
     @Override
     public StringGenerator complement() {
         return new RegexStringGenerator(
@@ -151,10 +141,6 @@ public class RegexStringGenerator implements StringGenerator {
 
     static String intersectRepresentation(String left, String right) {
         return String.format("(%s ∩ %s)", left, right);
-    }
-
-    static String unionRepresentation(String left, String right) {
-        return String.format("(%s ∪ %s)", left, right);
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/RegexStringGenerator.java
@@ -16,18 +16,18 @@
 
 package com.scottlogic.datahelix.generator.core.generation.string.generators;
 
+import com.scottlogic.datahelix.generator.common.RandomNumberGenerator;
 import com.scottlogic.datahelix.generator.common.profile.FieldType;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpecFactory;
 import com.scottlogic.datahelix.generator.core.generation.string.AutomatonUtils;
-import com.scottlogic.datahelix.generator.core.generation.string.iterators.FiniteStringAutomatonIterator;
 import com.scottlogic.datahelix.generator.core.generation.string.factorys.InterestingStringFactory;
 import com.scottlogic.datahelix.generator.core.generation.string.factorys.RandomStringFactory;
+import com.scottlogic.datahelix.generator.core.generation.string.iterators.FiniteStringAutomatonIterator;
 import com.scottlogic.datahelix.generator.core.restrictions.string.StringRestrictions;
-import com.scottlogic.datahelix.generator.common.RandomNumberGenerator;
 import dk.brics.automaton.Automaton;
 
 import java.util.*;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -45,15 +45,14 @@ public class RegexStringGenerator implements StringGenerator {
     private static final RegexStringGenerator DEFAULT = (RegexStringGenerator) ((StringRestrictions) FieldSpecFactory.fromType(FieldType.STRING).getRestrictions()).createGenerator();
 
     private Automaton automaton;
-    private final String regexRepresentation;
-    private Pattern regexPattern;
 
     private RandomStringFactory randomStringFactory = new RandomStringFactory();
     private InterestingStringFactory interestingStringFactory = new InterestingStringFactory();
+    private final RegexPattern regexPattern;
 
-    private RegexStringGenerator(Automaton automaton, String regexRepresentation) {
+    private RegexStringGenerator(Automaton automaton, RegexPattern regexPattern) {
         this.automaton = automaton;
-        this.regexRepresentation = regexRepresentation;
+        this.regexPattern = regexPattern;
     }
 
     public RegexStringGenerator(String regexStr, boolean matchFullString) {
@@ -62,32 +61,16 @@ public class RegexStringGenerator implements StringGenerator {
             ? cache.get(regexStr)
             : AutomatonUtils.createAutomaton(regexStr, matchFullString, cache);
 
-        String prefix = matchFullString ? "" : "*";
-        String suffix = matchFullString ? "" : "*";
-        this.regexRepresentation = String.format("%s/%s/%s", prefix, regexStr, suffix);
+        this.regexPattern = new SingleRegexPattern(regexStr, matchFullString);
         this.automaton = generatedAutomaton;
-    }
-
-    private Pattern pattern() {
-        if (regexPattern != null) {
-            return regexPattern;
-        }
-        if (regexRepresentation.contains("∩")) {
-            throw new IllegalArgumentException("Faker generation does not support regexes");
-        }
-        String firstStripped = regexRepresentation.charAt(0) == '/'
-            ? regexRepresentation.substring(1)
-            : regexRepresentation;
-        String lastStripped = firstStripped.charAt(firstStripped.length() - 1) == '/'
-            ? firstStripped.substring(0, firstStripped.length() - 1)
-            : firstStripped;
-        return regexPattern = Pattern.compile(lastStripped);
     }
 
     @Override
     public String toString() {
-        if (regexRepresentation != null) {
-            return regexRepresentation;
+        String representation = regexPattern.getRepresentation();
+
+        if (representation != null && !representation.equals("")) {
+            return representation;
         }
 
         if (this.automaton != null) {
@@ -100,8 +83,11 @@ public class RegexStringGenerator implements StringGenerator {
     public static RegexStringGenerator createFromBlacklist(Set<String> blacklist) {
         String[] blacklistStrings = blacklist.toArray(new String[0]);
         Automaton automaton = Automaton.makeStringUnion(blacklistStrings).complement();
+        List<RegexPattern> constraints = blacklist.stream()
+            .map(regex -> new SingleRegexPattern(regex, true))
+            .collect(Collectors.toList());
 
-        return new RegexStringGenerator(automaton, String.format("NOT-IN %s", blacklist));
+        return new RegexStringGenerator(automaton, new NegatedRegexPattern(new AnyRegexPatterns(constraints)));
     }
 
     @Override
@@ -121,26 +107,19 @@ public class RegexStringGenerator implements StringGenerator {
             return new NoStringsStringGenerator("regex combination was contradictory");
         }
 
-        String mergedRepresentation = intersectRepresentation(
-            this.regexRepresentation,
-            ((RegexStringGenerator) otherGenerator).regexRepresentation);
+        RegexPattern intersectedPatterns = new AllRegexPatterns(
+            Arrays.asList(
+                this.regexPattern,
+                otherRegexGenerator.regexPattern));
 
-        return new RegexStringGenerator(merged, mergedRepresentation);
+        return new RegexStringGenerator(merged, intersectedPatterns);
     }
 
     @Override
     public StringGenerator complement() {
         return new RegexStringGenerator(
             this.automaton.clone().complement().intersection(DEFAULT.automaton),
-            complementaryRepresentation(this.regexRepresentation));
-    }
-
-    private static String complementaryRepresentation(String representation) {
-        return String.format("¬(%s)", representation);
-    }
-
-    static String intersectRepresentation(String left, String right) {
-        return String.format("(%s ∩ %s)", left, right);
+            this.regexPattern.complement());
     }
 
     @Override
@@ -163,7 +142,7 @@ public class RegexStringGenerator implements StringGenerator {
     }
 
     public boolean validate(String input) {
-        return pattern().asPredicate().test(input);
+        return this.regexPattern.matches(input);
     }
 
     public boolean matches(String subject) {

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/SingleRegexPattern.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/string/generators/SingleRegexPattern.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.string.generators;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class SingleRegexPattern implements RegexPattern {
+    private final String regex;
+    private final boolean matchFullString;
+    private final Predicate<String> predicate;
+
+    public SingleRegexPattern(String regex, boolean matchFullString) {
+        this.regex = getPattern(regex);
+        this.matchFullString = matchFullString;
+        this.predicate = Pattern.compile(this.regex).asPredicate();
+    }
+
+    @Override
+    public String getRepresentation() {
+        if (matchFullString) {
+            return String.format("/%s/", regex);
+        }
+
+        return String.format("*/%s/*", regex);
+    }
+
+    @Override
+    public boolean matches(String input) {
+        return predicate.test(input);
+    }
+
+    private static String getPattern(String regex){
+        String firstStripped = regex.charAt(0) == '/'
+            ? regex.substring(1)
+            : regex;
+        return firstStripped.charAt(firstStripped.length() - 1) == '/'
+            ? firstStripped.substring(0, firstStripped.length() - 1)
+            : firstStripped;
+    }
+
+    @Override
+    public RegexPattern complement() {
+        return new NegatedRegexPattern(this);
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/constraints/atomic/FakerConstraint.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/constraints/atomic/FakerConstraint.java
@@ -16,23 +16,20 @@
 
 package com.scottlogic.datahelix.generator.core.profile.constraints.atomic;
 
-import com.github.javafaker.Faker;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpec;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpecFactory;
 import com.scottlogic.datahelix.generator.core.restrictions.string.StringRestrictionsFactory;
 
-import java.util.function.Function;
-
 public class FakerConstraint implements AtomicConstraint {
 
     private final Field field;
 
-    private final Function<Faker, String> method;
+    private final String fakerSpec;
 
-    public FakerConstraint(Field field, Function<Faker, String> method) {
+    public FakerConstraint(Field field, String fakerSpec) {
         this.field = field;
-        this.method = method;
+        this.fakerSpec = fakerSpec;
     }
 
     @Override
@@ -47,6 +44,6 @@ public class FakerConstraint implements AtomicConstraint {
 
     @Override
     public FieldSpec toFieldSpec() {
-        return FieldSpecFactory.fromRestriction(StringRestrictionsFactory.forFaker(method));
+        return FieldSpecFactory.fromRestriction(StringRestrictionsFactory.forFaker(fakerSpec));
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/restrictions/string/StringRestrictions.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/restrictions/string/StringRestrictions.java
@@ -16,14 +16,13 @@
 
 package com.scottlogic.datahelix.generator.core.restrictions.string;
 
-import com.github.javafaker.Faker;
+import com.scottlogic.datahelix.generator.common.SetUtils;
 import com.scottlogic.datahelix.generator.core.generation.fieldvaluesources.FieldValueSource;
 import com.scottlogic.datahelix.generator.core.generation.string.generators.FakerGenerator;
 import com.scottlogic.datahelix.generator.core.generation.string.generators.NoStringsStringGenerator;
 import com.scottlogic.datahelix.generator.core.generation.string.generators.RegexStringGenerator;
 import com.scottlogic.datahelix.generator.core.generation.string.generators.StringGenerator;
 import com.scottlogic.datahelix.generator.core.restrictions.TypedRestrictions;
-import com.scottlogic.datahelix.generator.common.SetUtils;
 
 import java.util.*;
 import java.util.function.Function;
@@ -42,7 +41,7 @@ public class StringRestrictions implements TypedRestrictions<String>
     private final Set<Pattern> notMatchingRegex;
     private final Set<Pattern> notContainingRegex;
     private StringGenerator generator;
-    private Function<Faker, String> fakerFunction;
+    private String fakerSpec;
 
     public StringRestrictions(
         Integer minLength,
@@ -52,7 +51,7 @@ public class StringRestrictions implements TypedRestrictions<String>
         Set<Integer> excludedLengths,
         Set<Pattern> notMatchingRegex,
         Set<Pattern> notContainingRegex,
-        Function<Faker, String> fakerFunction) {
+        String fakerSpec) {
         this.minLength = minLength;
         this.maxLength = maxLength;
         this.matchingRegex = matchingRegex;
@@ -60,7 +59,7 @@ public class StringRestrictions implements TypedRestrictions<String>
         this.excludedLengths = excludedLengths;
         this.notMatchingRegex = notMatchingRegex;
         this.notContainingRegex = notContainingRegex;
-        this.fakerFunction = fakerFunction;
+        this.fakerSpec = fakerSpec;
     }
 
     @Override
@@ -73,11 +72,11 @@ public class StringRestrictions implements TypedRestrictions<String>
     public FieldValueSource<String> createFieldValueSource(Set<String> blacklist) {
         StringGenerator regexFieldValueSource = createRegexFieldValueSource(blacklist);
 
-        if (fakerFunction == null) {
+        if (fakerSpec == null) {
             return regexFieldValueSource;
         }
 
-        return new FakerGenerator(regexFieldValueSource, fakerFunction);
+        return new FakerGenerator(regexFieldValueSource, fakerSpec);
     }
 
     private StringGenerator createRegexFieldValueSource(Set<String> blacklist) {
@@ -98,7 +97,7 @@ public class StringRestrictions implements TypedRestrictions<String>
             throw new IllegalArgumentException("Other StringRestrictions must not be null");
         }
 
-        if (!permittedFunctions(fakerFunction, other.fakerFunction)) {
+        if (!permittedFunctions(fakerSpec, other.fakerSpec)) {
             throw new IllegalArgumentException("Cannot combine two different faker functions");
         }
 
@@ -110,7 +109,7 @@ public class StringRestrictions implements TypedRestrictions<String>
             SetUtils.union(excludedLengths, other.excludedLengths),
             SetUtils.union(notMatchingRegex, other.notMatchingRegex),
             SetUtils.union(notContainingRegex, other.notContainingRegex),
-            combineFaker(fakerFunction, other.fakerFunction)
+            combineFaker(fakerSpec, other.fakerSpec)
         );
 
         return merged.isContradictory()
@@ -125,7 +124,7 @@ public class StringRestrictions implements TypedRestrictions<String>
         return true;
     }
 
-    private Function<Faker, String> combineFaker(Function<Faker, String> left, Function<Faker, String> right) {
+    private String combineFaker(String left, String right) {
         if (left == null) {
             return right;
         }
@@ -365,7 +364,7 @@ public class StringRestrictions implements TypedRestrictions<String>
             containingRegex.isEmpty() ? "" : " containing: " + patternsAsString(containingRegex),
             notMatchingRegex.isEmpty() ? "" : " not matching: " + patternsAsString(notMatchingRegex),
             notContainingRegex.isEmpty() ? "" : " not containing: " + patternsAsString(notContainingRegex),
-            fakerFunction != null ? fakerFunction.toString() : "");
+            fakerSpec != null ? fakerSpec : "");
     }
 
     private String patternsAsString(Set<Pattern> patterns) {
@@ -388,11 +387,11 @@ public class StringRestrictions implements TypedRestrictions<String>
             && matchingRegex.equals(that.matchingRegex)
             && notContainingRegex.equals(that.notContainingRegex)
             && notMatchingRegex.equals(that.notMatchingRegex)
-            && (fakerFunction == null && that.fakerFunction == null) || (fakerFunction != null && fakerFunction.equals(that.fakerFunction));
+            && (fakerSpec == null && that.fakerSpec == null) || (fakerSpec != null && fakerSpec.equals(that.fakerSpec));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(excludedLengths, maxLength, minLength, containingRegex, matchingRegex, notMatchingRegex, notContainingRegex, fakerFunction);
+        return Objects.hash(excludedLengths, maxLength, minLength, containingRegex, matchingRegex, notMatchingRegex, notContainingRegex, fakerSpec);
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/restrictions/string/StringRestrictionsFactory.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/restrictions/string/StringRestrictionsFactory.java
@@ -16,11 +16,9 @@
 
 package com.scottlogic.datahelix.generator.core.restrictions.string;
 
-import com.github.javafaker.Faker;
 import com.scottlogic.datahelix.generator.common.util.Defaults;
 
 import java.util.Collections;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
 public class StringRestrictionsFactory {
@@ -99,7 +97,7 @@ public class StringRestrictionsFactory {
         );
     }
 
-    public static StringRestrictions forFaker(Function<Faker, String> fakerFunction) {
+    public static StringRestrictions forFaker(String fakerSpec) {
         return new StringRestrictions(
             0,
             Defaults.MAX_STRING_LENGTH,
@@ -108,7 +106,7 @@ public class StringRestrictionsFactory {
             Collections.emptySet(),
             Collections.emptySet(),
             Collections.emptySet(),
-            fakerFunction
+            fakerSpec
         );
     }
 }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/string/generators/FakerGeneratorTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/string/generators/FakerGeneratorTest.java
@@ -15,7 +15,6 @@
  */
 package com.scottlogic.datahelix.generator.core.generation.string.generators;
 
-import com.github.javafaker.Faker;
 import com.scottlogic.datahelix.generator.common.util.Defaults;
 import com.scottlogic.datahelix.generator.core.restrictions.string.StringRestrictions;
 import com.scottlogic.datahelix.generator.core.restrictions.string.StringRestrictionsFactory;
@@ -23,11 +22,11 @@ import com.scottlogic.datahelix.generator.core.utils.JavaUtilRandomNumberGenerat
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FakerGeneratorTest {
 
@@ -35,8 +34,7 @@ class FakerGeneratorTest {
     void generateRandomValuesUnrestricted() {
         StringRestrictions restrictions = StringRestrictionsFactory.forMaxLength(Defaults.MAX_STRING_LENGTH);
         RegexStringGenerator regex = (RegexStringGenerator) restrictions.createGenerator();
-        Function<Faker, String> function = f -> f.name().firstName();
-        FakerGenerator generator = new FakerGenerator(regex, function);
+        FakerGenerator generator = new FakerGenerator(regex, "name.firstName");
 
         final int size = 10;
 
@@ -52,8 +50,7 @@ class FakerGeneratorTest {
         final int length = 9;
         StringRestrictions restrictions = StringRestrictionsFactory.forMinLength(length);
         RegexStringGenerator regex = (RegexStringGenerator) restrictions.createGenerator();
-        Function<Faker, String> function = f -> f.name().firstName();
-        FakerGenerator generator = new FakerGenerator(regex, function);
+        FakerGenerator generator = new FakerGenerator(regex, "name.firstName");
 
         final int size = 10;
 
@@ -68,8 +65,7 @@ class FakerGeneratorTest {
         final int length = 4;
         StringRestrictions restrictions = StringRestrictionsFactory.forMaxLength(length);
         RegexStringGenerator regex = (RegexStringGenerator) restrictions.createGenerator();
-        Function<Faker, String> function = f -> f.name().firstName();
-        FakerGenerator generator = new FakerGenerator(regex, function);
+        FakerGenerator generator = new FakerGenerator(regex, "name.firstName");
 
         final int size = 10;
 

--- a/examples/faker/profile_regex.json
+++ b/examples/faker/profile_regex.json
@@ -1,0 +1,32 @@
+{
+  "fields": [
+    {
+      "name": "shortName",
+      "type": "faker.name.firstName",
+      "nullable": false
+    },
+    {
+      "name": "longName",
+      "type": "faker.name.lastName",
+      "nullable": false
+    }
+  ],
+  "constraints": [
+    {
+      "field": "shortName",
+      "shorterThan": 6
+    },
+    {
+      "field": "longName",
+      "longerThan": 9
+    },
+    {
+      "field": "shortName",
+      "matchingRegex": "[S].*"
+    },
+    {
+      "field": "shortName",
+      "matchingRegex": ".*[n]$"
+    }
+  ]
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
@@ -99,7 +99,7 @@ public class ConstraintService {
             field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FAKER.getType(),
-            field -> new FakerConstraint(field, faker -> genericFakerCall(field.getSpecificType().getFakerMethod().split("\\."), faker))); // TODO: FINISH IMPLEMENTATION
+            field -> new FakerConstraint(field, faker -> genericFakerCall(field.getSpecificType().getFakerMethod().split("\\."), faker)));
     }
 
     private static String genericFakerCall(String[] subTypes, Object invokee) {
@@ -111,7 +111,7 @@ public class ConstraintService {
                 return returnedValue.toString();
             }
             String[] tail = Arrays.copyOfRange(subTypes, 1, subTypes.length);
-            return genericFakerCall(tail, returnedValue).toString();
+            return genericFakerCall(tail, returnedValue);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
@@ -16,7 +16,6 @@
 
 package com.scottlogic.datahelix.generator.profile.services;
 
-import com.github.javafaker.Faker;
 import com.google.inject.Inject;
 import com.scottlogic.datahelix.generator.common.profile.*;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
@@ -98,11 +97,7 @@ public class ConstraintService {
             field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FAKER.getType(),
-            field -> new FakerConstraint(field, faker -> genericFakerCall(field.getSpecificType().getFakerMethod(), faker)));
-    }
-
-    private static String genericFakerCall(String key, Faker faker) {
-        return faker.expression("#{" + key + "}");
+            field -> new FakerConstraint(field, field.getSpecificType().getFakerMethod()));
     }
 
     public Optional<Constraint> createSpecificTypeConstraint(Field field) {

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.datahelix.generator.profile.services;
 
+import com.github.javafaker.Faker;
 import com.google.inject.Inject;
 import com.scottlogic.datahelix.generator.common.profile.*;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
@@ -34,8 +35,6 @@ import com.scottlogic.datahelix.generator.profile.dtos.constraints.relations.Rel
 import com.scottlogic.datahelix.generator.profile.factories.constraint_factories.*;
 import com.scottlogic.datahelix.generator.profile.factories.relation_factories.*;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -99,22 +98,11 @@ public class ConstraintService {
             field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FAKER.getType(),
-            field -> new FakerConstraint(field, faker -> genericFakerCall(field.getSpecificType().getFakerMethod().split("\\."), faker)));
+            field -> new FakerConstraint(field, faker -> genericFakerCall(field.getSpecificType().getFakerMethod(), faker)));
     }
 
-    private static String genericFakerCall(String[] subTypes, Object invokee) {
-        try {
-            Class<?> clazz = invokee.getClass();
-            Method method = clazz.getMethod(subTypes[0]);
-            Object returnedValue = method.invoke(invokee);
-            if (subTypes.length == 1) {
-                return returnedValue.toString();
-            }
-            String[] tail = Arrays.copyOfRange(subTypes, 1, subTypes.length);
-            return genericFakerCall(tail, returnedValue);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+    private static String genericFakerCall(String key, Faker faker) {
+        return faker.expression("#{" + key + "}");
     }
 
     public Optional<Constraint> createSpecificTypeConstraint(Field field) {


### PR DESCRIPTION
### Description
The Faker implementation at present inverts a number of facets, making the ConstraintService responsible for controlling *how* the FakerGenerator works - rather than dictating *what* it should produce. This PR addresses this.

In addition this PR introduces a structure to accurately describe and permit code-analysis of the regular expressions that have been used to create the `RegexStringGenerator`. Rather than normalising this into a String that cannot then be reverse engineered.

### Changes
- Fix to Faker example run configuration
- Introduction of structure (`RegexPattern`) to store tree of regular expressions used to build the `RegexStringGenerator`
- `FakerGenerator` updated to take the 'faker spec' from the profile, rather than the function that can produce the faker values
- Few faker example created to demonstrate, and test, the intersection of Faker values with Regular expressions (albeit produced at them moment via a brute-force approach)

### Additional notes
- A [PR has been raised](https://github.com/DiUS/java-faker/pull/467) for `JavaFaker` which should in future permit extraction of all Faker values that match the given regular expression tree.