### PR TITLE
#1677- Ensure profileFile is expressed as an absolute path rather than relative

### DIFF
--- a/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
+++ b/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
@@ -154,7 +154,7 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
 
     @Override
     public File getProfileFile() {
-        return profileFile;
+        return profileFile.getAbsoluteFile();
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix issue with the generator when trying to use a profile in the same directory as the generator

### Changes
- Convert a file as the command line argument to have an absolute path

### Issue
Resolves #1677
