### PR TITLE
#1639: Publish release artefacts as a zip file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             - "3f:77:2b:8b:bb:87:d1:ce:14:d5:be:dd:6d:6b:ef:1c"
       - checkout
       - run: gradle fatJar :output:test :profile:test :core:test :common:test :orchestrator:test
+      - run: gradle releaseZip
       - run: gradle release -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password
       - run:
           name: Save test results

--- a/orchestrator/build.gradle
+++ b/orchestrator/build.gradle
@@ -96,6 +96,16 @@ task fatJar(type: Jar) {
     archiveName = "${baseName}.${extension}"
 }
 
+task releaseZip(type: Zip) {
+    dependsOn("fatJar")
+
+    archiveFileName = "generator.zip"
+    
+    from("$buildDir/libs") {
+        include "generator.jar"
+    }
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'com.scottlogic.datahelix.generator.orchestrator.App'
@@ -107,6 +117,6 @@ project.ext.ghToken = project.hasProperty('ghToken') ? project.getProperty('ghTo
 semanticRelease {
     repo {
         ghToken = project.ghToken
-        releaseAsset fatJar
+        releaseAsset releaseZip
     }
 }


### PR DESCRIPTION
### Description
Embed release artefacts in a zip file, permitting the bundling of other files (e.g. scripts). Also supports the tool working with Chocolatey.

### Changes
- New Gradle step to bundle the `.jar` file into `generator.zip`
- Updated CircleCI steps to invoke Gradle task
- Gradle release task updated to depend on `zip` rather than `fatJar`

### Issue
Related to #1639