### PR TITLE
Use more interesting demo in playground

### DIFF
--- a/playground/examples.json
+++ b/playground/examples.json
@@ -55,10 +55,15 @@
       "category": "Logical"
     },
     {
-      "profileDirectory": "faker",
-      "description": "Faker",
+      "profileDirectory": "demo",
+      "description": "DataHelix demo",
       "category": "Data Types",
       "default": true
+    },
+    {
+      "profileDirectory": "faker",
+      "description": "Faker",
+      "category": "Data Types"
     },
     {
       "profileDirectory": "formatting",

--- a/playground/index.html
+++ b/playground/index.html
@@ -14,7 +14,6 @@
   <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
   <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://unpkg.com/bootstrap@4.4.0/dist/js/bootstrap.min.js"></script>
-  <script src="https://unpkg.com/showdown@1.9.1/dist/showdown.min.js"></script>
 </head>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-between">

--- a/playground/index.html
+++ b/playground/index.html
@@ -57,7 +57,6 @@
     </div>
   </div>
   <div id="output-panel">
-    <table id="output" class="table table-striped table-bordered"></table>
   </div>
 </div>
 

--- a/playground/index.js
+++ b/playground/index.js
@@ -8,7 +8,7 @@ const shareUrl = document.getElementById("shareUrl");
 const examplesDisplay = document.getElementById("examples");
 const examplesRootUrl = "examples.json";
 const examplesContentUrl = "https://api.github.com/repos/finos/datahelix/contents/examples/";
-const markdownConverter = new showdown.Converter();
+const markdownConverter = new showdown.Converter({ tables: true });
 const readmeBaseUrl = "https://github.com/finos/datahelix/tree/master/examples/";
 
 new ClipboardJS("#copyButton");

--- a/playground/index.js
+++ b/playground/index.js
@@ -8,7 +8,6 @@ const shareUrl = document.getElementById("shareUrl");
 const examplesDisplay = document.getElementById("examples");
 const examplesRootUrl = "examples.json";
 const examplesContentUrl = "https://api.github.com/repos/finos/datahelix/contents/examples/";
-const markdownConverter = new showdown.Converter({ tables: true });
 const readmeBaseUrl = "https://github.com/finos/datahelix/tree/master/examples/";
 
 new ClipboardJS("#copyButton");
@@ -125,16 +124,31 @@ const createCategory = (categoryName, categoryMap) => {
 }
 
 const displayReadmeMarkdown = (markdown) => {
-  const html = markdownConverter.makeHtml(markdown);
-
   const readmeHeading = "<p>Click <i>Run</i> above to execute this example.</p>";
   const readmeFooter = "";
-  generatorOutputPanel.innerHTML = readmeHeading + html + readmeFooter;
 
-  generatorOutputPanel.querySelectorAll("table")
-  .forEach(table => {
-    table.className = "table table-striped table-bordered";
-  });
+  fetch('https://api.github.com/markdown/raw',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      body: markdown
+    }).then(
+      response => {
+        response.text().then(html => {
+          generatorOutputPanel.innerHTML = readmeHeading + html + readmeFooter;
+
+          generatorOutputPanel.querySelectorAll("table")
+          .forEach(table => {
+            table.className = "table table-striped table-bordered";
+          });
+        })
+      },
+      err => {
+        generatorOutputPanel.innerHTML = err.message;
+      }
+    )
 }
 
 const renderExample = (profileExample) => {

--- a/playground/index.js
+++ b/playground/index.js
@@ -1,6 +1,6 @@
 const generatorEndpoint = "https://1551npsbdh.execute-api.eu-west-2.amazonaws.com/api/generator";
 const runButton = document.getElementById("run");
-const generatorOutput = document.getElementById("output");
+const generatorOutputPanel = document.getElementById("output-panel");
 const profileArea = document.getElementById("profile");
 const editorPanel = document.getElementById("editor-panel");
 const spinner = document.getElementById("spinner");
@@ -56,7 +56,7 @@ const mapToElements = (arr, element, fn = v => v) =>
     arr.map(value => "<" + element + ">" + fn(value) + "</" + element + ">").join("");
 
 runButton.addEventListener("click", () => {
-  generatorOutput.innerHTML = "";
+  generatorOutputPanel.innerHTML = "";
   const profile = editor.getValue();
 
   hideAlert();
@@ -98,7 +98,7 @@ runButton.addEventListener("click", () => {
       const table = "<thead><tr>" + mapToElements(columns, "th") + "</tr></thead>" +
         "<tbody>" + mapToElements(rows, "tr", row => mapToElements(row, "td")) + "</tbody>";
 
-      generatorOutput.innerHTML = table;
+      generatorOutputPanel.innerHTML = `<table id=output" class="table table-striped table-bordered">${table}</table>`;
     })
     .catch(() => {
       showAlert("There was a problem in reaching the DataHelix API endpoint");
@@ -129,7 +129,12 @@ const displayReadmeMarkdown = (markdown) => {
 
   const readmeHeading = "<p>Click <i>Run</i> above to execute this example.</p>";
   const readmeFooter = "";
-  generatorOutput.innerHTML = readmeHeading + html + readmeFooter;
+  generatorOutputPanel.innerHTML = readmeHeading + html + readmeFooter;
+
+  generatorOutputPanel.querySelectorAll("table")
+  .forEach(table => {
+    table.className = "table table-striped table-bordered";
+  });
 }
 
 const renderExample = (profileExample) => {
@@ -141,7 +146,7 @@ const renderExample = (profileExample) => {
   const readmeContentPath = profilePath + "/README.md";
 
   editor.setValue("Loading profile...");
-  generatorOutput.innerHTML = "Loading profile...";
+  generatorOutputPanel.innerHTML = "Loading profile...";
 
   fetch(profileContentPath)
     .then(response => {
@@ -170,10 +175,10 @@ const renderExample = (profileExample) => {
           throw new Error("Unknown encoding for profile content: " + apiData.encoding);
         }
       }, err => {
-        generatorOutput.innerHTML = "Error loading readme. " + err.message;
+        generatorOutputPanel.innerHTML = "Error loading readme. " + err.message;
       })
     }, err => {
-      generatorOutput.innerHTML = "Error getting readme. " + err.message;
+      generatorOutputPanel.innerHTML = "Error getting readme. " + err.message;
     });
 }
 
@@ -234,7 +239,7 @@ const loadExamples = () => {
   });
 };
 
-generatorOutput.addEventListener("click", (e) => {
+generatorOutputPanel.addEventListener("click", (e) => {
   if (e.target.tagName !== "A" || !e.target.getAttribute("href")) {
     return;
   }


### PR DESCRIPTION
### Description
Use more interesting demo in playground

### Changes
- Default to demo/profile.json
- Display the README.md content in the `div` rather than in the content of the `table`.
- Use GitHub API to render markdown content into HTML

See [sl-slaing.github.io/datahelix/playground/](https://sl-slaing.github.io/datahelix/playground/)

### Issue
Resolves #1595