### PR TITLE
refactor(#1534): Use composition to control generation behaviour

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/LimitingDataGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/LimitingDataGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation;
+
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.core.profile.Profile;
+
+import java.util.stream.Stream;
+
+public class LimitingDataGenerator implements DataGenerator {
+    private final DataGenerator dataGenerator;
+    private final long maxRows;
+
+    //created by DataGeneratorProvider
+    public LimitingDataGenerator(
+        DataGenerator dataGenerator,
+        long maxRows) {
+        this.dataGenerator = dataGenerator;
+        this.maxRows = maxRows;
+    }
+
+    @Override
+    public Stream<GeneratedObject> generateData(Profile profile) {
+        return dataGenerator.generateData(profile)
+            .limit(maxRows);
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/MonitoringDataGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/MonitoringDataGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation;
+
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.core.profile.Profile;
+
+import java.util.stream.Stream;
+
+public class MonitoringDataGenerator implements DataGenerator {
+    private final DataGenerator dataGenerator;
+    private final DataGeneratorMonitor monitor;
+
+    //created by DataGeneratorProvider
+    public MonitoringDataGenerator(
+        DataGenerator dataGenerator,
+        DataGeneratorMonitor monitor) {
+        this.dataGenerator = dataGenerator;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Stream<GeneratedObject> generateData(Profile profile) {
+        monitor.generationStarting();
+
+        return dataGenerator.generateData(profile)
+            .peek(monitor::rowEmitted);
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.scottlogic.datahelix.generator.core.generation.*;
+
+public class DataGeneratorProvider implements Provider<DataGenerator> {
+    private final DataGenerator coreGenerator;
+    private final long maxRows;
+    private final DataGeneratorMonitor monitor;
+
+    @Inject
+    public DataGeneratorProvider(
+        DecisionTreeDataGenerator coreGenerator,
+        @Named("config:maxRows") long maxRows,
+        DataGeneratorMonitor monitor) {
+        this.coreGenerator = coreGenerator;
+        this.maxRows = maxRows;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public DataGenerator get() {
+        return new MonitoringDataGenerator(
+            new LimitingDataGenerator(coreGenerator, maxRows),
+            monitor);
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
@@ -61,7 +61,7 @@ public class GeneratorModule extends AbstractModule {
 
         // Bind known implementations - no user input required
         bind(DataGeneratorMonitor.class).to(AbstractDataGeneratorMonitor.class);
-        bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);
+        bind(DataGenerator.class).toProvider(DataGeneratorProvider.class);
 
         bind(JavaUtilRandomNumberGenerator.class)
             .toInstance(new JavaUtilRandomNumberGenerator(OffsetDateTime.now().getNano()));

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
@@ -63,7 +63,6 @@ class DecisionTreeDataGeneratorTests {
         combinationStrategy = Mockito.mock(CombinationStrategy.class);
         upfrontTreePruner = Mockito.mock(UpfrontTreePruner.class);
         visualiserFactory = Mockito.mock(VisualiserFactory.class);
-        long maxRows = 10;
         generator = new DecisionTreeDataGenerator(
             factory,
             treeWalker,
@@ -72,8 +71,7 @@ class DecisionTreeDataGeneratorTests {
             monitor,
             combinationStrategy,
             upfrontTreePruner,
-            visualiserFactory,
-            maxRows
+            visualiserFactory
         );
     }
 


### PR DESCRIPTION
### Description
Refactor the architecture to use composition to control specific elements of how the generator behaves, rather than overloading a generator with too many responsibilities

### Changes
- New generator to limit quantities of output
- New generator to monitor output
- Above functions removed from default (DecisionTreeDataGenerator)

Related to #1534