### PR TITLE
chore: Remove unused travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-script: mvn clean test


### PR DESCRIPTION
### Changes
Removes an unused file for Travis CI (we use circle CI on the datahelix).
