### PR TITLE
#1627: Provide additional detail if CSV read fails

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberFileReader.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberFileReader.java
@@ -16,6 +16,7 @@
 package com.scottlogic.datahelix.generator.orchestrator.cucumber.testframework.utils;
 
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
+import com.scottlogic.datahelix.generator.profile.reader.CsvInputStreamReaderFactory;
 import com.scottlogic.datahelix.generator.profile.reader.FileReader;
 
 import javax.inject.Inject;
@@ -25,7 +26,7 @@ public class CucumberFileReader extends FileReader {
 
     @Inject
     public CucumberFileReader(CucumberTestState testState) {
-        super("");
+        super(new CsvInputStreamReaderFactory(""));
         this.testState = testState;
     }
 

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvFileInputReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvFileInputReader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.profile.reader;
+
+import com.scottlogic.datahelix.generator.common.ValidationException;
+import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
+
+import java.io.*;
+
+public class CsvFileInputReader implements CsvInputReader {
+    private final String path;
+
+    public CsvFileInputReader(String path) {
+        this.path = path;
+    }
+
+    public DistributedList<String> retrieveLines() {
+        try (InputStream stream = createStream()) {
+            return new CsvStreamInputReader(stream, path).retrieveLines();
+        } catch (IOException exc){
+            throw new UncheckedIOException(exc);
+        }
+    }
+
+    public DistributedList<String> retrieveLines(String key) {
+        try (InputStream stream = createStream()) {
+            return new CsvStreamInputReader(stream, path).retrieveLines(key);
+        } catch (IOException exc){
+            throw new UncheckedIOException(exc);
+        }
+    }
+
+    private InputStream createStream() {
+        try {
+            return new FileInputStream(path);
+        } catch (FileNotFoundException e) {
+            throw new ValidationException(e.getMessage());
+        }
+    }
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputReader.java
@@ -1,0 +1,8 @@
+package com.scottlogic.datahelix.generator.profile.reader;
+
+import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
+
+public interface CsvInputReader{
+    DistributedList<String> retrieveLines();
+    DistributedList<String> retrieveLines(String key);
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.datahelix.generator.profile.reader;
 
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputStreamReaderFactory.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputStreamReaderFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.datahelix.generator.profile.reader;
 
 import com.google.inject.name.Named;

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputStreamReaderFactory.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvInputStreamReaderFactory.java
@@ -1,0 +1,26 @@
+package com.scottlogic.datahelix.generator.profile.reader;
+
+import com.google.inject.name.Named;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.InputStream;
+
+public class CsvInputStreamReaderFactory {
+    private final String filePath;
+
+    @Inject
+    public CsvInputStreamReaderFactory(@Named("config:filePath") String filePath) {
+        this.filePath = filePath.endsWith(File.separator) || filePath.isEmpty()
+            ? filePath
+            : filePath + File.separator;
+    }
+
+    public CsvInputReader getReaderForFile(String file) {
+        return new CsvFileInputReader(filePath + file);
+    }
+
+    public CsvInputReader getReaderForStream(InputStream stream, String name) {
+        return new CsvStreamInputReader(stream, name);
+    }
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvStreamInputReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvStreamInputReader.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 Scott Logic Ltd
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.scottlogic.datahelix.generator.profile.reader;
 
 import com.scottlogic.datahelix.generator.common.ValidationException;
@@ -23,26 +7,29 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-public final class CsvInputStreamReader {
-    private CsvInputStreamReader() {
-        throw new UnsupportedOperationException("No instantiation of static class");
+public class CsvStreamInputReader implements CsvInputReader {
+    private final InputStream stream;
+    private final String path;
+
+    public CsvStreamInputReader(InputStream stream, String path) {
+        this.stream = stream;
+        this.path = path;
     }
 
-    public static DistributedList<String> retrieveLines(InputStream stream) {
+    public DistributedList<String> retrieveLines() {
         List<CSVRecord> records = parse(stream);
         return new DistributedList<>(records.stream()
-            .map(CsvInputStreamReader::createWeightedElementFromRecord)
+            .map(this::createWeightedElementFromRecord)
             .collect(Collectors.toList()));
     }
 
-    public static DistributedList<String> retrieveLines(InputStream stream, String key) {
+    public DistributedList<String> retrieveLines(String key) {
         List<CSVRecord> records = parse(stream);
 
         int index = getIndexForKey(records.get(0), key);
@@ -67,11 +54,20 @@ public final class CsvInputStreamReader {
         throw new ValidationException("unable to find data for key " + key);
     }
 
-    private static WeightedElement<String> createWeightedElementFromRecord(CSVRecord record) {
-        return createWeightedElement(record.get(0),
-            record.size() == 1 ? Optional.empty() : Optional.of(Double.parseDouble(record.get(1))));
-    }
+    private WeightedElement<String> createWeightedElementFromRecord(CSVRecord record) {
+        try {
+            Optional<Double> weighting = record.size() == 1
+                ? Optional.empty()
+                : Optional.of(Double.parseDouble(record.get(1)));
 
+            return createWeightedElement(record.get(0), weighting);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(
+                "Weighting '" + record.get(1) + "' is not a valid number\n" +
+                "CSV lines containing 2 columns must hold a weighting (double) in the second column, e.g. <value>,0.5\n" +
+                "Value: '" + record.get(0) + "', File: '" + this.path + "', Line " + record.getRecordNumber(), e);
+        }
+    }
 
     private static WeightedElement<String> createWeightedElement(String element, Optional<Double> weight) {
         return weight.map(integer -> new WeightedElement<>(element, integer))

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvStreamInputReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/CsvStreamInputReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.scottlogic.datahelix.generator.profile.reader;
 
 import com.scottlogic.datahelix.generator.common.ValidationException;

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/ConstraintService.java
@@ -48,7 +48,7 @@ public class ConstraintService {
     private final Map<String, Function<Field, Constraint>> fieldTypeToConstraint;
 
     @Inject
-    public ConstraintService(CustomConstraintFactory customConstraintFactory) {
+    public ConstraintService(CustomConstraintFactory customConstraintFactory, NameRetrievalService nameRetrievalService) {
         this.customConstraintFactory = customConstraintFactory;
         atomicConstraintFactoryMap = new EnumMap<>(FieldType.class);
         atomicConstraintFactoryMap.put(FieldType.DATETIME, new DateTimeConstraintFactory());
@@ -88,13 +88,13 @@ public class ConstraintService {
             field -> new MatchesStandardConstraint(field, StandardConstraintTypes.RIC));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FIRST_NAME.getType(),
-            field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FIRST)));
+            field -> new InSetConstraint(field, nameRetrievalService.loadNamesFromFile(NameConstraintTypes.FIRST)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.LAST_NAME.getType(),
-            field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.LAST)));
+            field -> new InSetConstraint(field, nameRetrievalService.loadNamesFromFile(NameConstraintTypes.LAST)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FULL_NAME.getType(),
-            field -> new InSetConstraint(field, NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL)));
+            field -> new InSetConstraint(field, nameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL)));
         fieldTypeToConstraint.put(
             StandardSpecificFieldType.FAKER.getType(),
             field -> new FakerConstraint(field, field.getSpecificType().getFakerMethod()));

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/TestFileReader.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/TestFileReader.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 
 public class TestFileReader extends FileReader {
     public TestFileReader() {
-        super("");
+        super(null);
     }
 
     @Override

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReaderTests.java
@@ -35,6 +35,7 @@ import com.scottlogic.datahelix.generator.profile.custom.CustomConstraint;
 import com.scottlogic.datahelix.generator.profile.custom.CustomConstraintFactory;
 import com.scottlogic.datahelix.generator.profile.services.ConstraintService;
 import com.scottlogic.datahelix.generator.profile.services.FieldService;
+import com.scottlogic.datahelix.generator.profile.services.NameRetrievalService;
 import com.scottlogic.datahelix.generator.profile.validators.ConfigValidator;
 import com.scottlogic.datahelix.generator.profile.validators.CreateProfileValidator;
 import com.scottlogic.datahelix.generator.profile.validators.profile.ProfileValidator;
@@ -42,7 +43,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -61,7 +61,7 @@ public class JsonProfileReaderTests {
 
     private class MockFromFileReader extends FileReader {
         MockFromFileReader() {
-            super("");
+            super(null);
         }
 
         @Override
@@ -85,7 +85,9 @@ public class JsonProfileReaderTests {
         new MockFromFileReader(),
         new ProfileCommandBus(
             new FieldService(),
-                new ConstraintService(new CustomConstraintFactory(new CustomGeneratorList())),
+                new ConstraintService(
+                    new CustomConstraintFactory(new CustomGeneratorList()),
+                    new NameRetrievalService(new CsvInputStreamReaderFactory(""))),
                 new CustomConstraintFactory(new CustomGeneratorList()),
             new CreateProfileValidator(new ProfileValidator(null))));
 
@@ -93,7 +95,7 @@ public class JsonProfileReaderTests {
         this.json = json;
     }
 
-    private Profile getResultingProfile() throws IOException {
+    private Profile getResultingProfile() {
         return jsonProfileReader.read(json);
     }
     
@@ -103,7 +105,7 @@ public class JsonProfileReaderTests {
     }
 
     @SafeVarargs
-    private final void expectConstraints(Consumer<Constraint>... constraintAssertions) throws IOException {
+    private final void expectConstraints(Consumer<Constraint>... constraintAssertions) {
         expectMany(this.getResultingProfile().getConstraints(), constraintAssertions);
     }
 
@@ -111,6 +113,7 @@ public class JsonProfileReaderTests {
         return constraint -> {
             Assert.assertThat(constraint, instanceOf(constraintType));
 
+            //noinspection unchecked
             asserter.accept((T) constraint);
         };
     }
@@ -120,7 +123,7 @@ public class JsonProfileReaderTests {
     }
 
     @SafeVarargs
-    private final void expectFields(Consumer<Field>... fieldAssertions) throws IOException {
+    private final void expectFields(Consumer<Field>... fieldAssertions) {
         expectMany(this.getResultingProfile().getFields(), fieldAssertions);
     }
 
@@ -146,7 +149,7 @@ public class JsonProfileReaderTests {
 
 
     @Test
-    public void shouldDeserialiseSingleField() throws IOException {
+    public void shouldDeserialiseSingleField() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"f1\", \"type\": \"string\" } ]," +
@@ -157,7 +160,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseMultipleFields() throws IOException {
+    public void shouldDeserialiseMultipleFields() {
         givenJson(
                 "{" +
                         "    \"fields\": [ " +
@@ -198,7 +201,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIsOfTypeConstraint() throws IOException {
+    public void shouldDeserialiseIsOfTypeConstraint() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"string\", \"nullable\": true } ]," +
@@ -214,7 +217,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIsOfTypeConstraint_whenInteger() throws IOException {
+    public void shouldDeserialiseIsOfTypeConstraint_whenInteger() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"integer\", \"nullable\": true } ]," +
@@ -230,7 +233,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIsEqualToConstraint() throws IOException {
+    public void shouldDeserialiseIsEqualToConstraint() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"string\", \"nullable\": true } ]," +
@@ -247,7 +250,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseFormatConstraint() throws IOException {
+    public void shouldDeserialiseFormatConstraint() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { " +
@@ -267,7 +270,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIsOfLengthConstraint() throws IOException {
+    public void shouldDeserialiseIsOfLengthConstraint() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"id\", \"type\": \"string\" , \"nullable\": true} ]," +
@@ -281,7 +284,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseNotWrapper() throws IOException {
+    public void shouldDeserialiseNotWrapper() {
         // Arrange
         givenJson(
                 "{" +
@@ -296,7 +299,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseOrConstraint() throws IOException {
+    public void shouldDeserialiseOrConstraint() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"foo\", \"type\": \"decimal\", \"nullable\": true } ]," +
@@ -315,7 +318,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseAndConstraint() throws IOException {
+    public void shouldDeserialiseAndConstraint() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"foo\", \"type\": \"decimal\", \"nullable\": true } ]," +
@@ -334,7 +337,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIfConstraint() throws IOException {
+    public void shouldDeserialiseIfConstraint() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"foo\", \"type\": \"string\", \"nullable\": true } ]," +
@@ -364,7 +367,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseIfConstraintWithoutElse() throws IOException {
+    public void shouldDeserialiseIfConstraintWithoutElse() {
         givenJson(
                 "{" +
                         "    \"fields\": [ { \"name\": \"foo\", \"type\": \"string\", \"nullable\": true } ]," +
@@ -393,7 +396,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseOneAsNumericGranularToConstraint() throws IOException {
+    public void shouldDeserialiseOneAsNumericGranularToConstraint() {
         givenJson(
             "{" +
             "    \"fields\": [ { \"name\": \"foo\", \"type\": \"decimal\", \"nullable\": true } ]," +
@@ -407,7 +410,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDeserialiseTenthAsNumericGranularToConstraint() throws IOException {
+    public void shouldDeserialiseTenthAsNumericGranularToConstraint() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"decimal\", \"nullable\": true } ]," +
@@ -421,7 +424,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldDisregardTrailingZeroesInNumericGranularities() throws IOException {
+    public void shouldDisregardTrailingZeroesInNumericGranularities() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"decimal\", \"nullable\": true } ]," +
@@ -435,7 +438,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void shouldAllowValidISO8601DateTime() throws IOException {
+    public void shouldAllowValidISO8601DateTime() {
         givenJson(
             "{" +
                 "    \"fields\": [ { \"name\": \"foo\", \"type\": \"datetime\", \"nullable\": true } ]," +
@@ -545,7 +548,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void unique_setsFieldPropertyToTrue_whenSetToTrue() throws IOException {
+    public void unique_setsFieldPropertyToTrue_whenSetToTrue() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -565,7 +568,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void unique_setsFieldPropertyToFalse_whenOmitted() throws IOException {
+    public void unique_setsFieldPropertyToFalse_whenOmitted() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -583,7 +586,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void unique_setsFieldPropertyToFalse_whenSetToFalse() throws IOException {
+    public void unique_setsFieldPropertyToFalse_whenSetToFalse() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -603,7 +606,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void nullable_addsConstraintForField_whenSetToFalse() throws IOException {
+    public void nullable_addsConstraintForField_whenSetToFalse() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -620,8 +623,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void nullable_DoesNotAddConstraintForField_whenSetToTrue() throws IOException
-    {
+    public void nullable_DoesNotAddConstraintForField_whenSetToTrue() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -636,7 +638,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void nullable_addsConstraintForFields_whenSetToFalse() throws IOException  {
+    public void nullable_addsConstraintForFields_whenSetToFalse() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -660,7 +662,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void nullable_addsConstraintForFields_whenOneSetToFalse() throws IOException  {
+    public void nullable_addsConstraintForFields_whenOneSetToFalse() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -681,7 +683,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void type_setsFieldTypeProperty_whenSetInFieldDefinition() throws IOException  {
+    public void type_setsFieldTypeProperty_whenSetInFieldDefinition() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -704,7 +706,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    void parser_createsInternalField_whenProfileHasAnInMapConstraint() throws IOException {
+    void parser_createsInternalField_whenProfileHasAnInMapConstraint() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -737,7 +739,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    void parser_createsInternalField_whenProfileHasANestedInMapConstraint() throws IOException {
+    void parser_createsInternalField_whenProfileHasANestedInMapConstraint() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -786,7 +788,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void formatting_withDateType_shouldSetCorrectGranularity() throws IOException  {
+    public void formatting_withDateType_shouldSetCorrectGranularity() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -802,7 +804,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void formatting_withDateType_shouldSetCorrectFormatting() throws IOException  {
+    public void formatting_withDateType_shouldSetCorrectFormatting() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -816,7 +818,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void formatting_withDateTypeAndFormatting_shouldSetCorrectFormatting() throws IOException  {
+    public void formatting_withDateTypeAndFormatting_shouldSetCorrectFormatting() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -831,7 +833,7 @@ public class JsonProfileReaderTests {
     }
 
     @Test
-    public void addsConstraintForGenerator() throws IOException  {
+    public void addsConstraintForGenerator() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +
@@ -850,7 +852,7 @@ public class JsonProfileReaderTests {
 
 
     @Test
-    public void exceptionWhenGeneratorDoesNotExist() throws IOException  {
+    public void exceptionWhenGeneratorDoesNotExist() {
         givenJson(
             "{" +
                 "    \"fields\": [ { " +

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/file/CsvStreamInputReaderTest.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/file/CsvStreamInputReaderTest.java
@@ -17,7 +17,8 @@ package com.scottlogic.datahelix.generator.profile.reader.file;
 
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
 import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
-import com.scottlogic.datahelix.generator.profile.reader.CsvInputStreamReader;
+import com.scottlogic.datahelix.generator.profile.reader.CsvInputReader;
+import com.scottlogic.datahelix.generator.profile.reader.CsvStreamInputReader;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -25,15 +26,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CsvInputStreamReaderTest {
+class CsvStreamInputReaderTest {
     @Test
     public void testReadingLinesFromNames() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         final InputStream is = loader.getResourceAsStream("names/firstname.csv");
+        final CsvInputReader reader = new CsvStreamInputReader(is, "names/firstname.csv");
 
-        final DistributedList<String> names = CsvInputStreamReader.retrieveLines(is);
+        final DistributedList<String> names = reader.retrieveLines();
 
         final Set<String> sampleNames = Stream.of("Rory", "Kyle", "Grace").collect(Collectors.toSet());
 
@@ -44,8 +46,9 @@ class CsvInputStreamReaderTest {
     public void testReadingLinesFromFileWithoutFrequencies() {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         final InputStream is = loader.getResourceAsStream("csv/without-frequencies.csv");
+        final CsvInputReader reader = new CsvStreamInputReader(is, "csv/without-frequencies.csv");
 
-        final DistributedList<String> set = CsvInputStreamReader.retrieveLines(is);
+        final DistributedList<String> set = reader.retrieveLines();
 
         assertTrue(checkAllWeightsAreEquals(set));
     }

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/file/names/NameRetrievalServiceTest.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/file/names/NameRetrievalServiceTest.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.profile.reader.file.names;
 
 import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.NameConstraintTypes;
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
+import com.scottlogic.datahelix.generator.profile.reader.CsvInputStreamReaderFactory;
 import com.scottlogic.datahelix.generator.profile.services.NameRetrievalService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,21 +31,30 @@ public class NameRetrievalServiceTest
 {
     @Test
     public void testLoadingFirstNames() {
-        DistributedList<Object> names = NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FIRST);
+        CsvInputStreamReaderFactory csvReaderFactory = new CsvInputStreamReaderFactory("");
+        NameRetrievalService service = new NameRetrievalService(csvReaderFactory);
+
+        DistributedList<Object> names = service.loadNamesFromFile(NameConstraintTypes.FIRST);
 
         assertEquals(704, names.distributedList().size());
     }
 
     @Test
     public void testLoadingLastNames() {
-        DistributedList<Object> names = NameRetrievalService.loadNamesFromFile(NameConstraintTypes.LAST);
+        CsvInputStreamReaderFactory csvReaderFactory = new CsvInputStreamReaderFactory("");
+        NameRetrievalService service = new NameRetrievalService(csvReaderFactory);
+
+        DistributedList<Object> names = service.loadNamesFromFile(NameConstraintTypes.LAST);
 
         assertEquals(280, names.distributedList().size());
     }
 
     @Test
     public void testLoadingFullNames() {
-        DistributedList<Object> names = NameRetrievalService.loadNamesFromFile(NameConstraintTypes.FULL);
+        CsvInputStreamReaderFactory csvReaderFactory = new CsvInputStreamReaderFactory("");
+        NameRetrievalService service = new NameRetrievalService(csvReaderFactory);
+
+        DistributedList<Object> names = service.loadNamesFromFile(NameConstraintTypes.FULL);
 
         assertEquals(197120, names.distributedList().size());
     }
@@ -52,7 +62,10 @@ public class NameRetrievalServiceTest
     @ParameterizedTest
     @EnumSource(NameConstraintTypes.class)
     public void testAllValuesGiveValidResult(NameConstraintTypes config) {
-        DistributedList<Object> result = NameRetrievalService.loadNamesFromFile(config);
+        CsvInputStreamReaderFactory csvReaderFactory = new CsvInputStreamReaderFactory("");
+        NameRetrievalService service = new NameRetrievalService(csvReaderFactory);
+
+        DistributedList<Object> result = service.loadNamesFromFile(config);
 
         assertNotNull(result);
     }


### PR DESCRIPTION
### Description
As identified in #1627, when a CSV file is read to provide the values for a set, it can fail if a row cannot be processed. This provides very little detail about the issue, and what corrective action could be performed.

### Changes
- Refactoring to use less static method calls
- Throw an exception, with the following details if a value from a CSV cannot be used
   - The line number and filename
   - The value that couldn't be loaded (could not be parsed as a Double)
   - Explanation of what corrective measures should be performed

e.g.
```
* Profile json is not valid
Weighting 'v.1' is not a valid number
CSV lines containing 2 values must hold a weighting (double) in the second column, e.g. <value>,0.5
Value: 'Sect.B', File: 'frequently_reprinted_subset-1.csv', Line 14
```

Also sufficiently resolves #1628 
```
* Profile json is not valid
Weighting '' is not a valid number
CSV lines containing 2 columns must hold a weighting (double) in the second column, e.g. <value>,0.5
Value: '1540?-1594', File: 'titlemeta-0.csv', Line 68
```

These changes 'resolve' #1627 by providing sufficient detail back to the user about what needs to be performed to resolve the issue. The CSV is incorrectly formatted, so could not be used as-is, so not a bug in the generator.

### Issue
Resolves #1627
Resolves #1628 
Resolves #1630 