### PR TITLE
841- Relational data - beta feature

### DIFF
--- a/.idea/runConfigurations/Example_generation__relational_.xml
+++ b/.idea/runConfigurations/Example_generation__relational_.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Example generation (relational)" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.scottlogic.datahelix.generator.orchestrator.App" />
+    <module name="datahelix.generator.orchestrator.main" />
+    <option name="PROGRAM_PARAMETERS" value="generate --profile-file=examples\relational\profile.json --output-format=JSON --quiet --max-rows=10" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/common/src/main/java/com/scottlogic/datahelix/generator/common/output/OutputFormat.java
+++ b/common/src/main/java/com/scottlogic/datahelix/generator/common/output/OutputFormat.java
@@ -16,10 +16,7 @@
 
 package com.scottlogic.datahelix.generator.common.output;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
-
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+public enum OutputFormat {
+    CSV,
+    JSON
 }

--- a/common/src/main/java/com/scottlogic/datahelix/generator/common/output/RelationalGeneratedObject.java
+++ b/common/src/main/java/com/scottlogic/datahelix/generator/common/output/RelationalGeneratedObject.java
@@ -16,10 +16,8 @@
 
 package com.scottlogic.datahelix.generator.common.output;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
+import java.util.Map;
 
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+public interface RelationalGeneratedObject {
+    Map<String, SubGeneratedObject> getSubObjects();
 }

--- a/common/src/main/java/com/scottlogic/datahelix/generator/common/output/SubGeneratedObject.java
+++ b/common/src/main/java/com/scottlogic/datahelix/generator/common/output/SubGeneratedObject.java
@@ -18,8 +18,10 @@ package com.scottlogic.datahelix.generator.common.output;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+import java.util.List;
+
+public interface SubGeneratedObject {
+    List<Field> getFields();
+    List<GeneratedObject> getData();
+    boolean isArray();
 }

--- a/common/src/main/java/com/scottlogic/datahelix/generator/common/profile/Fields.java
+++ b/common/src/main/java/com/scottlogic/datahelix/generator/common/profile/Fields.java
@@ -16,62 +16,13 @@
 
 package com.scottlogic.datahelix.generator.common.profile;
 
