### PR TITLE
chore(#1696): fix id on output table

### DIFF
--- a/playground/index.js
+++ b/playground/index.js
@@ -97,7 +97,7 @@ runButton.addEventListener("click", () => {
       const table = "<thead><tr>" + mapToElements(columns, "th") + "</tr></thead>" +
         "<tbody>" + mapToElements(rows, "tr", row => mapToElements(row, "td")) + "</tbody>";
 
-      generatorOutputPanel.innerHTML = `<table id=output" class="table table-striped table-bordered">${table}</table>`;
+      generatorOutputPanel.innerHTML = `<table id="output" class="table table-striped table-bordered">${table}</table>`;
     })
     .catch(() => {
       showAlert("There was a problem in reaching the DataHelix API endpoint");


### PR DESCRIPTION
### Description
Fix the html table id for selecting with selenium - was rendering as `output"`, now `output`

### Changes
Changed the playground output table id

### Additional notes
Will be a seperate PR to add the selenium tests into master

### Issue
Related to #1696
