### PR TITLE
#1650: Ensure JSON output matches NDJSON format

### DIFF
--- a/output/src/main/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactory.java
+++ b/output/src/main/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactory.java
@@ -16,7 +16,7 @@
 
 package com.scottlogic.datahelix.generator.output.writer.json;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SequenceWriter;
@@ -41,7 +41,7 @@ public class JsonOutputWriterFactory implements OutputWriterFactory {
 
     @Override
     public DataSetWriter createWriter(OutputStream stream, Fields fields) throws IOException {
-        ObjectWriter objectWriter = new ObjectMapper().writer(new DefaultPrettyPrinter(NEW_LINE_DELIMITER));
+        ObjectWriter objectWriter = new ObjectMapper().writer(new MinimalPrettyPrinter(NEW_LINE_DELIMITER));
         SequenceWriter writer = objectWriter.writeValues(stream);
         writer.init(!streamOutput);
 

--- a/output/src/main/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactory.java
+++ b/output/src/main/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactory.java
@@ -16,6 +16,8 @@
 
 package com.scottlogic.datahelix.generator.output.writer.json;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -41,7 +43,10 @@ public class JsonOutputWriterFactory implements OutputWriterFactory {
 
     @Override
     public DataSetWriter createWriter(OutputStream stream, Fields fields) throws IOException {
-        ObjectWriter objectWriter = new ObjectMapper().writer(new MinimalPrettyPrinter(NEW_LINE_DELIMITER));
+        PrettyPrinter prettyPrinter = streamOutput
+            ? new MinimalPrettyPrinter(NEW_LINE_DELIMITER)
+            : new DefaultPrettyPrinter();
+        ObjectWriter objectWriter = new ObjectMapper().writer(prettyPrinter);
         SequenceWriter writer = objectWriter.writeValues(stream);
         writer.init(!streamOutput);
 

--- a/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
+++ b/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
@@ -44,7 +44,7 @@ class JsonOutputWriterFactoryTest {
         expectJson(
             fields,
             true,
-            Matchers.equalTo("{\n  \"my_field\" : \"my_value\"\n}\n{\n  \"my_field\" : \"my_value\"\n}"));
+            Matchers.equalTo("{\"my_field\":\"my_value\"}\n{\"my_field\":\"my_value\"}"));
     }
 
     @Test
@@ -54,7 +54,7 @@ class JsonOutputWriterFactoryTest {
         expectJson(
             fields,
             false,
-            Matchers.equalTo("[ {\n  \"my_field\" : \"my_value\"\n}, {\n  \"my_field\" : \"my_value\"\n} ]"));
+            Matchers.equalTo("[{\"my_field\":\"my_value\"},{\"my_field\":\"my_value\"}]"));
     }
 
     @Test
@@ -68,7 +68,7 @@ class JsonOutputWriterFactoryTest {
         expectJson(
             fields,
             true,
-            Matchers.equalTo("{\n  \"External\" : \"my_value\"\n}\n{\n  \"External\" : \"my_value\"\n}")
+            Matchers.equalTo("{\"External\":\"my_value\"}\n{\"External\":\"my_value\"}")
         );
     }
 

--- a/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
+++ b/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
@@ -54,7 +54,7 @@ class JsonOutputWriterFactoryTest {
         expectJson(
             fields,
             false,
-            Matchers.equalTo("[{\"my_field\":\"my_value\"},{\"my_field\":\"my_value\"}]"));
+            Matchers.equalTo("[ {\n  \"my_field\" : \"my_value\"\n}, {\n  \"my_field\" : \"my_value\"\n} ]"));
     }
 
     @Test


### PR DESCRIPTION
### Description
Fix JSON output to ensure it matches the NDJSON format when streaming

### Changes
- Don't pretty-print JSON output when streaming
- JSON is still pretty-printed when not streaming (output to a file directly)

### Issue
Resolves #1650