-
-
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class Fields implements Iterable<Field> {
-    private final List<Field> fields;
-
-    public Fields(List<Field> fields) {
-        this.fields = fields;
-    }
-
-    public Field getByName(String fieldName) {
-        return this.fields.stream()
-            .filter(f -> f.getName().equals(fieldName))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Profile fields do not contain " + fieldName));
-    }
-    
-    public int size() {
-        return this.fields.size();
-    }
-
-    @Override
-    public Iterator<Field> iterator() {
-        return fields.iterator();
-    }
-
-    public Stream<Field> stream() {
-        return this.fields.stream();
-    }
-
-    public Stream<Field> getExternalStream() {
-        return this.stream().filter(f -> !f.isInternal());
-    }
-
-    public List<Field> asList() {
-        return fields;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        Fields fields = (Fields) obj;
-        return this.fields.equals(fields.fields);
-    }
-
-    @Override
-    public int hashCode() {
-        return fields.hashCode();
-    }
+public interface Fields extends Iterable<Field> {
+    Field getByName(String fieldName);
+    int size();
+    Stream<Field> stream();
+    Stream<Field> getExternalStream();
+    List<Field> asList();
 }

--- a/common/src/main/java/com/scottlogic/datahelix/generator/common/profile/ProfileFields.java
+++ b/common/src/main/java/com/scottlogic/datahelix/generator/common/profile/ProfileFields.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.common.profile;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ProfileFields implements Fields {
+    private final List<Field> fields;
+
+    public ProfileFields(List<Field> fields) {
+        this.fields = fields;
+    }
+
+    public Field getByName(String fieldName) {
+        return this.fields.stream()
+            .filter(f -> f.getName().equals(fieldName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Profile fields do not contain " + fieldName));
+    }
+
+    public int size() {
+        return this.fields.size();
+    }
+
+    @Override
+    public Iterator<Field> iterator() {
+        return fields.iterator();
+    }
+
+    public Stream<Field> stream() {
+        return this.fields.stream();
+    }
+
+    public Stream<Field> getExternalStream() {
+        return this.stream().filter(f -> !f.isInternal());
+    }
+
+    public List<Field> asList() {
+        return fields;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+
+        ProfileFields fields = (ProfileFields) obj;
+        return this.fields.equals(fields.fields);
+    }
+
+    @Override
+    public int hashCode() {
+        return fields.hashCode();
+    }
+}

--- a/common/src/test/java/com/scottlogic/datahelix/generator/common/profile/ProfileFieldsTests.java
+++ b/common/src/test/java/com/scottlogic/datahelix/generator/common/profile/ProfileFieldsTests.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import static com.scottlogic.datahelix.generator.common.profile.FieldBuilder.createField;
 
-class FieldsTests
+class ProfileFieldsTests
 {
     @Test
     void equals_objIsNull_returnsFalse() {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("Test")
             )
@@ -43,7 +43,7 @@ class FieldsTests
 
     @Test
     void equals_objTypeIsNotProfileFields_returnsFalse() {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("Test")
             )
@@ -59,7 +59,7 @@ class FieldsTests
 
     @Test
     void equals_rowSpecFieldsLengthNotEqualToOtherObjectFieldsLength_returnsFalse() {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
@@ -67,7 +67,7 @@ class FieldsTests
         );
 
         boolean result = fields.equals(
-            new Fields(
+            new ProfileFields(
                 Arrays.asList(
                     createField("First Field")
                 )
@@ -82,7 +82,7 @@ class FieldsTests
 
     @Test
     void equals_rowSpecFieldsLengthEqualToOterObjectFieldsLengthButValuesDiffer_returnsFalse() {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
@@ -90,7 +90,7 @@ class FieldsTests
         );
 
         boolean result = fields.equals(
-            new Fields(
+            new ProfileFields(
                 Arrays.asList(
                     createField("First Field"),
                     createField("Third Field")
@@ -106,7 +106,7 @@ class FieldsTests
 
     @Test
     void equals_rowSpecFieldsAreEqualToTheFieldsOfTheOtherObject_returnsTrue() {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
@@ -114,7 +114,7 @@ class FieldsTests
         );
 
         boolean result = fields.equals(
-            new Fields(
+            new ProfileFields(
                 Arrays.asList(
                     createField("First Field"),
                     createField("Second Field")
@@ -130,13 +130,13 @@ class FieldsTests
 
     @Test
     void hashCode_valuesinFieldsDifferInSize_returnsDifferentHashCodes() {
-        Fields firstFields = new Fields(
+        Fields firstFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
             )
         );
-        Fields secondFields = new Fields(
+        Fields secondFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field"),
@@ -156,13 +156,13 @@ class FieldsTests
 
     @Test
     void hashCode_valuesInFieldsAreEqualSizeButValuesDiffer_returnsDifferentHashCodes() {
-        Fields firstFields = new Fields(
+        Fields firstFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
             )
         );
-        Fields secondFields = new Fields(
+        Fields secondFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Third Field")
@@ -181,13 +181,13 @@ class FieldsTests
 
     @Test
     void hashCode_valuesInFieldsAreEqual_identicalHashCodesAreReturned() {
-        Fields firstFields = new Fields(
+        Fields firstFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")
             )
         );
-        Fields secondFields = new Fields(
+        Fields secondFields = new ProfileFields(
             Arrays.asList(
                 createField("First Field"),
                 createField("Second Field")

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/TreePartitioner.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/TreePartitioner.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNodeBuilder;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionNode;
 import com.scottlogic.datahelix.generator.core.fieldspecs.relations.FieldSpecRelation;
@@ -88,12 +89,12 @@ public class TreePartitioner {
                         .addRelations(partition.getRelations())
                         .setDecisions(partition.getDecisionNodes())
                         .build(),
-                    new Fields(new ArrayList<>(partition.fields))
+                    new ProfileFields(new ArrayList<>(partition.fields))
                 )),
             unpartitionedFields
                 .map(field -> new DecisionTree(
                     new ConstraintNodeBuilder().build(),
-                    new Fields(Collections.singletonList(field))
+                    new ProfileFields(Collections.singletonList(field))
                 ))
             );
     }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGenerator.java
@@ -25,7 +25,7 @@ import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTreeOptimise
 import com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.datahelix.generator.core.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.datahelix.generator.core.generation.databags.DataBag;
-import com.scottlogic.datahelix.generator.core.generation.relationships.RelationshipsProcessor;
+import com.scottlogic.datahelix.generator.core.generation.relationships.RelationshipsDataGenerator;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.Visualiser;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.VisualiserFactory;
 import com.scottlogic.datahelix.generator.core.profile.Profile;
@@ -45,7 +45,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
     private final CombinationStrategy partitionCombiner;
     private final UpfrontTreePruner upfrontTreePruner;
     private final VisualiserFactory visualiserFactory;
-    private final RelationshipsProcessor relationshipsProcessor;
+    private final RelationshipsDataGenerator relationshipsDataGenerator;
 
     @Inject
     public DecisionTreeDataGenerator(
@@ -57,7 +57,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
         CombinationStrategy combinationStrategy,
         UpfrontTreePruner upfrontTreePruner,
         VisualiserFactory visualiserFactory,
-        RelationshipsProcessor relationshipsProcessor) {
+        RelationshipsDataGenerator relationshipsDataGenerator) {
         this.decisionTreeGenerator = decisionTreeGenerator;
         this.treePartitioner = treePartitioner;
         this.treeOptimiser = optimiser;
@@ -66,7 +66,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
         this.partitionCombiner = combinationStrategy;
         this.upfrontTreePruner = upfrontTreePruner;
         this.visualiserFactory = visualiserFactory;
-        this.relationshipsProcessor = relationshipsProcessor;
+        this.relationshipsDataGenerator = relationshipsDataGenerator;
     }
 
     @Override
@@ -86,7 +86,7 @@ public class DecisionTreeDataGenerator implements DataGenerator {
             .map(tree -> () -> treeWalker.walk(tree));
 
         return partitionCombiner.permute(partitionedDataBags)
-            .map(generatedObject -> relationshipsProcessor.produceRelationalObjects(
+            .map(generatedObject -> relationshipsDataGenerator.produceRelationalObjects(
                 profile.getFields(),
                 generatedObject,
                 profile.getRelationships(),

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/GenerationConfigSource.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/GenerationConfigSource.java
@@ -26,7 +26,8 @@ import java.nio.file.Path;
 public interface GenerationConfigSource  {
     DataGenerationType getGenerationType();
     CombinationStrategyType getCombinationStrategyType();
-    long getMaxRows();
+    Long getMaxRows();
+    boolean getInfiniteOutput();
 
     MonitorType getMonitorType();
 

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/databags/DataBag.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/databags/DataBag.java
@@ -35,8 +35,13 @@ public class DataBag implements GeneratedObject {
     }
 
     @Override
+    public Object getValue(Field field) {
+        return getDataBagValue(field).getValue();
+    }
+
+    @Override
     public Object getFormattedValue(Field field) {
-        Object value = getDataBagValue(field).getValue();
+        Object value = getValue(field);
         String formatting = field.getFormatting();
 
         if (formatting == null || value == null) {

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/ExtentAugmentedFields.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/ExtentAugmentedFields.java
@@ -21,16 +21,21 @@ import com.scottlogic.datahelix.generator.common.profile.FieldType;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.common.profile.SpecificFieldType;
 
-public class ExtentAugmentedFields extends Fields {
-    private static final SpecificFieldType integer = new SpecificFieldType("integer", FieldType.NUMERIC, null);
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
 
-    public static final String minField = "min";
-    public static final String maxField = "max";
-    public static final Field min = new Field(minField, integer, false, null, false, true, null);
-    public static final Field max = new Field(maxField, integer, false, null, false, true, null);
+public class ExtentAugmentedFields implements Fields {
+    private static final SpecificFieldType integer = new SpecificFieldType("integer", FieldType.NUMERIC, null);
+    private static final String minField = "min";
+    private static final String maxField = "max";
+    private static final Field min = new Field(minField, integer, false, null, false, true, null);
+    private static final Field max = new Field(maxField, integer, false, null, false, true, null);
+
+    private final Fields underlying;
 
     public ExtentAugmentedFields(Fields fields) {
-        super(fields.asList());
+        this.underlying = fields;
     }
 
     @Override
@@ -43,6 +48,47 @@ public class ExtentAugmentedFields extends Fields {
             return max;
         }
 
-        return super.getByName(fieldName);
+        return underlying.getByName(fieldName);
+    }
+
+    @Override
+    public int size() {
+        return underlying.size();
+    }
+
+    @Override
+    public Stream<Field> stream() {
+        return Stream.concat(
+            underlying.stream(),
+            Stream.of(min, max));
+    }
+
+    @Override
+    public Stream<Field> getExternalStream() {
+        return underlying.getExternalStream();
+    }
+
+    @Override
+    public List<Field> asList() {
+        return underlying.asList();
+    }
+
+    @Override
+    public Iterator<Field> iterator() {
+        return underlying.iterator();
+    }
+
+    public boolean isExtentField(Field field) {
+        return field.equals(min) || field.equals(max);
+    }
+
+    public OneToManyRange applyExtent(OneToManyRange range, Field field, int extent) {
+        if (field.equals(min)) {
+            return range.withMin(extent);
+        } else if (field.equals(max)) {
+            return range.withMax(extent);
+        }
+
+        return range;
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/ExtentAugmentedFields.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/ExtentAugmentedFields.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.SpecificFieldType;
+
+public class ExtentAugmentedFields extends Fields {
+    private static final SpecificFieldType integer = new SpecificFieldType("integer", FieldType.NUMERIC, null);
+
+    public static final String minField = "min";
+    public static final String maxField = "max";
+    public static final Field min = new Field(minField, integer, false, null, false, true, null);
+    public static final Field max = new Field(maxField, integer, false, null, false, true, null);
+
+    public ExtentAugmentedFields(Fields fields) {
+        super(fields.asList());
+    }
+
+    @Override
+    public Field getByName(String fieldName) {
+        if (fieldName.equals(minField)) {
+            return min;
+        }
+
+        if (fieldName.equals(maxField)) {
+            return max;
+        }
+
+        return super.getByName(fieldName);
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/GeneratedRelationalData.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/GeneratedRelationalData.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.output.RelationalGeneratedObject;
+import com.scottlogic.datahelix.generator.common.output.SubGeneratedObject;
+import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GeneratedRelationalData implements GeneratedObject, RelationalGeneratedObject {
+    private final GeneratedObject underlyingObject;
+    private final Map<String, SubGeneratedObject> subObjects = new HashMap<>();
+
+    public GeneratedRelationalData(GeneratedObject underlyingObject) {
+        this.underlyingObject = underlyingObject;
+    }
+
+    @Override
+    public Object getFormattedValue(Field field) {
+        return underlyingObject.getFormattedValue(field);
+    }
+
+    @Override
+    public Object getValue(Field field) {
+        return underlyingObject.getValue(field);
+    }
+
+    @Override
+    public Map<String, SubGeneratedObject> getSubObjects() {
+        return subObjects;
+    }
+
+    public void addSubObject(Relationship relationship, SubGeneratedObject subObject) {
+        if (!subObjects.containsKey(relationship.getName())) {
+            subObjects.put(relationship.getName(), subObject);
+        } else {
+            throw new RuntimeException("Sub-object for this relationship already exists");
+        }
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+public class OneToManyRange {
+    private final int min;
+    private final Integer max;
+
+    public OneToManyRange(int min, Integer max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public Integer getMax() {
+        return max;
+    }
+
+    public OneToManyRange withMin(int min) {
+        if (min > this.min) {
+            return new OneToManyRange(min, max);
+        }
+
+        return this;
+    }
+
+    public OneToManyRange withMax(int max) {
+        if (this.max == null || max < this.max) {
+            return new OneToManyRange(min, max);
+        }
+
+        return this;
+    }
+
+    public boolean isEmpty() {
+        return this.max != null && this.min >= this.max;
+    }
+
+    @Override
+    public String toString() {
+        if (max == null) {
+            return min + "..";
+        }
+
+        return min + ".." + max;
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
@@ -50,7 +50,7 @@ public class OneToManyRange {
     }
 
     public boolean isEmpty() {
-        return this.max != null && this.min >= this.max;
+        return this.max != null && this.min > this.max;
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRange.java
@@ -50,7 +50,7 @@ public class OneToManyRange {
     }
 
     public boolean isEmpty() {
-        return this.max != null && this.min > this.max;
+        return this.max != null && (this.min > this.max || (this.min == 0 && this.max == 0));
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRangeResolver.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRangeResolver.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.google.inject.Inject;
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
+import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTree;
+import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTreeFactory;
+import com.scottlogic.datahelix.generator.core.generation.databags.DataBagValue;
+import com.scottlogic.datahelix.generator.core.profile.Profile;
+import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
+import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.AtomicConstraint;
+import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.EqualToConstraint;
+import com.scottlogic.datahelix.generator.core.walker.pruner.Merged;
+import com.scottlogic.datahelix.generator.core.walker.pruner.TreePruner;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class OneToManyRangeResolver {
+    private final DecisionTreeFactory factory;
+    private final TreePruner treePruner;
+
+    private static final Field min = ExtentAugmentedFields.min;
+    private static final Field max = ExtentAugmentedFields.max;
+
+    @Inject
+    public OneToManyRangeResolver(
+        DecisionTreeFactory factory,
+        TreePruner treePruner) {
+        this.factory = factory;
+        this.treePruner = treePruner;
+    }
+
+    public OneToManyRange getRange(Fields profileFields, Collection<Constraint> constraints, GeneratedObject generatedObject) {
+        OneToManyRange range = new OneToManyRange(0, null);
+
+        DecisionTree tree = factory.analyse(new Profile(
+            getFields(profileFields),
+            new ArrayList<>(constraints),
+            Collections.emptyList())
+        );
+
+        //apply each value of generatedObject to the tree
+        ConstraintNode rootNode = applyGeneratedData(profileFields, tree.getRootNode(), generatedObject);
+
+        if (rootNode == null) {
+            throw new RuntimeException("There are conditions that result in an unresolved extent");
+        }
+
+        if (!rootNode.getDecisions().isEmpty()) {
+            throw new RuntimeException("There are conditional constraints that haven't been resolved");
+        }
+
+        //read the root-level properties for <min> and <max> if there are any decisions
+        range = rootNode.getAtomicConstraints()
+            .stream()
+            .filter(ac -> ac.getField().equals(min) || ac.getField().equals(max))
+            .reduce(
+                range,
+                OneToManyRangeResolver::applyAtomicConstraint,
+                (a, b) -> null);
+
+        return range;
+    }
+
+    private static OneToManyRange applyAtomicConstraint(OneToManyRange range, AtomicConstraint atomicConstraint) {
+        Field field = atomicConstraint.getField();
+
+        if (field.equals(min)) {
+            return range.withMin(getExtent(atomicConstraint));
+        } else if (field.equals(max)) {
+            return range.withMax(getExtent(atomicConstraint));
+        }
+
+        return range;
+    }
+
+    private static int getExtent(AtomicConstraint atomicConstraint) {
+        if (atomicConstraint instanceof EqualToConstraint) {
+            return getIntegerValue(((EqualToConstraint) atomicConstraint).value);
+        }
+
+        throw new RuntimeException("Unsure how to extract an extent from a " + atomicConstraint.getClass().getName());
+    }
+
+    private static int getIntegerValue(Object value) {
+        if (value instanceof Integer){
+            return (int) value;
+        }
+
+        if (value instanceof BigDecimal){
+            return ((BigDecimal) value).intValue();
+        }
+
+        throw new RuntimeException("Unable to extract an integer value from a " + value.getClass().getName());
+    }
+
+    private ConstraintNode applyGeneratedData(Fields profileFields, ConstraintNode rootNode, GeneratedObject generatedObject) {
+        return profileFields.stream().reduce(
+            rootNode,
+            (nextRootNode, field) -> {
+                if (nextRootNode == null) {
+                    return null;
+                }
+
+                Object value = generatedObject.getValue(field);
+                Merged<ConstraintNode> constraintNodeMerged = treePruner.pruneConstraintNode(nextRootNode, field, new DataBagValue(value));
+                if (constraintNodeMerged.isContradictory()){
+                    return null;
+                }
+
+                return constraintNodeMerged.get();
+            },
+            (a, b) -> null
+        );
+    }
+
+    private List<Field> getFields(Fields profileFields) {
+        return Stream.concat(
+            profileFields.asList().stream(),
+            Stream.of(min, max))
+            .collect(Collectors.toList());
+
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRelationshipProcessor.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRelationshipProcessor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.google.inject.Inject;
+import com.scottlogic.datahelix.generator.common.RandomNumberGenerator;
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.output.SubGeneratedObject;
+import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.generation.DataGenerator;
+import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+import com.scottlogic.datahelix.generator.core.utils.JavaUtilRandomNumberGenerator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OneToManyRelationshipProcessor implements RelationshipProcessor {
+    private final RandomNumberGenerator randomNumberGenerator;
+    private final OneToManyRangeResolver rangeResolver;
+
+    @Inject
+    public OneToManyRelationshipProcessor(
+        JavaUtilRandomNumberGenerator randomNumberGenerator,
+        OneToManyRangeResolver rangeResolver) {
+        this.randomNumberGenerator = randomNumberGenerator;
+        this.rangeResolver = rangeResolver;
+    }
+
+    @Override
+    public void processRelationship(Fields profileFields, Relationship relationship, GeneratedRelationalData generatedObject, DataGenerator dataGenerator) {
+        List<Constraint> extents = relationship.getExtents();
+        OneToManyRange range = this.rangeResolver.getRange(profileFields, extents, generatedObject);
+
+        if (range.isEmpty()) {
+            return;
+        }
+
+        int numberOfObjects = getNumberOfObjectsToProduce(range.getMin(), range.getMax());
+
+        generatedObject.addSubObject(relationship, new SubGeneratedObject() {
+            @Override
+            public List<Field> getFields() {
+                return relationship.getProfile().getFields().asList();
+            }
+
+            @Override
+            public List<GeneratedObject> getData() {
+                return dataGenerator.generateData(relationship.getProfile())
+                    .limit(numberOfObjects)
+                    .collect(Collectors.toList());
+            }
+
+            @Override
+            public boolean isArray() {
+                return true;
+            }
+        });
+    }
+
+    private Integer getNumberOfObjectsToProduce(int min, Integer max) {
+        if (max == null) {
+            throw new RuntimeException("Unable to produce sub-objects, range is unbounded");
+        }
+
+        int range = max - min;
+        if (range == 0){
+            return min;
+        }
+
+        return randomNumberGenerator.nextInt(range + 1) + min;
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToOneRelationshipProcessor.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToOneRelationshipProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.output.SubGeneratedObject;
+import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.generation.DataGenerator;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class OneToOneRelationshipProcessor implements RelationshipProcessor {
+    @Override
+    public void processRelationship(Fields profileFields, Relationship relationship, GeneratedRelationalData generatedObject, DataGenerator dataGenerator) {
+        Optional<GeneratedObject> subObject = dataGenerator.generateData(relationship.getProfile()).limit(1).findFirst();
+        if (!subObject.isPresent()) {
+            return;
+        }
+
+        generatedObject.addSubObject(relationship, new SubGeneratedObject() {
+            @Override
+            public List<Field> getFields() {
+                return relationship.getProfile().getFields().asList();
+            }
+
+            @Override
+            public List<GeneratedObject> getData() {
+                return Collections.singletonList(subObject.get());
+            }
+
+            @Override
+            public boolean isArray() {
+                return false;
+            }
+        });
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipProcessor.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipProcessor.java
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package com.scottlogic.datahelix.generator.output.guice;
+package com.scottlogic.datahelix.generator.core.generation.relationships;
 
-public enum OutputFormat {
-    CSV,
-    JSON
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.generation.DataGenerator;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+
+interface RelationshipProcessor {
+    void processRelationship(Fields profileFields, Relationship relationship, GeneratedRelationalData generatedObject, DataGenerator dataGenerator);
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipsDataGenerator.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipsDataGenerator.java
@@ -17,7 +17,6 @@
 package com.scottlogic.datahelix.generator.core.generation.relationships;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
 import com.scottlogic.datahelix.generator.common.output.OutputFormat;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
@@ -26,13 +25,13 @@ import com.scottlogic.datahelix.generator.core.profile.relationships.Relationshi
 
 import java.util.Collection;
 
-public class RelationshipsProcessor {
+public class RelationshipsDataGenerator {
     private final OutputFormat outputFormat;
     private final RelationshipProcessor oneToOne;
     private final RelationshipProcessor oneToMany;
 
     @Inject
-    public RelationshipsProcessor(
+    public RelationshipsDataGenerator(
         OutputFormat outputFormat,
         OneToOneRelationshipProcessor oneToOne,
         OneToManyRelationshipProcessor oneToMany) {

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipsProcessor.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/generation/relationships/RelationshipsProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.output.OutputFormat;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.generation.DataGenerator;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+
+import java.util.Collection;
+
+public class RelationshipsProcessor {
+    private final OutputFormat outputFormat;
+    private final RelationshipProcessor oneToOne;
+    private final RelationshipProcessor oneToMany;
+
+    @Inject
+    public RelationshipsProcessor(
+        OutputFormat outputFormat,
+        OneToOneRelationshipProcessor oneToOne,
+        OneToManyRelationshipProcessor oneToMany) {
+        this.outputFormat = outputFormat;
+        this.oneToOne = oneToOne;
+        this.oneToMany = oneToMany;
+    }
+
+    public GeneratedObject produceRelationalObjects(Fields profileFields, GeneratedObject generatedObject, Collection<Relationship> relationships, DataGenerator dataGenerator) {
+        if (relationships == null || relationships.isEmpty()){
+            return generatedObject;
+        }
+
+        if (outputFormat != OutputFormat.JSON) {
+            throw new RuntimeException("Unable to produce relational data except in JSON format, please supply the --output-format=JSON command line argument");
+        }
+
+        GeneratedRelationalData generatedRelationalData = new GeneratedRelationalData(generatedObject);
+
+        relationships.forEach(relationship -> processRelationship(profileFields, relationship, generatedRelationalData, dataGenerator));
+
+        return generatedRelationalData;
+    }
+
+    private void processRelationship(Fields profileFields, Relationship relationship, GeneratedRelationalData generatedObject, DataGenerator dataGenerator) {
+        if (relationship.getProfile() == null) {
+            throw new RuntimeException("Profile must be supplied for the relationship");
+        }
+
+        if (relationship.getExtents().isEmpty()) {
+            oneToOne.processRelationship(profileFields, relationship, generatedObject, dataGenerator);
+        } else {
+            oneToMany.processRelationship(profileFields, relationship, generatedObject, dataGenerator);
+        }
+    }
+}

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/CombinationStrategyProvider.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/CombinationStrategyProvider.java
@@ -35,7 +35,7 @@ public class CombinationStrategyProvider  implements Provider<CombinationStrateg
         if (config.getGenerationType() == DataGenerationType.RANDOM){
             // The minimal combination strategy doesn't reuse values for fields.
             // This is required to get truly random data.
-            return new ExhaustiveCombinationStrategy();
+            return new MinimalCombinationStrategy();
         }
 
         switch(config.getCombinationStrategyType()){

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/CombinationStrategyProvider.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/CombinationStrategyProvider.java
@@ -35,7 +35,7 @@ public class CombinationStrategyProvider  implements Provider<CombinationStrateg
         if (config.getGenerationType() == DataGenerationType.RANDOM){
             // The minimal combination strategy doesn't reuse values for fields.
             // This is required to get truly random data.
-            return new MinimalCombinationStrategy();
+            return new ExhaustiveCombinationStrategy();
         }
 
         switch(config.getCombinationStrategyType()){

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
@@ -22,16 +22,18 @@ import com.google.inject.name.Named;
 import com.scottlogic.datahelix.generator.core.config.detail.MonitorType;
 import com.scottlogic.datahelix.generator.core.generation.*;
 
+import javax.annotation.Nullable;
+
 public class DataGeneratorProvider implements Provider<DataGenerator> {
     private final DataGenerator coreGenerator;
-    private final long maxRows;
+    private final Long maxRows;
     private final MonitorType monitorType;
     private final DataGeneratorMonitor monitor;
 
     @Inject
     public DataGeneratorProvider(
         DecisionTreeDataGenerator coreGenerator,
-        @Named("config:maxRows") long maxRows,
+        @Nullable @Named("config:maxRows") Long maxRows,
         MonitorType monitorType,
         DataGeneratorMonitor monitor) {
         this.coreGenerator = coreGenerator;
@@ -42,7 +44,9 @@ public class DataGeneratorProvider implements Provider<DataGenerator> {
 
     @Override
     public DataGenerator get() {
-        DataGenerator limitingGenerator = new LimitingDataGenerator(coreGenerator, maxRows);
+        DataGenerator limitingGenerator = maxRows == null
+            ? coreGenerator
+            : new LimitingDataGenerator(coreGenerator, maxRows);
 
         if (monitorType == MonitorType.QUIET){
             return limitingGenerator;

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/DataGeneratorProvider.java
@@ -19,27 +19,37 @@ package com.scottlogic.datahelix.generator.core.guice;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.name.Named;
+import com.scottlogic.datahelix.generator.core.config.detail.MonitorType;
 import com.scottlogic.datahelix.generator.core.generation.*;
 
 public class DataGeneratorProvider implements Provider<DataGenerator> {
     private final DataGenerator coreGenerator;
     private final long maxRows;
+    private final MonitorType monitorType;
     private final DataGeneratorMonitor monitor;
 
     @Inject
     public DataGeneratorProvider(
         DecisionTreeDataGenerator coreGenerator,
         @Named("config:maxRows") long maxRows,
+        MonitorType monitorType,
         DataGeneratorMonitor monitor) {
         this.coreGenerator = coreGenerator;
         this.maxRows = maxRows;
+        this.monitorType = monitorType;
         this.monitor = monitor;
     }
 
     @Override
     public DataGenerator get() {
+        DataGenerator limitingGenerator = new LimitingDataGenerator(coreGenerator, maxRows);
+
+        if (monitorType == MonitorType.QUIET){
+            return limitingGenerator;
+        }
+
         return new MonitoringDataGenerator(
-            new LimitingDataGenerator(coreGenerator, maxRows),
+            limitingGenerator,
             monitor);
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
@@ -21,6 +21,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import com.scottlogic.datahelix.generator.core.config.detail.CombinationStrategyType;
 import com.scottlogic.datahelix.generator.core.config.detail.DataGenerationType;
+import com.scottlogic.datahelix.generator.core.config.detail.MonitorType;
 import com.scottlogic.datahelix.generator.core.generation.*;
 import com.scottlogic.datahelix.generator.core.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.datahelix.generator.core.utils.JavaUtilRandomNumberGenerator;
@@ -58,6 +59,9 @@ public class GeneratorModule extends AbstractModule {
         bind(long.class)
             .annotatedWith(Names.named("config:maxRows"))
             .toInstance(generationConfigSource.getMaxRows());
+
+        bind(MonitorType.class)
+            .toInstance(generationConfigSource.getMonitorType());
 
         // Bind known implementations - no user input required
         bind(DataGeneratorMonitor.class).to(AbstractDataGeneratorMonitor.class);

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/guice/GeneratorModule.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.core.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import com.google.inject.util.Providers;
 import com.scottlogic.datahelix.generator.core.config.detail.CombinationStrategyType;
 import com.scottlogic.datahelix.generator.core.config.detail.DataGenerationType;
 import com.scottlogic.datahelix.generator.core.config.detail.MonitorType;
@@ -29,6 +30,8 @@ import com.scottlogic.datahelix.generator.core.walker.DecisionTreeWalker;
 import com.scottlogic.datahelix.generator.core.walker.decisionbased.OptionPicker;
 
 import java.time.OffsetDateTime;
+
+import static com.scottlogic.datahelix.generator.common.util.Defaults.DEFAULT_MAX_ROWS;
 
 /**
  * Class to define default bindings for Guice injection. Utilises the generation config source to determine which
@@ -56,9 +59,9 @@ public class GeneratorModule extends AbstractModule {
         bind(DataGenerationType.class).toInstance(generationConfigSource.getGenerationType());
         bind(CombinationStrategyType.class).toInstance(generationConfigSource.getCombinationStrategyType());
 
-        bind(long.class)
+        bind(Long.class)
             .annotatedWith(Names.named("config:maxRows"))
-            .toInstance(generationConfigSource.getMaxRows());
+            .toProvider(Providers.of(getMaxRows(generationConfigSource)));
 
         bind(MonitorType.class)
             .toInstance(generationConfigSource.getMonitorType());
@@ -72,5 +75,21 @@ public class GeneratorModule extends AbstractModule {
         bind(int.class)
             .annotatedWith(Names.named("config:internalRandomRowSpecStorage"))
             .toInstance(256);
+    }
+
+    private static Long getMaxRows(GenerationConfigSource generationConfigSource) {
+        Long requestedMaxRows = generationConfigSource.getMaxRows();
+
+        return requestedMaxRows == null
+            ? getDefaultMaxRows(generationConfigSource)
+            : requestedMaxRows;
+    }
+
+    private static Long getDefaultMaxRows(GenerationConfigSource generationConfigSource) {
+        if (generationConfigSource.getInfiniteOutput()){
+            return null;
+        }
+
+        return DEFAULT_MAX_ROWS;
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/Profile.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/Profile.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.profile;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
 import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
 
@@ -31,11 +32,11 @@ public class Profile {
     private final Collection<Relationship> relationships;
 
     public Profile(List<Field> fields, Collection<Constraint> constraints, Collection<Relationship> relationships) {
-        this(null, new Fields(fields), constraints, relationships);
+        this(null, new ProfileFields(fields), constraints, relationships);
     }
 
     public Profile(List<Field> fields, Collection<Constraint> constraints, Collection<Relationship> relationships, String description) {
-        this(description, new Fields(fields), constraints, relationships);
+        this(description, new ProfileFields(fields), constraints, relationships);
     }
 
     public Profile(Fields fields, Collection<Constraint> constraints, Collection<Relationship> relationships) {

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/Profile.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/Profile.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.core.profile;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,23 +28,25 @@ public class Profile {
     private final Fields fields;
     private final Collection<Constraint> constraints;
     private final String description;
+    private final Collection<Relationship> relationships;
 
-    public Profile(List<Field> fields, Collection<Constraint> constraints) {
-        this(null, new Fields(fields), constraints);
+    public Profile(List<Field> fields, Collection<Constraint> constraints, Collection<Relationship> relationships) {
+        this(null, new Fields(fields), constraints, relationships);
     }
 
-    public Profile(List<Field> fields, Collection<Constraint> constraints, String description) {
-        this(description, new Fields(fields), constraints);
+    public Profile(List<Field> fields, Collection<Constraint> constraints, Collection<Relationship> relationships, String description) {
+        this(description, new Fields(fields), constraints, relationships);
     }
 
-    public Profile(Fields fields, Collection<Constraint> constraints) {
-        this(null, fields, constraints);
+    public Profile(Fields fields, Collection<Constraint> constraints, Collection<Relationship> relationships) {
+        this(null, fields, constraints, relationships);
     }
 
-    public Profile(String description, Fields fields, Collection<Constraint> constraints) {
+    public Profile(String description, Fields fields, Collection<Constraint> constraints, Collection<Relationship> relationships) {
         this.fields = fields;
         this.constraints = constraints;
         this.description = description;
+        this.relationships = relationships;
     }
 
     public Fields getFields() {
@@ -56,5 +59,9 @@ public class Profile {
 
     public String getDescription() {
         return description;
+    }
+
+    public Collection<Relationship> getRelationships() {
+        return relationships;
     }
 }

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/relationships/Relationship.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/relationships/Relationship.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.profile.relationships;
+
+import com.scottlogic.datahelix.generator.core.profile.Profile;
+import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
+
+import java.util.List;
+
+public class Relationship {
+    private final String name;
+    private final String description;
+    private final Profile profile;
+    private final List<Constraint> extents;
+
+    public Relationship(
+        String name,
+        String description,
+        Profile profile,
+        List<Constraint> extents) {
+        this.name = name;
+        this.description = description;
+        this.profile = profile;
+        this.extents = extents;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public List<Constraint> getExtents() {
+        return extents;
+    }
+}

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeFactoryTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeFactoryTests.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.decisiontree;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.common.util.NumberUtils;
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
 import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
@@ -73,7 +74,7 @@ class DecisionTreeFactoryTests {
     private DecisionTree getActualOutput() {
         if (this.actualOutput == null) {
             Profile testInput = new Profile(
-                new Fields(
+                new ProfileFields(
                     Arrays.asList(this.fieldA, this.fieldB, this.fieldC)),
                 this.constraints,
                 Collections.emptyList());
@@ -113,7 +114,7 @@ class DecisionTreeFactoryTests {
         DecisionTree testOutput = testObject.analyse(testInput);
         Fields actualFields = testOutput.getFields();
 
-        Fields expected = new Fields(inputFieldList);
+        Fields expected = new ProfileFields(inputFieldList);
         assertThat(actualFields, sameBeanAs(expected));
     }
 

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeFactoryTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeFactoryTests.java
@@ -75,7 +75,8 @@ class DecisionTreeFactoryTests {
             Profile testInput = new Profile(
                 new Fields(
                     Arrays.asList(this.fieldA, this.fieldB, this.fieldC)),
-                this.constraints);
+                this.constraints,
+                Collections.emptyList());
 
             DecisionTreeFactory testObject = new DecisionTreeFactory();
 
@@ -91,7 +92,7 @@ class DecisionTreeFactoryTests {
 
     @Test
     void shouldReturnAnalysedProfileWithNoAnalysedRules_IfProfileHasNoRules() {
-        Profile testInput = new Profile(new ArrayList<>(), new ArrayList<>());
+        Profile testInput = new Profile(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree testOutput = testObject.analyse(testInput);
@@ -106,7 +107,7 @@ class DecisionTreeFactoryTests {
     @Test
     void shouldReturnAnalysedProfileWithCorrectFields() {
         List<Field> inputFieldList = Arrays.asList(createField("one"), createField("two"), createField("three"));
-        Profile testInput = new Profile(inputFieldList, new ArrayList<>());
+        Profile testInput = new Profile(inputFieldList, new ArrayList<>(), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree testOutput = testObject.analyse(testInput);
@@ -124,7 +125,7 @@ class DecisionTreeFactoryTests {
             new DistributedList<>(Collections.singletonList(new WeightedElement<>(10, 1.0F))));
         GreaterThanConstraint constraint1 = new GreaterThanConstraint(inputFieldList.get(0), NumberUtils.coerceToBigDecimal(0));
         MatchesRegexConstraint constraint2 = new MatchesRegexConstraint(inputFieldList.get(1), Pattern.compile("start.*end"));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(constraint0, constraint1, constraint2));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(constraint0, constraint1, constraint2), new ArrayList<>());
 
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
@@ -146,7 +147,7 @@ class DecisionTreeFactoryTests {
         GreaterThanConstraint constraint1 = new GreaterThanConstraint(inputFieldList.get(0), NumberUtils.coerceToBigDecimal(0));
         MatchesRegexConstraint constraint2 = new MatchesRegexConstraint(inputFieldList.get(1), Pattern.compile("start.*end"));
         List<Constraint> inputConstraints = Arrays.asList(constraint0, constraint1, constraint2);
-        Profile testInput = new Profile(inputFieldList, inputConstraints);
+        Profile testInput = new Profile(inputFieldList, inputConstraints, new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -168,7 +169,7 @@ class DecisionTreeFactoryTests {
         GreaterThanConstraint constraint1 = new GreaterThanConstraint(inputFieldList.get(0), NumberUtils.coerceToBigDecimal(0));
         AndConstraint andConstraint0 = new AndConstraint(Arrays.asList(constraint0, constraint1));
         MatchesRegexConstraint constraint2 = new MatchesRegexConstraint(inputFieldList.get(1), Pattern.compile("start.*end"));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(andConstraint0, constraint2));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(andConstraint0, constraint2), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -187,7 +188,7 @@ class DecisionTreeFactoryTests {
         GreaterThanConstraint constraint1 = new GreaterThanConstraint(inputFieldList.get(0), NumberUtils.coerceToBigDecimal(0));
         AndConstraint andConstraint0 = new AndConstraint(Arrays.asList(constraint0, constraint1));
         MatchesRegexConstraint constraint2 = new MatchesRegexConstraint(inputFieldList.get(1), Pattern.compile("start.*end"));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(andConstraint0, constraint2));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(andConstraint0, constraint2), new ArrayList<>());
 
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
@@ -217,7 +218,7 @@ class DecisionTreeFactoryTests {
             inputFieldList.get(1),
             new DistributedList<>(Collections.singletonList(new WeightedElement<>("diesel", 1.0F))));
         OrConstraint orConstraint1 = new OrConstraint(Arrays.asList(constraint2, constraint3));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -241,7 +242,7 @@ class DecisionTreeFactoryTests {
             inputFieldList.get(1),
             new DistributedList<>(Collections.singletonList(new WeightedElement<>("diesel", 1.0F))));
         OrConstraint orConstraint1 = new OrConstraint(Arrays.asList(constraintC, constraintD));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -265,7 +266,7 @@ class DecisionTreeFactoryTests {
             inputFieldList.get(1),
             new DistributedList<>(Collections.singletonList(new WeightedElement<>("diesel", 1.0F))));
         OrConstraint orConstraint1 = new OrConstraint(Arrays.asList(constraintC, constraintD));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -302,7 +303,7 @@ class DecisionTreeFactoryTests {
             inputFieldList.get(1),
             new DistributedList<>(Collections.singletonList(new WeightedElement<>("diesel", 1.0F))));
         OrConstraint orConstraint1 = new OrConstraint(Arrays.asList(constraintD, constraintE));
-        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1));
+        Profile testInput = new Profile(inputFieldList, Arrays.asList(orConstraint0, orConstraint1), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -331,7 +332,7 @@ class DecisionTreeFactoryTests {
         GreaterThanConstraint constraintB = new GreaterThanConstraint(inputFieldList.get(1), NumberUtils.coerceToBigDecimal(10));
         GreaterThanConstraint constraintC = new GreaterThanConstraint(inputFieldList.get(1), NumberUtils.coerceToBigDecimal(20));
         ConditionalConstraint conditionalConstraint = new ConditionalConstraint(constraintA, constraintB, constraintC);
-        Profile testInput = new Profile(inputFieldList,  Collections.singletonList(conditionalConstraint));
+        Profile testInput = new Profile(inputFieldList,  Collections.singletonList(conditionalConstraint), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -393,7 +394,7 @@ class DecisionTreeFactoryTests {
         GreaterThanConstraint constraintC = new GreaterThanConstraint(inputFieldList.get(1), NumberUtils.coerceToBigDecimal(10));
         ConditionalConstraint conditionalConstraint = new ConditionalConstraint(constraintA, constraintB, constraintC);
         Constraint notConstraint = conditionalConstraint.negate();
-        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint));
+        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -446,7 +447,7 @@ class DecisionTreeFactoryTests {
         InSetConstraint constraintA = new InSetConstraint(inputFieldList.get(0), new DistributedList<>(Collections.singletonList(new WeightedElement<>(10, 1.0F))));
         Constraint notConstraint0 = constraintA.negate();
         Constraint notConstraint1 = notConstraint0.negate();
-        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint1));
+        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint1), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);
@@ -468,7 +469,7 @@ class DecisionTreeFactoryTests {
         InSetConstraint constraintA = new InSetConstraint(inputFieldList.get(0), new DistributedList<>(Collections.singletonList(new WeightedElement<>(10, 1.0F))));
         GreaterThanConstraint constraintB = new GreaterThanConstraint(inputFieldList.get(1), NumberUtils.coerceToBigDecimal(5));
         NegatedGrammaticalConstraint notConstraint = (NegatedGrammaticalConstraint) new AndConstraint(Arrays.asList(constraintA, constraintB)).negate();
-        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint));
+        Profile testInput = new Profile(inputFieldList, Collections.singletonList(notConstraint), new ArrayList<>());
         DecisionTreeFactory testObject = new DecisionTreeFactory();
 
         DecisionTree outputRule = testObject.analyse(testInput);

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeOptimiserTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeOptimiserTest.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.decisiontree;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -53,7 +54,7 @@ class DecisionTreeOptimiserTest {
                     .where(B).isNotNull())
             .build();
 
-        ConstraintNode actual = optimiser.optimiseTree(new DecisionTree(original, new Fields(Collections.EMPTY_LIST)))
+        ConstraintNode actual = optimiser.optimiseTree(new DecisionTree(original, new ProfileFields(Collections.EMPTY_LIST)))
             .getRootNode();
 
         assertThat(actual, sameBeanAs(original));
@@ -86,7 +87,7 @@ class DecisionTreeOptimiserTest {
                     .where(A).isNotInSet("a1"))
             .build();
 
-        ConstraintNode actual = optimiser.optimiseTree(new DecisionTree(original, new Fields(Collections.EMPTY_LIST)))
+        ConstraintNode actual = optimiser.optimiseTree(new DecisionTree(original, new ProfileFields(Collections.EMPTY_LIST)))
             .getRootNode();
 
         assertThat(actual, sameBeanAs(original));

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeSimplifierTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/DecisionTreeSimplifierTests.java
@@ -16,20 +16,24 @@
 
 package com.scottlogic.datahelix.generator.core.decisiontree;
 
+import com.scottlogic.datahelix.generator.common.SetUtils;
 import com.scottlogic.datahelix.generator.common.profile.Field;
-import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
+import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
+import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
 import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.AtomicConstraint;
 import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.InSetConstraint;
 import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.IsNullConstraint;
-import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
-import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
-import com.scottlogic.datahelix.generator.common.SetUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import static com.scottlogic.datahelix.generator.common.profile.FieldBuilder.createField;
 
 class DecisionTreeSimplifierTests {
@@ -56,7 +60,7 @@ class DecisionTreeSimplifierTests {
                     )
                 )
             )).build(),
-            new Fields(
+            new ProfileFields(
                 new ArrayList<Field>() {{ add(createField("Field 1")); }}
             )
         );
@@ -83,7 +87,7 @@ class DecisionTreeSimplifierTests {
                     )
                 )
             )).build(),
-            new Fields(
+            new ProfileFields(
                 new ArrayList<Field>() {{ add(createField("Field 1")); }}
             )
         );

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
@@ -129,7 +129,7 @@ class RowSpecTreeSolverTests {
                     new DistributedList<>(Collections.singletonList(new WeightedElement<>("GBP", 1.0F)))
                 )));
 
-        Profile profile = new Profile(fields, constraints);
+        Profile profile = new Profile(fields, constraints, new ArrayList<>());
 
         final DecisionTree merged = this.dTreeGenerator.analyse(profile);
 

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
@@ -17,6 +17,7 @@
 package com.scottlogic.datahelix.generator.core.decisiontree;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.profile.Profile;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
@@ -85,7 +86,7 @@ class RowSpecTreeSolverTests {
         final Field currency = createField("currency");
         final Field city = createField("city");
 
-        Fields fields = new Fields(Arrays.asList(country, currency, city));
+        Fields fields = new ProfileFields(Arrays.asList(country, currency, city));
 
         List<Constraint> constraints = Arrays.asList(
             new ConditionalConstraint(

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/ConstraintToFieldMapperTests.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.FieldBuilder;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNodeBuilder;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionNode;
 import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.InSetConstraint;
@@ -116,7 +117,7 @@ class ConstraintToFieldMapperTests {
     void beforeEach() {
         constraintsSet = new HashSet<>();
         decisionsSet = new HashSet<>();
-        fields = new Fields(Collections.emptyList());
+        fields = new ProfileFields(Collections.emptyList());
         mappings = null;
     }
 
@@ -134,7 +135,7 @@ class ConstraintToFieldMapperTests {
     }
 
     private void givenFields(String... fieldNames) {
-        fields = new Fields(
+        fields = new ProfileFields(
             Arrays.stream(fieldNames)
                 .map(FieldBuilder::createField)
                 .collect(Collectors.toList()));

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/TreePartitionerTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/treepartitioning/TreePartitionerTests.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning;
 
 import com.scottlogic.datahelix.generator.common.profile.FieldBuilder;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.common.whitelist.DistributedList;
 import com.scottlogic.datahelix.generator.common.whitelist.WeightedElement;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
@@ -289,7 +290,7 @@ class TreePartitionerTests {
     }
 
     private Fields fields(String... fieldNames) {
-        return new Fields(
+        return new ProfileFields(
             Stream.of(fieldNames)
                 .map(FieldBuilder::createField)
                 .collect(Collectors.toList()));

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/RowSpecMergerTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/fieldspecs/RowSpecMergerTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.common.profile.FieldType;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ class RowSpecMergerTest {
     FieldSpec notNull = FieldSpecFactory.fromType(FieldType.STRING).withNotNull();
     Field A = createField("A");
     Field B = createField("B");
-    Fields fields = new Fields(Arrays.asList(A, B));
+    Fields fields = new ProfileFields(Arrays.asList(A, B));
 
     @Test
     void merge_notContradictoryForField() {

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
@@ -24,7 +24,7 @@ import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTreeOptimise
 import com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.datahelix.generator.core.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.datahelix.generator.core.generation.databags.DataBag;
-import com.scottlogic.datahelix.generator.core.generation.relationships.RelationshipsProcessor;
+import com.scottlogic.datahelix.generator.core.generation.relationships.RelationshipsDataGenerator;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.Visualiser;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.VisualiserFactory;
 import com.scottlogic.datahelix.generator.core.profile.Profile;
@@ -69,7 +69,7 @@ class DecisionTreeDataGeneratorTests {
             combinationStrategy,
             upfrontTreePruner,
             visualiserFactory,
-            Mockito.mock(RelationshipsProcessor.class)
+            Mockito.mock(RelationshipsDataGenerator.class)
         );
     }
 

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/DecisionTreeDataGeneratorTests.java
@@ -17,7 +17,6 @@
 package com.scottlogic.datahelix.generator.core.generation;
 
 import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
-import com.scottlogic.datahelix.generator.core.profile.Profile;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTree;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTreeFactory;
@@ -25,15 +24,16 @@ import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTreeOptimise
 import com.scottlogic.datahelix.generator.core.decisiontree.treepartitioning.TreePartitioner;
 import com.scottlogic.datahelix.generator.core.generation.combinationstrategies.CombinationStrategy;
 import com.scottlogic.datahelix.generator.core.generation.databags.DataBag;
+import com.scottlogic.datahelix.generator.core.generation.relationships.RelationshipsProcessor;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.Visualiser;
 import com.scottlogic.datahelix.generator.core.generation.visualiser.VisualiserFactory;
+import com.scottlogic.datahelix.generator.core.profile.Profile;
 import com.scottlogic.datahelix.generator.core.walker.DecisionTreeWalker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,32 +46,30 @@ import static org.mockito.Mockito.verify;
 class DecisionTreeDataGeneratorTests {
     private DecisionTreeDataGenerator generator;
     private DecisionTreeFactory factory;
-    private DataGeneratorMonitor monitor;
     private TreePartitioner treePartitioner;
     private CombinationStrategy combinationStrategy;
     private DecisionTreeOptimiser optimiser;
-    private DecisionTreeWalker treeWalker;
     private UpfrontTreePruner upfrontTreePruner;
     private VisualiserFactory visualiserFactory;
+
     @BeforeEach
     void setup() {
         factory = Mockito.mock(DecisionTreeFactory.class);
-        treeWalker = Mockito.mock(DecisionTreeWalker.class);
         treePartitioner = Mockito.mock(TreePartitioner.class);
         optimiser = Mockito.mock(DecisionTreeOptimiser.class);
-        monitor = Mockito.mock(DataGeneratorMonitor.class);
         combinationStrategy = Mockito.mock(CombinationStrategy.class);
         upfrontTreePruner = Mockito.mock(UpfrontTreePruner.class);
         visualiserFactory = Mockito.mock(VisualiserFactory.class);
         generator = new DecisionTreeDataGenerator(
             factory,
-            treeWalker,
+            Mockito.mock(DecisionTreeWalker.class),
             treePartitioner,
             optimiser,
-            monitor,
+            Mockito.mock(DataGeneratorMonitor.class),
             combinationStrategy,
             upfrontTreePruner,
-            visualiserFactory
+            visualiserFactory,
+            Mockito.mock(RelationshipsProcessor.class)
         );
     }
 
@@ -82,7 +80,7 @@ class DecisionTreeDataGeneratorTests {
         private Profile profile;
         private Visualiser visualiser;
         @BeforeEach
-        void setup() throws IOException {
+        void setup() {
             tree = Mockito.mock(DecisionTree.class);
             rootNode = Mockito.mock(ConstraintNode.class);
             profile = Mockito.mock(Profile.class);

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/UpfrontTreePrunerTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/UpfrontTreePrunerTests.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.generation;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.builders.TestConstraintNodeBuilder;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNodeBuilder;
@@ -63,10 +64,10 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
             DecisionTree treeMarkedWithContradictions = new DecisionTree(
                 new ConstraintNodeBuilder().build().builder().markNode(NodeMarking.CONTRADICTORY).build(),
-                new Fields(fields));
+                new ProfileFields(fields));
 
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.of(prunedRoot));
             Mockito.when(contradictionValidator.markContradictions(tree)).thenReturn(treeMarkedWithContradictions);
@@ -88,11 +89,11 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldB, FieldSpecFactory.fromType(fieldB.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
 
             DecisionTree treeMarkedWithContradictions = new DecisionTree(
                 new ConstraintNodeBuilder().build().builder().markNode(NodeMarking.CONTRADICTORY).build(),
-                new Fields(fields));
+                new ProfileFields(fields));
 
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.of(prunedRoot));
             Mockito.when(contradictionValidator.markContradictions(tree)).thenReturn(treeMarkedWithContradictions);
@@ -112,7 +113,7 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
 
             //Act
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.contradictory());
@@ -131,10 +132,10 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
             DecisionTree completelyUnmarkedTree = new DecisionTree(
                 new ConstraintNodeBuilder().build(),
-                new Fields(fields));
+                new ProfileFields(fields));
 
             //Act
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.of(unPrunedRoot));
@@ -154,13 +155,13 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
             ConstraintNode root = constraintNode()
                 .withDecision(
                     constraintNode().markNode(NodeMarking.CONTRADICTORY)).build();
             DecisionTree treeMarkedWithContradictions = new DecisionTree(
                 root,
-                new Fields(fields));
+                new ProfileFields(fields));
 
             //Act
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.of(root));
@@ -182,10 +183,10 @@ class UpfrontTreePrunerTests {
             fieldSpecs.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
 
             ConstraintNode unPrunedRoot = Mockito.mock(ConstraintNode.class);
-            DecisionTree tree = new DecisionTree(unPrunedRoot, new Fields(fields));
+            DecisionTree tree = new DecisionTree(unPrunedRoot, new ProfileFields(fields));
             DecisionTree treeMarkedWithContradictions = new DecisionTree(
                 new ConstraintNodeBuilder().build().builder().markNode(NodeMarking.CONTRADICTORY).build(),
-                new Fields(fields));
+                new ProfileFields(fields));
 
             //Act
             Mockito.when(treePruner.pruneConstraintNode(unPrunedRoot, fieldSpecs)).thenReturn(Merged.contradictory());
@@ -228,7 +229,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -252,7 +253,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -285,7 +286,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -322,7 +323,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -348,7 +349,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -373,7 +374,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -404,7 +405,7 @@ class UpfrontTreePrunerTests {
                                 .where(fieldB).isNull()))
                 .build();
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -441,7 +442,7 @@ class UpfrontTreePrunerTests {
                                 .where(fieldB).isNull()))
                 .build();
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -480,7 +481,7 @@ class UpfrontTreePrunerTests {
                 )
                 .build();
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -503,7 +504,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -531,7 +532,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -561,7 +562,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -592,7 +593,7 @@ class UpfrontTreePrunerTests {
                                         .where(fieldA).isNotNull())))
                 .build();
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -622,7 +623,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);
@@ -652,7 +653,7 @@ class UpfrontTreePrunerTests {
                 .build();
 
 
-            DecisionTree tree = new DecisionTree(root, new Fields(fields));
+            DecisionTree tree = new DecisionTree(root, new ProfileFields(fields));
 
             //Act
             upfrontPruner.runUpfrontPrune(tree, monitor);

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/databags/RowSpecDataBagGeneratorTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/databags/RowSpecDataBagGeneratorTests.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.core.generation.databags;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.builders.DataBagBuilder;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpec;
 import com.scottlogic.datahelix.generator.core.fieldspecs.RowSpec;
@@ -43,7 +44,7 @@ class RowSpecDataBagGeneratorTests {
     private Field field = createField("Field1");
     Field field2 = createField("field2");
     Field field3 = createField("field3");
-    private Fields fields = new Fields(Collections.singletonList(field));
+    private Fields fields = new ProfileFields(Collections.singletonList(field));
     private FieldSpec fieldSpec = mock(FieldSpec.class);
     private FieldSpec fieldSpec2 = mock(FieldSpec.class);
     private FieldSpec fieldSpec3 = mock(FieldSpec.class);
@@ -80,7 +81,7 @@ class RowSpecDataBagGeneratorTests {
             put(field2, fieldSpec2);
             put(field3, fieldSpec3); }};
         RowSpec rowSpec = new RowSpec(
-            new Fields(Arrays.asList(field2, field, field3)),
+            new ProfileFields(Arrays.asList(field2, field, field3)),
             map,
             Collections.emptyList());
 

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/grouped/RowSpecGrouperTest.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/grouped/RowSpecGrouperTest.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.core.generation.grouped;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpec;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpecFactory;
 import com.scottlogic.datahelix.generator.core.fieldspecs.FieldSpecGroup;
@@ -40,7 +41,7 @@ class RowSpecGrouperTest {
     void createGroups_withTwoRelatedFields_givesOneGroupOfSizeOne() {
         Field first = createField("first");
         Field second = createField("second");
-        Fields fields = new Fields(Arrays.asList(first, second));
+        Fields fields = new ProfileFields(Arrays.asList(first, second));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second);
 
@@ -59,7 +60,7 @@ class RowSpecGrouperTest {
         Field first = createField("first");
         Field second = createField("second");
         Field third = createField("third");
-        Fields fields = new Fields(Arrays.asList(first, second, third));
+        Fields fields = new ProfileFields(Arrays.asList(first, second, third));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second, third);
 
@@ -78,7 +79,7 @@ class RowSpecGrouperTest {
         Field first = createField("first");
         Field second = createField("second");
         Field third = createField("third");
-        Fields fields = new Fields(Arrays.asList(first, second, third));
+        Fields fields = new ProfileFields(Arrays.asList(first, second, third));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second, third);
 
@@ -96,7 +97,7 @@ class RowSpecGrouperTest {
         Field first = createField("first");
         Field second = createField("second");
         Field third = createField("third");
-        Fields fields = new Fields(Arrays.asList(first, second, third));
+        Fields fields = new ProfileFields(Arrays.asList(first, second, third));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second, third);
 
@@ -114,7 +115,7 @@ class RowSpecGrouperTest {
         Field first = createField("first");
         Field second = createField("second");
         Field third = createField("third");
-        Fields fields = new Fields(Arrays.asList(first, second, third));
+        Fields fields = new ProfileFields(Arrays.asList(first, second, third));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second, third);
 
@@ -138,7 +139,7 @@ class RowSpecGrouperTest {
         Field fourth = createField("fourth");
         Field fifth = createField("fifth");
 
-        Fields fields = new Fields(Arrays.asList(first, second, third, fourth, fifth));
+        Fields fields = new ProfileFields(Arrays.asList(first, second, third, fourth, fifth));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second, third, fourth, fifth);
 
@@ -159,7 +160,7 @@ class RowSpecGrouperTest {
         Field first = createField("first");
         Field second = createField("second");
 
-        Fields fields = new Fields(Arrays.asList(first, second));
+        Fields fields = new ProfileFields(Arrays.asList(first, second));
 
         Map<Field, FieldSpec> fieldSpecMap = fieldSpecMapOf(first, second);
 

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRangeTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/generation/relationships/OneToManyRangeTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.core.generation.relationships;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class OneToManyRangeTests {
+    @Test
+    public void isEmpty_whenMinAndMaxAreEqual_returnsFalse(){
+        OneToManyRange range = new OneToManyRange(1, 1);
+
+        assertThat(range.isEmpty(), is(false));
+    }
+
+    @Test
+    public void isEmpty_whenMinIsGreaterThanMax_returnsTrue(){
+        OneToManyRange range = new OneToManyRange(2, 1);
+
+        assertThat(range.isEmpty(), is(true));
+    }
+
+    @Test
+    public void isEmpty_whenMaxIsNull_returnsFalse(){
+        OneToManyRange range = new OneToManyRange(1, null);
+
+        assertThat(range.isEmpty(), is(false));
+    }
+
+    @Test
+    public void isEmpty_whenMinAndMaxAre0_returnsTrue(){
+        OneToManyRange range = new OneToManyRange(0, 0);
+
+        assertThat(range.isEmpty(), is(true));
+    }
+
+    @Test
+    public void withMin_whereValueIsLessThanExistingMin_doesNotRetrictFurther() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMin(1);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(3));
+    }
+
+    @Test
+    public void withMin_whereValueIsEqualToExistingMin_doesNotRetrictFurther() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMin(2);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(3));
+    }
+
+    @Test
+    public void withMin_whereValueIsGreaterThanExistingMin_restrictsRangeToNewValue() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMin(3);
+
+        assertThat(newRange.getMin(), is(3));
+        assertThat(newRange.getMax(), is(3));
+    }
+
+    @Test
+    public void withMin_whereValueIsGreaterThanExistingMax_restrictsRangeToEmptyRange() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMin(4);
+
+        assertThat(newRange.getMin(), is(4));
+        assertThat(newRange.getMax(), is(3));
+        assertThat(newRange.isEmpty(), is(true));
+    }
+
+    @Test
+    public void withMax_whereValueIsGreaterThanExistingMax_doesNotRetrictFurther() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMax(4);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(3));
+    }
+
+    @Test
+    public void withMax_whereValueIsEqualToExistingMax_doesNotRetrictFurther() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMax(3);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(3));
+    }
+
+    @Test
+    public void withMax_whereValueIsLessThanExistingMax_restrictsRangeToNewValue() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMax(2);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(2));
+    }
+
+    @Test
+    public void withMax_whereValueIsLessThanExistingMin_restrictsRangeEmptyRange() {
+        OneToManyRange range = new OneToManyRange(2, 3);
+
+        OneToManyRange newRange = range.withMax(1);
+
+        assertThat(newRange.getMin(), is(2));
+        assertThat(newRange.getMax(), is(1));
+        assertThat(newRange.isEmpty(), is(true));
+    }
+}

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/walker/decisionbased/RowSpecTreeSolverTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/walker/decisionbased/RowSpecTreeSolverTests.java
@@ -17,6 +17,7 @@ package com.scottlogic.datahelix.generator.core.walker.decisionbased;
 
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.builders.TestConstraintNodeBuilder;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTree;
@@ -37,7 +38,7 @@ import static com.scottlogic.datahelix.generator.common.profile.FieldBuilder.cre
 class RowSpecTreeSolverTests {
     private Field fieldA = createField("A");
     private Field fieldB = createField("B");
-    private Fields fields = new Fields(Arrays.asList(fieldA, fieldB));
+    private Fields fields = new ProfileFields(Arrays.asList(fieldA, fieldB));
     private FieldSpecMerger fieldSpecMerger = new FieldSpecMerger();
     private ConstraintReducer constraintReducer = new ConstraintReducer(fieldSpecMerger);
     private TreePruner pruner = new TreePruner(fieldSpecMerger, constraintReducer, new FieldSpecHelper());

--- a/docs/RelationalData.md
+++ b/docs/RelationalData.md
@@ -1,0 +1,170 @@
+## Beta Feature - Relational data
+
+**Relational data** can only be produced when the output format is JSON. Output to console (streaming) and output to file are both supported. An attempt to produce CSV data where there is a relationship will result in an error. Profiles without relationships can still produce CSV data.
+
+This feature introduces the following **additional functionality**. The changes are fully backward compatible. A new property can be added to the profile called `relationships`, this is a collection of 'relationship descriptions'.
+
+For example
+
+```
+{
+    "fields": [ ... ],
+    "constraints": [ ... ],
+    "relationships": [
+        ...
+    ]
+}
+```
+
+A relationship represents additional data that should be included in the output data as a sub-object (one-to-one) or sub-array (one-to-many). Each relationship is considered to be one-to-one, unless extents (the number of sub-objects to produce) are included.
+
+## Relationship description
+There can be any number of relationships within each profile. Sub profiles can also contain relationships.
+
+A relationship description can have the following properties
+
+| property | type | requirement | description |
+| ---- | ---- | ---- | ---- |
+| `name` | string | required | The name of the relationship, this is the name of the property in which the related data will be embedded |
+| `description` | string | optional | A description for the relationship, this is for documentation only - it has no bearing on the generation process | 
+| `profileFile` | string | optional* | A relative path to a profile file, that describes the data that should be generated within this relationship |
+| `profile` | object | optional* | that describes the data that should be generated within this relationship |
+| `extents` | array of `extents` | optional | the min and max number of records within a one-to-many relationship, if absent will be treated as a one-to-one relationship |
+
+For example:
+```
+{
+  ...
+  "relationships": [ 
+    {
+      "name": "name",
+      "profileFile": "profile-filename",
+      "extents": [
+          { "field": "min", "equalTo": 1 },
+          { "field": "max", "equalTo": 3 }
+      ],
+    }
+  ]
+}
+```
+
+\* One of `profile` or `profileFile` must be supplied, `profile` takes precedence over `profileFile`.
+
+**NOTE**: If `profileFile` is used, it is possible to create a circular/recursive 'dependency' on profiles. No current strategy has been implemented to prevent/detect this, however it should be simple to integrate.
+
+An `extent` is a description of the limit on the number of rows that must be produced, it is described as a regular - numeric - constraint, but for a virtual field called `min` or `max`, as in the example above. Any constraint that results in a integer value can be used.
+
+**If any extents are supplied** then a constraint for the `max` extent must be supplied. The `min` extent is 0 by default, but can be overridden with any &gt;= 0 value. Conditional constraints are supported.
+
+For one-to-many relationships a random number of records will be produced between `min` and `max`. Other strategies can be introduced in the fullness of time, this is the only approach at present.
+
+## Example profile:
+
+```
+{
+  "fields": [
+    {
+      "name": "shortName",
+      "type": "faker.name.firstName",
+      "nullable": false
+    }
+  ],
+  "constraints": [
+    {
+      "field": "shortName",
+      "shorterThan": 6
+    },
+    {
+      "field": "shortName",
+      "matchingRegex": "J.*"
+    }
+  ],
+  "relationships": 
+  [ 
+    {
+        "name": "dependants",
+        "description": "presence of min/max indicates that it is a collection (one-to-many)",
+        "profileFile": "dependants.profile.json",
+        "extents": [
+            { "field": "min", "equalTo": 0 },
+            {
+              "if": { "field": "shortName", "matchingRegex": "J[ae].*" },
+              "then": { "field": "min", "equalTo": 2 },
+              "else": { "field": "max", "equalTo": 3 }
+            },
+            { "field": "max", "equalTo": 3 },
+            {
+              "if": { "field": "shortName", "matchingRegex": "J[iou].*" },
+              "then": { "field": "max", "equalTo": 1 }
+            }
+        ]
+    },
+    {
+        "name": "mother",
+        "description": "absence of min/max indicates that it is a sub-object (one-to-one)",
+        "profile": {
+            "fields": [
+              {
+                "name": "name",
+                "type": "faker.name.firstName",
+                "nullable": false
+              },
+              {
+                "name": "age",
+                "type": "integer",
+                "nullable": false
+              }
+            ],
+            "constraints": [
+              {
+                "field": "age",
+                "greaterThanOrEqualTo": 16
+              },
+              {
+                "field": "age",
+                "lessThanOrEqualTo": 100
+              }
+            ]
+        }
+    }
+  ]
+}
+```
+
+This will produce data that looks like below:
+
+```
+{"mother":{"age":52,"name":"Vivien"},"shortName":"Jeri","dependants":[{"age":9,"name":"Ferne"},{"age":4,"name":"Eleonor"},{"age":8,"name":"Virgilio"}]}
+{"mother":{"age":61,"name":"Dante"},"shortName":"James","dependants":[{"age":0,"name":"Elli"},{"age":2,"name":"Jewel"}]}
+{"mother":{"age":24,"name":"Lana"},"shortName":"Jame","dependants":[{"age":3,"name":"Long"},{"age":9,"name":"Vergie"}]}
+{"mother":{"age":67,"name":"Angelica"},"shortName":"Jan","dependants":[{"age":14,"name":"Wyatt"},{"age":3,"name":"Charline"}]}
+{"mother":{"age":17,"name":"Hal"},"shortName":"Jamel","dependants":[{"age":5,"name":"Aurora"},{"age":3,"name":"Elisa"}]}
+{"mother":{"age":38,"name":"Connie"},"shortName":"John","dependants":[{"age":14,"name":"Antonio"}]}
+{"mother":{"age":88,"name":"Shae"},"shortName":"Jamey","dependants":[{"age":12,"name":"Enola"},{"age":6,"name":"Dania"}]}
+{"mother":{"age":50,"name":"Aja"},"shortName":"Jodi","dependants":[]}
+{"mother":{"age":24,"name":"Sherley"},"shortName":"James","dependants":[{"age":13,"name":"Thanh"},{"age":14,"name":"Stacey"},{"age":16,"name":"Dewayne"}]}
+{"mother":{"age":66,"name":"Rosetta"},"shortName":"Joana","dependants":[]}
+```
+
+Note that data within `mother` is:
+- A sub-object - because no `extents` were provided in the relationship
+- Is embedded within the property `mother` as that is the `name` of the relationship
+
+Note that data within `dependants` is:
+- A sub-array - because there are `extents` provided in the relationship
+- Is embedded within the property `dependants` as that is the `name` of the relationship
+- Sometimes an empty array, as the minimum extent is 0
+- Various sizes - the number of records to produce is a random number between `min` and `max` at generation time.
+
+### What it can do
+- Represent sub-objects (one-to-one)
+- Represent sub-arrays (one-to-many)
+- Represent n-levels of sub-objects and sub-arrays
+
+### What it cannot do (yet)
+- Constrain objects in one relationship by values in another, i.e.
+  - if `children` sub-objects have some `age`s &gt; 18 then `placesLived` must contain a `number-of-rooms` &gt;= 3 
+- Constrain the parent object by values in a relationship, i.e.
+  - if `children` sub-objects have all `age`s &gt; 18 then `councilTaxRateBand` = `A`
+- Constrain circular relationships to a maximum depth, i.e.
+  - Generate a tree of ancestors (or conversely children) from a given person (aka genealogical data)

--- a/docs/RelationalData.md
+++ b/docs/RelationalData.md
@@ -28,8 +28,8 @@ A relationship description can have the following properties
 | `name` | string | required | The name of the relationship, this is the name of the property in which the related data will be embedded |
 | `description` | string | optional | A description for the relationship, this is for documentation only - it has no bearing on the generation process | 
 | `profileFile` | string | optional* | A relative path to a profile file, that describes the data that should be generated within this relationship |
-| `profile` | object | optional* | that describes the data that should be generated within this relationship |
-| `extents` | array of `extents` | optional | the min and max number of records within a one-to-many relationship, if absent will be treated as a one-to-one relationship |
+| `profile` | object | optional* | A profile that describes the data that should be generated within this relationship |
+| `extents` | array of `extent` | optional | The _min_ and _max_ number of records within a one-to-many relationship, if absent will be treated as a one-to-one relationship |
 
 For example:
 ```
@@ -168,3 +168,30 @@ Note that data within `dependants` is:
   - if `children` sub-objects have all `age`s &gt; 18 then `councilTaxRateBand` = `A`
 - Constrain circular relationships to a maximum depth, i.e.
   - Generate a tree of ancestors (or conversely children) from a given person (aka genealogical data)
+
+## How to use the feature
+To be able to use the feature, you first need to work out how to build the profile. The generator needs a place to start producing data, this will depend on your relationships. Consider the following scenarios:
+
+### 1. One-to-many (Customers and their orders)
+Two entities related with a simple foreign-key relationship, i.e.
+
+- A customer entity with customer details
+- An order entity with order details and the id of the customer
+
+Create a profile that represents the customer initially, then embed the profile for the orders entity as a one-to-many relationship within this. You'll then get a collection of orders for each customer. A process of repeating each order (and grebbing the parent customer-id) will permit a collection of orders that can be injected into a database.
+
+### 2. Many-to-many (Parts and their orders)
+Two entities, orders and parts (ignoring customer for simplicity), i.e.
+
+- An order entity which represents an order with some related parts
+- A part entity which represents a purchasable item in a catalogue (ignoring stock quantity)
+
+Each order can have many parts and each part can be on many orders. Therefore, naturally, in a relational database there would be a Cross-reference table that contains the keys of the order and part in a row.
+
+To be able to use this feature to produce the data you need, you need to start at the Cross-Reference table, as this is the only unique 'entity' in this model. Therefore your profile would be constructed as follows:
+
+- Cross-Reference: an empty object (unless you want any additional data, e.g. requested-quantity), except for it's two one-to-many relationships
+  - Part: one-to-many collection of parts
+  - Order: one-to-many collection of orders
+
+From the output data you can derive all the orders that exist, all the parts that exist. Equally it is possible to dervive the orders that contain a part and conversely the parts that are contained in an order.

--- a/examples/relational/dependants.profile.json
+++ b/examples/relational/dependants.profile.json
@@ -1,0 +1,10 @@
+{
+  "fields": [
+    { "name": "name", "type": "faker.name.firstName", "nullable": false },
+    { "name": "age", "type": "integer", "nullable": false }
+  ],
+  "constraints": [
+    { "field": "age", "greaterThanOrEqualTo": 0 },
+    { "field": "age", "lessThan": 18 }
+  ]
+}

--- a/examples/relational/profile.json
+++ b/examples/relational/profile.json
@@ -1,0 +1,47 @@
+{
+  "fields": [
+	{ "name": "id", "type": "integer", "nullable": false, "unique": true },
+    { "name": "shortName", "type": "faker.name.firstName", "nullable": false }
+  ],
+  "constraints": [
+	{ "field": "id", "greaterThanOrEqualTo": 1 },
+	{ "field": "id", "lessThanOrEqualTo": 100 },
+    { "field": "shortName", "shorterThan": 6 },
+    { "field": "shortName", "matchingRegex": "J.*" }
+  ],
+  "relationships": 
+  [ 
+    {
+      "name": "dependants",
+      "description": "presence of min/max indicates that it is a collection (one-to-many)",
+      "profileFile": "dependants.profile.json",
+      "extents": [
+        { "field": "min", "equalTo": 0 },
+        {
+          "if": { "field": "shortName", "matchingRegex": "J[ae].*" },
+          "then": { "field": "min", "equalTo": 2 },
+          "else": { "field": "max", "equalTo": 3 }
+        },
+        { "field": "max", "equalTo": 3 },
+        {
+          "if": { "field": "shortName", "matchingRegex": "J[iou].*" },
+          "then": { "field": "max", "equalTo": 1 }
+        }
+      ]
+    },
+    {
+      "name": "mother",
+      "description": "absence of min/max indicates that it is a sub-object (one-to-one)",
+      "profile": {
+        "fields": [
+          { "name": "name", "type": "faker.name.firstName", "nullable": false },
+          { "name": "age", "type": "integer", "nullable": false }
+        ],
+        "constraints": [
+          { "field": "age", "greaterThanOrEqualTo": 16 },
+          { "field": "age", "lessThanOrEqualTo": 100 }
+        ]
+      }
+    }
+  ]
+}

--- a/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
+++ b/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
-import static com.scottlogic.datahelix.generator.common.util.Defaults.DEFAULT_MAX_ROWS;
 import static com.scottlogic.datahelix.generator.core.config.detail.CombinationStrategyType.MINIMAL;
 import static com.scottlogic.datahelix.generator.core.config.detail.DataGenerationType.RANDOM;
 import static com.scottlogic.datahelix.generator.common.output.OutputFormat.CSV;
@@ -116,7 +115,13 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
     @CommandLine.Option(
         names = {"-n", "--max-rows"},
         description = "Defines the maximum number of rows that should be generated")
-    private long maxRows = DEFAULT_MAX_ROWS;
+    private Long maxRows = null;
+
+    @SuppressWarnings("FieldCanBeLocal")
+    @CommandLine.Option(
+        names = {"--infinite"},
+        description = "Permits infinite generation of data")
+    private boolean infiniteGeneration = false;
 
     @SuppressWarnings("FieldCanBeLocal")
     @CommandLine.Option(
@@ -194,8 +199,13 @@ public class GenerateCommandLine implements AllConfigSource, Callable<Integer> {
     }
 
     @Override
-    public long getMaxRows() {
+    public Long getMaxRows() {
         return maxRows;
+    }
+
+    @Override
+    public boolean getInfiniteOutput() {
+        return infiniteGeneration;
     }
 
     public OutputFormat getOutputFormat() {

--- a/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
+++ b/orchestrator/src/main/java/com/scottlogic/datahelix/generator/orchestrator/generate/GenerateCommandLine.java
@@ -26,7 +26,7 @@ import com.scottlogic.datahelix.generator.core.config.detail.VisualiserLevel;
 import com.scottlogic.datahelix.generator.orchestrator.CommonOptionInfo;
 import com.scottlogic.datahelix.generator.orchestrator.guice.AllConfigSource;
 import com.scottlogic.datahelix.generator.orchestrator.guice.AllModule;
-import com.scottlogic.datahelix.generator.output.guice.OutputFormat;
+import com.scottlogic.datahelix.generator.common.output.OutputFormat;
 import com.scottlogic.datahelix.generator.profile.ProfileConfiguration;
 import picocli.CommandLine;
 
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable;
 import static com.scottlogic.datahelix.generator.common.util.Defaults.DEFAULT_MAX_ROWS;
 import static com.scottlogic.datahelix.generator.core.config.detail.CombinationStrategyType.MINIMAL;
 import static com.scottlogic.datahelix.generator.core.config.detail.DataGenerationType.RANDOM;
-import static com.scottlogic.datahelix.generator.output.guice.OutputFormat.CSV;
+import static com.scottlogic.datahelix.generator.common.output.OutputFormat.CSV;
 
 /**
  * This class holds the generate specific command line options.

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -82,7 +82,7 @@ public class CucumberGenerationConfigSource implements AllConfigSource {
 
     @Override
     public OutputFormat getOutputFormat() {
-        return null;
+        return OutputFormat.JSON;
     }
 
     @Override

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -22,7 +22,7 @@ import com.scottlogic.datahelix.generator.core.config.detail.DataGenerationType;
 import com.scottlogic.datahelix.generator.core.config.detail.MonitorType;
 import com.scottlogic.datahelix.generator.core.config.detail.VisualiserLevel;
 import com.scottlogic.datahelix.generator.orchestrator.guice.AllConfigSource;
-import com.scottlogic.datahelix.generator.output.guice.OutputFormat;
+import com.scottlogic.datahelix.generator.common.output.OutputFormat;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -51,8 +51,13 @@ public class CucumberGenerationConfigSource implements AllConfigSource {
     }
 
     @Override
-    public long getMaxRows() {
+    public Long getMaxRows() {
         return state.maxRows;
+    }
+
+    @Override
+    public boolean getInfiniteOutput() {
+        return false;
     }
 
     @Override

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberTestState.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/cucumber/testframework/utils/CucumberTestState.java
@@ -45,7 +45,7 @@ import com.scottlogic.datahelix.generator.profile.dtos.constraints.grammatical.A
 import com.scottlogic.datahelix.generator.profile.dtos.constraints.grammatical.ConditionalConstraintDTO;
 import com.scottlogic.datahelix.generator.profile.dtos.constraints.grammatical.NotConstraintDTO;
 import com.scottlogic.datahelix.generator.profile.dtos.constraints.relations.*;
-import com.scottlogic.datahelix.generator.profile.serialisation.ConstraintDeserializer;
+import com.scottlogic.datahelix.generator.profile.serialisation.ConstraintDeserializerFactory;
 import com.scottlogic.datahelix.generator.profile.serialisation.ConstraintDeserializerFactory;
 
 import java.io.IOException;

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/endtoend/JarExecuteTests.java
@@ -18,13 +18,17 @@ package com.scottlogic.datahelix.generator.orchestrator.endtoend;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JarExecuteTests {
     @Test
@@ -33,7 +37,7 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertOnOutputs(collectedOutput, "Generation successful", "");
+        assertCsvOutputs(collectedOutput, "Generation successful", "");
     }
 
     @Test
@@ -42,7 +46,7 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertOnOutputs(collectedOutput,
+        assertCsvOutputs(collectedOutput,
             "Generated successfully from file",
             "Either load from file no longer works, or ");
     }
@@ -53,31 +57,73 @@ public class JarExecuteTests {
 
         List<String> collectedOutput = collectOutputAndCloseProcess(p);
 
-        assertOnOutputs(collectedOutput,
+        assertCsvOutputs(collectedOutput,
             "Generated successfully from file",
             "Either load from file no longer works, or ");
     }
 
-    private void assertOnOutputs(List<String> outputs, String expectedFinalMessage, String extraErrorMessage) {
+    @Test
+    void generateRelationalDataSuccessfullyFromJar() throws Exception {
+        Process p = setupProcess("-p=src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile.json", "JSON");
+
+        List<String> collectedOutput = collectOutputAndCloseProcess(p);
+
+        assertJsonOutputs(collectedOutput,
+            "shortName",
+            null);
+    }
+
+    @Test
+    void generateRelationalDataSuccessfullyFromJarAndLoadFileWithinSubDirectory() throws Exception {
+        Process p = setupProcess("-p=src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile-referenced-relationship.json", "JSON");
+
+        List<String> collectedOutput = collectOutputAndCloseProcess(p);
+
+        assertJsonOutputs(collectedOutput,
+            "age",
+            "\"Generated successfully from file\"");
+    }
+
+    private void assertCsvOutputs(List<String> outputs, String expectedFinalMessage, String extraErrorMessage) {
         String errorMessageOnFailure = "Jar test failed. This may have been caused by one of the following:" +
             "1) You have not built the jar. \n Try running Gradle Build. \n" +
             "2) System.out is being printed to (which interferes with streaming output) e.g. using 'printStackTrace'.\n" +
             "3) There is a bug in code conditional on whether it is running inside the JAR, e.g. in SupportedVersionsGetter. \n" +
             outputs.stream().limit(5).collect(Collectors.joining("\n"));
         String fullErrorMessage = extraErrorMessage + errorMessageOnFailure;
-        assertTrue(outputs.size() >= 2, fullErrorMessage);
+        assertThat(fullErrorMessage, outputs.size(), is(greaterThanOrEqualTo(2)));
         assertEquals("foo", outputs.get(outputs.size() - 2), fullErrorMessage);
         assertEquals(expectedFinalMessage, outputs.get(outputs.size() - 1), fullErrorMessage);
     }
 
+    private void assertJsonOutputs(List<String> outputs, String expectedJsonPropertyName, String expectedData) {
+        String errorMessageOnFailure = "Jar test failed. This may have been caused by one of the following:" +
+            "1) You have not built the jar. \n Try running Gradle Build. \n" +
+            "2) System.out is being printed to (which interferes with streaming output) e.g. using 'printStackTrace'.\n" +
+            "3) There is a bug in code conditional on whether it is running inside the JAR, e.g. in SupportedVersionsGetter. \n" +
+            outputs.stream().limit(5).collect(Collectors.joining("\n"));
+        assertThat(errorMessageOnFailure, outputs.size(), is(greaterThanOrEqualTo(1)));
+        assertThat(errorMessageOnFailure, outputs.get(outputs.size() - 1), containsString("\"" + expectedJsonPropertyName + "\":"));
+        if (expectedData != null){
+            assertThat(errorMessageOnFailure, outputs.get(outputs.size() - 1), containsString(":" + expectedData));
+        }
+    }
+
     private Process setupProcess(final String profile) throws IOException {
+        return setupProcess(profile, null);
+    }
+
+    private Process setupProcess(final String profile, final String outputFormat) throws IOException {
         ProcessBuilder pb = new ProcessBuilder(
             "java",
             "-jar",
             "build/libs/datahelix.jar",
             profile,
             "--max-rows=1",
-            "--quiet");
+            "--quiet",
+            outputFormat == null
+                ? ""
+                : "--output-format=" + outputFormat);
         pb.redirectErrorStream(true);
         return pb.start();
     }

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/endtoend/JarExecuteTests.java
@@ -138,10 +138,11 @@ public class JarExecuteTests {
             "build/libs/datahelix.jar",
             profile,
             "--max-rows=1",
-            "--quiet",
-            outputFormat == null
-                ? ""
-                : "--output-format=" + outputFormat);
+            "--quiet");
+
+        if (outputFormat != null) {
+            pb.command().add("--output-format=" + outputFormat);
+        }
 
         pb.redirectErrorStream(true);
         Process process = pb.start();

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile-referenced-relationship.json
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile-referenced-relationship.json
@@ -1,0 +1,36 @@
+{
+  "fields": [
+    {
+      "name": "shortName",
+      "type": "faker.name.firstName",
+      "nullable": false
+    }
+  ],
+  "constraints": [
+    {
+      "field": "shortName",
+      "shorterThan": 6
+    },
+    {
+      "field": "shortName",
+      "matchingRegex": "J.*"
+    }
+  ],
+  "relationships": [ {
+    "name": "dependants",
+    "description": "presence of min/max indicates that it is a collection (one-to-many)",
+    "extents": [
+        { "field": "min", "equalTo": 1 },
+        {
+          "if": { "field": "shortName", "matchingRegex": "J[ae].*" },
+          "then": { "field": "min", "equalTo": 2 }
+        },
+        { "field": "max", "equalTo": 3 },
+        {
+          "if": { "field": "shortName", "matchingRegex": "J[iou].*" },
+          "then": { "field": "max", "equalTo": 1 }
+        }
+    ],
+    "profileFile": "subfolder/dependants.profile.json"
+   } ]
+}

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile.json
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/profile.json
@@ -1,0 +1,47 @@
+{
+  "fields": [
+    {
+      "name": "shortName",
+      "type": "faker.name.firstName",
+      "nullable": false
+    }
+  ],
+  "constraints": [
+    {
+      "field": "shortName",
+      "shorterThan": 6
+    },
+    {
+      "field": "shortName",
+      "matchingRegex": "J.*"
+    }
+  ],
+  "relationships": [ {
+    "name": "mother",
+    "description": "absence of min/max indicates that it is a sub-object (one-to-one)",
+    "profile": {
+        "fields": [
+          {
+            "name": "name",
+            "type": "faker.name.firstName",
+            "nullable": false
+          },
+          {
+            "name": "age",
+            "type": "integer",
+            "nullable": false
+          }
+        ],
+        "constraints": [
+          {
+            "field": "age",
+            "greaterThanOrEqualTo": 16
+          },
+          {
+            "field": "age",
+            "lessThanOrEqualTo": 100
+          }
+        ]
+      }
+   } ]
+}

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/subfolder/dependants.profile.json
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/subfolder/dependants.profile.json
@@ -1,0 +1,28 @@
+{
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "nullable": false
+    },
+    {
+      "name": "age",
+      "type": "integer",
+      "nullable": false
+    }
+  ],
+  "constraints": [
+    {
+        "field": "name",
+        "inSet": "testfile.csv"
+    },  
+    {
+      "field": "age",
+      "greaterThanOrEqualTo": 0
+    },
+    {
+      "field": "age",
+      "lessThan": 18
+    }
+  ]
+}

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/subfolder/testfile.csv
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/relational/subfolder/testfile.csv
@@ -1,0 +1,1 @@
+Generated successfully from file

--- a/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/validator/ProfileValidationTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/datahelix/generator/orchestrator/validator/ProfileValidationTests.java
@@ -32,6 +32,7 @@ import com.scottlogic.datahelix.generator.profile.services.FieldService;
 import com.scottlogic.datahelix.generator.profile.services.NameRetrievalService;
 import com.scottlogic.datahelix.generator.profile.validators.ConfigValidator;
 import com.scottlogic.datahelix.generator.profile.validators.CreateProfileValidator;
+import com.scottlogic.datahelix.generator.profile.validators.ReadRelationshipsValidator;
 import com.scottlogic.datahelix.generator.profile.validators.profile.ProfileValidator;
 import org.junit.Assert;
 import org.junit.jupiter.api.DynamicTest;
@@ -69,7 +70,9 @@ public class ProfileValidationTests {
             new FieldService(),
             constraintService,
             customConstraintFactory,
-            new CreateProfileValidator(new ProfileValidator(null)));
+            new CreateProfileValidator(new ProfileValidator(null)),
+            new ReadRelationshipsValidator(),
+            profileDeserialiser);
 
         JsonProfileReader profileReader = new JsonProfileReader(commandBus, profileDeserialiser);
 

--- a/output/src/main/java/com/scottlogic/datahelix/generator/output/guice/OutputConfigSource.java
+++ b/output/src/main/java/com/scottlogic/datahelix/generator/output/guice/OutputConfigSource.java
@@ -16,6 +16,8 @@
 
 package com.scottlogic.datahelix.generator.output.guice;
 
+import com.scottlogic.datahelix.generator.common.output.OutputFormat;
+
 import java.nio.file.Path;
 
 public interface OutputConfigSource {

--- a/output/src/main/java/com/scottlogic/datahelix/generator/output/guice/OutputModule.java
+++ b/output/src/main/java/com/scottlogic/datahelix/generator/output/guice/OutputModule.java
@@ -18,6 +18,8 @@ package com.scottlogic.datahelix.generator.output.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
+import com.google.inject.util.Providers;
+import com.scottlogic.datahelix.generator.common.output.OutputFormat;
 import com.scottlogic.datahelix.generator.output.OutputPath;
 import com.scottlogic.datahelix.generator.output.outputtarget.SingleDatasetOutputTarget;
 import com.scottlogic.datahelix.generator.output.writer.OutputWriterFactory;
@@ -45,5 +47,8 @@ public class OutputModule extends AbstractModule {
         bind(boolean.class)
             .annotatedWith(Names.named("config:streamOutput"))
             .toInstance(outputConfigSource.useStdOut());
+
+        bind(OutputFormat.class)
+            .toProvider(Providers.of(outputConfigSource.getOutputFormat()));
     }
 }

--- a/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/csv/CsvDataSetWriterTest.java
+++ b/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/csv/CsvDataSetWriterTest.java
@@ -18,10 +18,7 @@
 package com.scottlogic.datahelix.generator.output.writer.csv;
 
 import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
-import com.scottlogic.datahelix.generator.common.profile.Field;
-import com.scottlogic.datahelix.generator.common.profile.Fields;
-import com.scottlogic.datahelix.generator.common.profile.SpecificFieldType;
-import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.profile.*;
 import com.scottlogic.datahelix.generator.output.writer.DataSetWriter;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,7 +42,7 @@ public class CsvDataSetWriterTest {
     private Field fieldOne = new Field("one", StandardSpecificFieldType.STRING.toSpecificFieldType(),false,null,false, false, null);
     private Field fieldTwo = new Field("two", StandardSpecificFieldType.STRING.toSpecificFieldType(),false,null,false, false, null);
 
-    private Fields fields = new Fields(new ArrayList<>(Arrays.asList(
+    private Fields fields = new ProfileFields(new ArrayList<>(Arrays.asList(
         fieldOne, fieldTwo
     )));
 

--- a/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/csv/CsvOutputWriterFactoryTests.java
+++ b/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/csv/CsvOutputWriterFactoryTests.java
@@ -19,6 +19,7 @@ package com.scottlogic.datahelix.generator.output.writer.csv;
 import com.scottlogic.datahelix.generator.common.profile.FieldBuilder;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.output.writer.DataSetWriter;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -98,7 +99,7 @@ class CsvOutputWriterFactoryTests {
 
     @Test
     void writeRow_withInternalFields_shouldNotWriteInternalFields() throws IOException {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("External"),
                 createInternalField("Internal")
@@ -112,7 +113,7 @@ class CsvOutputWriterFactoryTests {
     }
 
     private static Fields fields(String ...names) {
-        return new Fields(
+        return new ProfileFields(
             Arrays.stream(names)
                 .map(FieldBuilder::createField)
                 .collect(Collectors.toList()));

--- a/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
+++ b/output/src/test/java/com/scottlogic/datahelix/generator/output/writer/json/JsonOutputWriterFactoryTest.java
@@ -18,6 +18,7 @@ package com.scottlogic.datahelix.generator.output.writer.json;
 import com.scottlogic.datahelix.generator.common.output.GeneratedObject;
 import com.scottlogic.datahelix.generator.common.profile.FieldBuilder;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.output.writer.DataSetWriter;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.when;
 class JsonOutputWriterFactoryTest {
     @Test
     void writer_whereStreamingJson__shouldOutputNewLineDelimiterRows() throws IOException {
-        Fields fields = new Fields(Collections.singletonList(FieldBuilder.createField("my_field")));
+        Fields fields = new ProfileFields(Collections.singletonList(FieldBuilder.createField("my_field")));
 
         expectJson(
             fields,
@@ -49,7 +50,7 @@ class JsonOutputWriterFactoryTest {
 
     @Test
     void writer_whereNotStreamingJson__shouldOutputRowsWrappedInAnArray() throws IOException {
-        Fields fields = new Fields(Collections.singletonList(FieldBuilder.createField("my_field")));
+        Fields fields = new ProfileFields(Collections.singletonList(FieldBuilder.createField("my_field")));
 
         expectJson(
             fields,
@@ -59,7 +60,7 @@ class JsonOutputWriterFactoryTest {
 
     @Test
     void writeRow_withInternalFields_shouldNotWriteInternalFields() throws IOException {
-        Fields fields = new Fields(
+        Fields fields = new ProfileFields(
             Arrays.asList(
                 createField("External"),
                 createInternalField("Internal")

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/commands/ReadRelationships.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/commands/ReadRelationships.java
@@ -17,19 +17,21 @@
 package com.scottlogic.datahelix.generator.profile.commands;
 
 import com.scottlogic.datahelix.generator.common.commands.Command;
-import com.scottlogic.datahelix.generator.core.profile.Profile;
-import com.scottlogic.datahelix.generator.profile.dtos.RelationalProfileDTO;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+import com.scottlogic.datahelix.generator.profile.dtos.RelationshipDTO;
 
 import java.nio.file.Path;
+import java.util.List;
 
-public class CreateProfile extends Command<Profile>
-{
-    public final RelationalProfileDTO profileDTO;
+public class ReadRelationships extends Command<List<Relationship>> {
+    public final Fields fields;
+    public final List<RelationshipDTO> relationships;
     public final Path profileDirectory;
 
-    public CreateProfile(Path profileDirectory, RelationalProfileDTO profileDTO)
-    {
+    public ReadRelationships(Path profileDirectory, Fields fields, List<RelationshipDTO> relationships) {
         this.profileDirectory = profileDirectory;
-        this.profileDTO = profileDTO;
+        this.fields = fields;
+        this.relationships = relationships;
     }
 }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/dtos/RelationalProfileDTO.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/dtos/RelationalProfileDTO.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.scottlogic.datahelix.generator.common.output;
+package com.scottlogic.datahelix.generator.profile.dtos;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
+import java.util.List;
 
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+public class RelationalProfileDTO extends ProfileDTO {
+    public List<RelationshipDTO> relationships;
 }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/dtos/RelationshipDTO.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/dtos/RelationshipDTO.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package com.scottlogic.datahelix.generator.common.output;
+package com.scottlogic.datahelix.generator.profile.dtos;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.ConstraintDTO;
 
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+import java.util.List;
+
+public class RelationshipDTO {
+    public String name;
+    public String description;
+    public String profileFile;
+    public RelationalProfileDTO profile;
+    public List<ConstraintDTO> extents;
 }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/guice/ProfileModule.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/guice/ProfileModule.java
@@ -23,8 +23,10 @@ import com.google.inject.name.Names;
 import com.scottlogic.datahelix.generator.common.commands.CommandBus;
 import com.scottlogic.datahelix.generator.common.validators.Validator;
 import com.scottlogic.datahelix.generator.profile.commands.CreateProfile;
+import com.scottlogic.datahelix.generator.profile.commands.ReadRelationships;
 import com.scottlogic.datahelix.generator.profile.dtos.ProfileDTO;
 import com.scottlogic.datahelix.generator.profile.validators.CreateProfileValidator;
+import com.scottlogic.datahelix.generator.profile.validators.ReadRelationshipsValidator;
 import com.scottlogic.datahelix.generator.profile.validators.profile.ProfileValidator;
 import com.scottlogic.datahelix.generator.profile.reader.*;
 
@@ -53,6 +55,7 @@ public class ProfileModule extends AbstractModule {
 
         bind(Key.get(new TypeLiteral<Validator<ProfileDTO>>(){})).to(ProfileValidator.class);
         bind(Key.get(new TypeLiteral<Validator<CreateProfile>>(){})).to(CreateProfileValidator.class);
+        bind(Key.get(new TypeLiteral<Validator<ReadRelationships>>(){})).to(ReadRelationshipsValidator.class);
         bind(CommandBus.class).to(ProfileCommandBus.class);
     }
 }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/handlers/ReadRelationshipsHandler.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/handlers/ReadRelationshipsHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.profile.handlers;
+
+import com.google.inject.Inject;
+import com.scottlogic.datahelix.generator.common.commands.CommandHandler;
+import com.scottlogic.datahelix.generator.common.commands.CommandResult;
+import com.scottlogic.datahelix.generator.common.validators.Validator;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+import com.scottlogic.datahelix.generator.profile.commands.ReadRelationships;
+import com.scottlogic.datahelix.generator.profile.services.RelationshipService;
+
+import java.util.List;
+
+public class ReadRelationshipsHandler extends CommandHandler<ReadRelationships, List<Relationship>> {
+    private final RelationshipService relationshipService;
+
+    @Inject
+    public ReadRelationshipsHandler(
+        RelationshipService relationshipService,
+        Validator<ReadRelationships> validator) {
+        super(validator);
+        this.relationshipService = relationshipService;
+    }
+
+    @Override
+    public CommandResult<List<Relationship>> handleCommand(ReadRelationships command) {
+        return CommandResult.success(relationshipService.createRelationships(command.profileDirectory, command.fields, command.relationships));
+    }
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReader.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReader.java
@@ -22,7 +22,7 @@ import com.scottlogic.datahelix.generator.common.commands.CommandBus;
 import com.scottlogic.datahelix.generator.common.commands.CommandResult;
 import com.scottlogic.datahelix.generator.core.profile.Profile;
 import com.scottlogic.datahelix.generator.profile.commands.CreateProfile;
-import com.scottlogic.datahelix.generator.profile.dtos.ProfileDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.RelationalProfileDTO;
 import com.scottlogic.datahelix.generator.profile.serialisation.ProfileDeserialiser;
 
 import java.io.File;
@@ -53,11 +53,11 @@ public class JsonProfileReader implements ProfileReader {
     }
 
     public Profile read(Path profileDirectory, String profileJson) {
-        ProfileDTO profileDTO = profileDeserialiser.deserialise(profileDirectory, profileJson);
+        RelationalProfileDTO profileDTO = profileDeserialiser.deserialise(profileDirectory, profileJson);
         return createFromDto(profileDirectory, profileDTO);
     }
 
-    private Profile createFromDto(Path profileDirectory, ProfileDTO profileDTO) {
+    private Profile createFromDto(Path profileDirectory, RelationalProfileDTO profileDTO) {
         CommandResult<Profile> createProfileResult = commandBus.send(new CreateProfile(profileDirectory, profileDTO));
 
         if (!createProfileResult.isSuccess){

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/ProfileCommandBus.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/reader/ProfileCommandBus.java
@@ -19,10 +19,14 @@ import com.google.inject.Inject;
 import com.scottlogic.datahelix.generator.common.commands.CommandBus;
 import com.scottlogic.datahelix.generator.common.validators.Validator;
 import com.scottlogic.datahelix.generator.profile.commands.CreateProfile;
+import com.scottlogic.datahelix.generator.profile.commands.ReadRelationships;
 import com.scottlogic.datahelix.generator.profile.custom.CustomConstraintFactory;
 import com.scottlogic.datahelix.generator.profile.handlers.CreateProfileHandler;
+import com.scottlogic.datahelix.generator.profile.handlers.ReadRelationshipsHandler;
+import com.scottlogic.datahelix.generator.profile.serialisation.ProfileDeserialiser;
 import com.scottlogic.datahelix.generator.profile.services.ConstraintService;
 import com.scottlogic.datahelix.generator.profile.services.FieldService;
+import com.scottlogic.datahelix.generator.profile.services.RelationshipService;
 
 public class ProfileCommandBus extends CommandBus
 {
@@ -31,7 +35,9 @@ public class ProfileCommandBus extends CommandBus
         FieldService fieldService,
         ConstraintService constraintService,
         CustomConstraintFactory customConstraintFactory,
-        Validator<CreateProfile> validator)
+        Validator<CreateProfile> validator,
+        Validator<ReadRelationships> relationshipValidator,
+        ProfileDeserialiser profileDeserialiser)
     {
         register(
             CreateProfile.class,
@@ -39,6 +45,16 @@ public class ProfileCommandBus extends CommandBus
                 fieldService,
                 constraintService,
                 customConstraintFactory,
-                validator));
+                validator,
+                this));
+
+        register(
+            ReadRelationships.class,
+            new ReadRelationshipsHandler(
+                new RelationshipService(
+                    this,
+                    constraintService,
+                    profileDeserialiser),
+                relationshipValidator));
     }
 }

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/serialisation/ProfileDeserialiser.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/serialisation/ProfileDeserialiser.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.Inject;
 import com.scottlogic.datahelix.generator.common.ValidationException;
-import com.scottlogic.datahelix.generator.profile.dtos.ProfileDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.RelationalProfileDTO;
 import com.scottlogic.datahelix.generator.profile.dtos.constraints.ConstraintDTO;
 import com.scottlogic.datahelix.generator.profile.validators.ConfigValidator;
 
@@ -44,14 +44,14 @@ public class ProfileDeserialiser
         this.constraintDeserializerFactory = constraintDeserializerFactory;
     }
 
-    public ProfileDTO deserialise(File profileFile) throws IOException {
+    public RelationalProfileDTO deserialise(File profileFile) throws IOException {
         configValidator.validate(profileFile);
         byte[] encoded = Files.readAllBytes(profileFile.toPath());
         String profileJson = new String(encoded, StandardCharsets.UTF_8);
         return deserialise(profileFile.getParentFile().toPath(), profileJson);
     }
 
-    public ProfileDTO deserialise(Path profileDirectory, String json) {
+    public RelationalProfileDTO deserialise(Path profileDirectory, String json) {
         if (profileDirectory == null) {
             throw new IllegalArgumentException("profileDirectory must be supplied");
         }
@@ -66,7 +66,7 @@ public class ProfileDeserialiser
 
         try {
             return mapper
-                .readerFor(ProfileDTO.class)
+                .readerFor(RelationalProfileDTO.class)
                 .readValue(json);
         } catch (Exception e) {
             StringWriter stackTrace = new StringWriter();

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/FieldService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/FieldService.java
@@ -16,10 +16,7 @@
 
 package com.scottlogic.datahelix.generator.profile.services;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
-import com.scottlogic.datahelix.generator.common.profile.Fields;
-import com.scottlogic.datahelix.generator.common.profile.SpecificFieldType;
-import com.scottlogic.datahelix.generator.common.profile.StandardSpecificFieldType;
+import com.scottlogic.datahelix.generator.common.profile.*;
 import com.scottlogic.datahelix.generator.profile.dtos.FieldDTO;
 import com.scottlogic.datahelix.generator.profile.dtos.ProfileDTO;
 import com.scottlogic.datahelix.generator.profile.dtos.constraints.ConstraintDTO;
@@ -39,7 +36,7 @@ public class FieldService {
     public Fields createFields(ProfileDTO dto) {
         List<Field> fields = dto.fields.stream().map(this::createRegularField).collect(Collectors.toList());
         getInMapFieldNames(dto.constraints).stream().map(this::createInMapField).forEach(fields::add);
-        return new Fields(fields);
+        return new ProfileFields(fields);
     }
 
     public SpecificFieldType specificFieldTypeFromString(String type, String formatting) {

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/RelationshipService.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/services/RelationshipService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Scott Logic Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scottlogic.datahelix.generator.profile.services;
+
+import com.google.inject.Inject;
+import com.scottlogic.datahelix.generator.common.ValidationException;
+import com.scottlogic.datahelix.generator.common.commands.CommandBus;
+import com.scottlogic.datahelix.generator.common.commands.CommandResult;
+import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.core.generation.relationships.ExtentAugmentedFields;
+import com.scottlogic.datahelix.generator.core.profile.Profile;
+import com.scottlogic.datahelix.generator.core.profile.constraints.Constraint;
+import com.scottlogic.datahelix.generator.core.profile.relationships.Relationship;
+import com.scottlogic.datahelix.generator.profile.commands.CreateProfile;
+import com.scottlogic.datahelix.generator.profile.dtos.RelationalProfileDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.RelationshipDTO;
+import com.scottlogic.datahelix.generator.profile.dtos.constraints.ConstraintDTO;
+import com.scottlogic.datahelix.generator.profile.serialisation.ProfileDeserialiser;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RelationshipService {
+    private final CommandBus commandBus;
+    private final ConstraintService constraintService;
+    private final ProfileDeserialiser profileDeserialiser;
+
+    @Inject
+    public RelationshipService(
+        CommandBus commandBus,
+        ConstraintService constraintService,
+        ProfileDeserialiser profileDeserialiser) {
+        this.commandBus = commandBus;
+        this.constraintService = constraintService;
+        this.profileDeserialiser = profileDeserialiser;
+    }
+
+    public List<Relationship> createRelationships(Path profileDirectory, Fields fields, List<RelationshipDTO> relationships) {
+        if (relationships == null) {
+            return Collections.emptyList();
+        }
+
+        return relationships.stream()
+            .map(relationshipDTO -> createRelationship(profileDirectory, fields, relationshipDTO))
+            .collect(Collectors.toList());
+    }
+
+    private Relationship createRelationship(Path profileDirectory, Fields fields, RelationshipDTO relationshipDTO) {
+        return new Relationship(
+            relationshipDTO.name,
+            relationshipDTO.description,
+            relationshipDTO.profile != null
+                ? createProfile(profileDirectory, relationshipDTO.profile)
+                : readProfile(profileDirectory, relationshipDTO.profileFile),
+            mapConstraints(fields, relationshipDTO.extents)
+        );
+    }
+
+    private List<Constraint> mapConstraints(Fields fields, List<ConstraintDTO> extents) {
+        if (extents == null || extents.isEmpty()){
+            return Collections.emptyList();
+        }
+
+        return extents
+            .stream()
+            .map(c -> createConstraint(fields, c))
+            .collect(Collectors.toList());
+    }
+
+    private Constraint createConstraint(Fields fields, ConstraintDTO extent) {
+        return constraintService.createConstraints(
+            Collections.singletonList(extent),
+            new ExtentAugmentedFields(fields)).get(0);
+    }
+
+    private Profile readProfile(Path profileDirectory, String profileFile) {
+        if (profileFile == null || profileFile.equals("")) {
+            throw new ValidationException("Relationships must have a `profile` (sub profile) or a `profileFile` (file path) property populated");
+        }
+
+        //read file from disk.
+        File file = Paths.get(profileDirectory.toString(), profileFile).toFile();
+        try {
+            RelationalProfileDTO profileDTO = profileDeserialiser.deserialise(file);
+            return createProfile(profileDirectory, profileDTO);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Profile createProfile(Path profileDirectory, RelationalProfileDTO profile) {
+        CommandResult<Profile> createProfileResult = commandBus.send(new CreateProfile(profileDirectory, profile));
+        if (!createProfileResult.isSuccess){
+            throw new ValidationException(createProfileResult.errors);
+        }
+        return createProfileResult.value;
+    }
+}

--- a/profile/src/main/java/com/scottlogic/datahelix/generator/profile/validators/ReadRelationshipsValidator.java
+++ b/profile/src/main/java/com/scottlogic/datahelix/generator/profile/validators/ReadRelationshipsValidator.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package com.scottlogic.datahelix.generator.common.output;
+package com.scottlogic.datahelix.generator.profile.validators;
 
-import com.scottlogic.datahelix.generator.common.profile.Field;
+import com.scottlogic.datahelix.generator.common.validators.ValidationResult;
+import com.scottlogic.datahelix.generator.common.validators.Validator;
+import com.scottlogic.datahelix.generator.profile.commands.ReadRelationships;
 
-/** A set of values representing one complete, discrete output (eg, this could be used to make a full CSV row) */
-public interface GeneratedObject {
-    Object getFormattedValue(Field field);
-    Object getValue(Field field);
+public class ReadRelationshipsValidator implements Validator<ReadRelationships>
+{
+    @Override
+    public ValidationResult validate(ReadRelationships obj) {
+        return ValidationResult.success();
+    }
 }

--- a/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReaderTests.java
+++ b/profile/src/test/java/com/scottlogic/datahelix/generator/profile/reader/JsonProfileReaderTests.java
@@ -40,6 +40,7 @@ import com.scottlogic.datahelix.generator.profile.services.FieldService;
 import com.scottlogic.datahelix.generator.profile.services.NameRetrievalService;
 import com.scottlogic.datahelix.generator.profile.validators.ConfigValidator;
 import com.scottlogic.datahelix.generator.profile.validators.CreateProfileValidator;
+import com.scottlogic.datahelix.generator.profile.validators.ReadRelationshipsValidator;
 import com.scottlogic.datahelix.generator.profile.validators.profile.ProfileValidator;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
@@ -97,9 +98,11 @@ public class JsonProfileReaderTests {
         new ProfileCommandBus(
             new FieldService(),
             constraintService,
-            new CustomConstraintFactory(new CustomGeneratorList()),
+                new CustomConstraintFactory(new CustomGeneratorList()),
             new CreateProfileValidator(
-                new ProfileValidator(null))),
+                new ProfileValidator(null)),
+            new ReadRelationshipsValidator(),
+            profileDeserialiser),
         profileDeserialiser);
 
     private void givenJson(String json) {


### PR DESCRIPTION
### Description
This pull request introduces the capability to produce relational data for the JSON output format.

### Changes
- Changes to components to allow better composition of components
- Changes to permit infinite data generation
- Extension to profile format to support relational data - backward compatible
- Production of relational data as JSON output for:
  - One to one relationships (nested objects)
  - One to many relationships (nested arrays) with conditional min and max extents
- Streamed JSON output (to console) and to a file
- Not performance tested
- Not every scenario tested (hence being left as a beta feature)
- Not every change/component has automated tests
- Documentation produced but not actively linked due to the beta feature status

### Additional notes
This is considered to be a beta feature to prove and provide the capability of relational data construction within DataHelix. Only a few scenarios have been considered, more scenarios **could** require a fundamental change to the implementation and **could** require a change to the profile format. That said every attempt has been made to ensure the profile format is sufficiently abstract from the implementation to reduce the chance of it requiring a change.

### Issue
Related to #841
Related to #1534