### PR TITLE
chore(#1639): Use distZip (application) rather than hand-rolled zip method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             - "3f:77:2b:8b:bb:87:d1:ce:14:d5:be:dd:6d:6b:ef:1c"
       - checkout
       - run: gradle fatJar :output:test :profile:test :core:test :common:test :orchestrator:test
-      - run: gradle releaseZip
+      - run: gradle distZip
       - run: gradle release -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password
       - run:
           name: Save test results

--- a/orchestrator/build.gradle
+++ b/orchestrator/build.gradle
@@ -17,6 +17,7 @@
 plugins {
     id "java"
     id "de.gliderpilot.semantic-release" version "1.4.0"
+    id "application"
 }
 
 group "com.scottlogic.datahelix.generator"
@@ -96,27 +97,29 @@ task fatJar(type: Jar) {
     archiveName = "${baseName}.${extension}"
 }
 
-task releaseZip(type: Zip) {
-    dependsOn("fatJar")
-
-    archiveFileName = "generator.zip"
-    
-    from("$buildDir/libs") {
-        include "generator.jar"
-    }
-}
-
 jar {
     manifest {
         attributes 'Main-Class': 'com.scottlogic.datahelix.generator.orchestrator.App'
     }
 }
 
+application {
+    mainClassName = 'com.scottlogic.datahelix.generator.orchestrator.App'
+}
+
 project.ext.ghToken = project.hasProperty('ghToken') ? project.getProperty('ghToken') : System.getenv('GH_TOKEN') ?: null
+
+distZip {
+    archiveName "generator.zip"
+}
+
+startScripts {
+    applicationName = 'datahelix'
+}
 
 semanticRelease {
     repo {
         ghToken = project.ghToken
-        releaseAsset releaseZip
+        releaseAsset distZip
     }
 }


### PR DESCRIPTION
### Description
Use the gradle 'application' plugin to create the release zip file (rather than other means)

### Changes
- Release zip now contains an 'expanded' jar file, no longer 1 (fat) jar file, but multiple
- Release zip contains bash and windows scripts to run the generator (orchestrator)

That is the zip file looks like:
- generator.zip
  - generator
     - bin
         - datahelix (bash script)
         - datahelix.bat (windows script)
         - orchestrator (bash script)   - 👎 - not required
         - orchestrator.bat (windows script)   - 👎 - not required
     - lib
         - many `jar` files, inc. orchestrator-[version]-.jar, common-[version].jar, etc.

### Issue
Related to #1639