### PR TITLE
#1704/#1705 weighted decision selection

### DIFF
--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/constraints/atomic/NotEqualToConstraint.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/profile/constraints/atomic/NotEqualToConstraint.java
@@ -48,7 +48,7 @@ public class NotEqualToConstraint implements AtomicConstraint {
 
     @Override
     public String toString(){
-        return String.format("`%s` = %s", field.getName(), value);
+        return String.format("`%s` != %s", field.getName(), value);
     }
 
     @Override

--- a/core/src/main/java/com/scottlogic/datahelix/generator/core/walker/rowspec/RowSpecDecisionTreeWalker.java
+++ b/core/src/main/java/com/scottlogic/datahelix/generator/core/walker/rowspec/RowSpecDecisionTreeWalker.java
@@ -16,6 +16,7 @@
 package com.scottlogic.datahelix.generator.core.walker.rowspec;
 
 import com.google.inject.Inject;
+import com.scottlogic.datahelix.generator.common.distribution.WeightedElement;
 import com.scottlogic.datahelix.generator.common.util.FlatMappingSpliterator;
 import com.scottlogic.datahelix.generator.core.decisiontree.DecisionTree;
 import com.scottlogic.datahelix.generator.core.generation.databags.DataBag;
@@ -38,7 +39,7 @@ public class RowSpecDecisionTreeWalker implements DecisionTreeWalker {
     @Override
     public Stream<DataBag> walk(DecisionTree tree) {
         return FlatMappingSpliterator.flatMap(
-            rowSpecTreeSolver.createRowSpecs(tree),
+            rowSpecTreeSolver.createRowSpecs(tree).map(WeightedElement::element),
             rowSpecDataBagGenerator::createDataBags);
     }
 }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/builders/TestAtomicConstraintBuilder.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/builders/TestAtomicConstraintBuilder.java
@@ -26,6 +26,7 @@ import com.scottlogic.datahelix.generator.core.profile.constraints.atomic.IsNull
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TestAtomicConstraintBuilder {
     private TestConstraintNodeBuilder testConstraintNodeBuilder;
@@ -52,6 +53,14 @@ public class TestAtomicConstraintBuilder {
         InSetConstraint inSetConstraint = new InSetConstraint(
             field,
             inSetRecordsFrom(legalValues));
+        testConstraintNodeBuilder.constraints.add(inSetConstraint);
+        return testConstraintNodeBuilder;
+    }
+
+    public TestConstraintNodeBuilder isInSet(InSetRecord... weightedValues) {
+        InSetConstraint inSetConstraint = new InSetConstraint(
+            field,
+            Stream.of(weightedValues).collect(Collectors.toList()));
         testConstraintNodeBuilder.constraints.add(inSetConstraint);
         return testConstraintNodeBuilder;
     }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/decisiontree/RowSpecTreeSolverTests.java
@@ -16,6 +16,7 @@
 
 package com.scottlogic.datahelix.generator.core.decisiontree;
 
+import com.scottlogic.datahelix.generator.common.distribution.WeightedElement;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
 import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
@@ -32,7 +33,6 @@ import com.scottlogic.datahelix.generator.core.reducer.ConstraintReducer;
 import com.scottlogic.datahelix.generator.core.walker.decisionbased.RowSpecTreeSolver;
 import com.scottlogic.datahelix.generator.core.walker.decisionbased.SequentialOptionPicker;
 import com.scottlogic.datahelix.generator.core.walker.pruner.TreePruner;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
 
 class RowSpecTreeSolverTests {
     private final FieldSpecMerger fieldSpecMerger = new FieldSpecMerger();
@@ -115,9 +116,10 @@ class RowSpecTreeSolverTests {
 
         final List<RowSpec> rowSpecs = dTreeWalker
             .createRowSpecs(merged)
+            .map(WeightedElement::element)
             .collect(Collectors.toList());
 
-        Assert.assertThat(rowSpecs, notNullValue());
+        assertThat(rowSpecs, notNullValue());
     }
 
 }

--- a/core/src/test/java/com/scottlogic/datahelix/generator/core/walker/decisionbased/RowSpecTreeSolverTests.java
+++ b/core/src/test/java/com/scottlogic/datahelix/generator/core/walker/decisionbased/RowSpecTreeSolverTests.java
@@ -15,8 +15,11 @@
  */
 package com.scottlogic.datahelix.generator.core.walker.decisionbased;
 
+import com.scottlogic.datahelix.generator.common.distribution.DistributedList;
+import com.scottlogic.datahelix.generator.common.distribution.WeightedElement;
 import com.scottlogic.datahelix.generator.common.profile.Field;
 import com.scottlogic.datahelix.generator.common.profile.Fields;
+import com.scottlogic.datahelix.generator.common.profile.InSetRecord;
 import com.scottlogic.datahelix.generator.common.profile.ProfileFields;
 import com.scottlogic.datahelix.generator.core.builders.TestConstraintNodeBuilder;
 import com.scottlogic.datahelix.generator.core.decisiontree.ConstraintNode;
@@ -33,6 +36,7 @@ import java.util.stream.Stream;
 import static com.scottlogic.datahelix.generator.common.profile.FieldBuilder.createField;
 import static com.shazam.shazamcrest.MatcherAssert.assertThat;
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+import static org.hamcrest.core.Is.is;
 
 class RowSpecTreeSolverTests {
     private Field fieldA = createField("A");
@@ -51,7 +55,7 @@ class RowSpecTreeSolverTests {
         DecisionTree tree = new DecisionTree(root, fields);
 
         //Act
-        Stream<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree);
+        Stream<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree);
 
         //Assert
         List<RowSpec> expectedRowSpecs = new ArrayList<>();
@@ -60,7 +64,9 @@ class RowSpecTreeSolverTests {
         fieldToFieldSpec.put(fieldB, FieldSpecFactory.fromType(fieldB.getType()));
         expectedRowSpecs.add(new RowSpec(fields, fieldToFieldSpec, Collections.emptyList()));
 
-        assertThat(expectedRowSpecs, sameBeanAs(rowSpecs.collect(Collectors.toList())));
+        assertThat(
+            expectedRowSpecs,
+            sameBeanAs(rowSpecs.map(WeightedElement::element).collect(Collectors.toList())));
     }
 
     @Test
@@ -70,7 +76,7 @@ class RowSpecTreeSolverTests {
         DecisionTree tree = new DecisionTree(root, fields);
 
         //Act
-        Stream<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree);
+        Stream<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree);
 
         //Assert
         List<RowSpec> expectedRowSpecs = new ArrayList<>();
@@ -79,7 +85,9 @@ class RowSpecTreeSolverTests {
         fieldToFieldSpec.put(fieldB, FieldSpecFactory.fromType(fieldB.getType()));
         expectedRowSpecs.add(new RowSpec(fields, fieldToFieldSpec, Collections.emptyList()));
 
-        assertThat(rowSpecs.collect(Collectors.toList()), sameBeanAs(expectedRowSpecs));
+        assertThat(
+            rowSpecs.map(WeightedElement::element).collect(Collectors.toList()),
+            sameBeanAs(expectedRowSpecs));
     }
 
     @Test
@@ -95,7 +103,7 @@ class RowSpecTreeSolverTests {
         DecisionTree tree = new DecisionTree(root, fields);
 
         //Act
-        Set<RowSpec> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
+        Set<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
 
         //Assert
         Set<RowSpec> expectedRowSpecs = new HashSet<>();
@@ -108,6 +116,138 @@ class RowSpecTreeSolverTests {
         option1.put(fieldB, FieldSpecFactory.fromLegalValuesList(Arrays.asList("1","2","3")));
         expectedRowSpecs.add(new RowSpec(fields, option1, Collections.emptyList()));
 
-        assertThat(rowSpecs, sameBeanAs(expectedRowSpecs));
+        assertThat(
+            rowSpecs.stream().map(WeightedElement::element).collect(Collectors.toSet()),
+            sameBeanAs(expectedRowSpecs));
+    }
+
+    @Test
+    void createRowSpecs_whenRootNodeHasSomeWeightedDecisions_returnsCorrectlyWeightedRowSpecs() {
+        //Arrange
+        ConstraintNode root = TestConstraintNodeBuilder.constraintNode()
+            .where(fieldB).isInSet(
+                new InSetRecord("1", 0.25d),
+                new InSetRecord("2", 0.75d))
+            .withDecision(
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("1"),
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("2"))
+            .build();
+        DecisionTree tree = new DecisionTree(root, fields);
+
+        //Act
+        Set<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
+
+        //Assert
+        Set<WeightedElement<RowSpec>> expectedRowSpecs = new HashSet<>();
+        Map<Field, FieldSpec> option0 = new HashMap<>();
+        option0.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option0.put(fieldB, FieldSpecFactory.fromList(distributedListOfOneItem("1", 0.25)));
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option0, Collections.emptyList()), 0.25));
+        Map<Field, FieldSpec> option1 = new HashMap<>();
+        option1.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option1.put(fieldB, FieldSpecFactory.fromList(distributedListOfOneItem("2", 0.75)));
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option1, Collections.emptyList()), 0.75));
+
+        assertThat(
+            rowSpecs,
+            sameBeanAs(expectedRowSpecs));
+    }
+
+    @Test
+    void createRowSpecs_whenRootNodeHasSomeWeightedDecisionsAndAllValuesAreExcluded_returnsCorrectlyWeightedRowSpecs() {
+        //Arrange
+        ConstraintNode root = TestConstraintNodeBuilder.constraintNode()
+            .where(fieldB).isInSet(
+                new InSetRecord("1", 0.25d),
+                new InSetRecord("2", 0.75d))
+            .withDecision(
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("3"),
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("4"))
+            .build();
+        DecisionTree tree = new DecisionTree(root, fields);
+
+        //Act
+        Set<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
+
+        //Assert
+        assertThat(
+            rowSpecs.isEmpty(),
+            is(true));
+    }
+
+    @Test
+    void createRowSpecs_whenRootNodeHasUnweightedDecisionsAndAllValuesAreAllowed_returnsCorrectlyWeightedRowSpecs() {
+        //Arrange
+        ConstraintNode root = TestConstraintNodeBuilder.constraintNode()
+            .where(fieldB).isInSet("1", "2")
+            .withDecision(
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("1", "2", "3"),
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("1", "2", "4"))
+            .build();
+        DecisionTree tree = new DecisionTree(root, fields);
+
+        //Act
+        Set<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
+
+        //Assert
+        Set<WeightedElement<RowSpec>> expectedRowSpecs = new HashSet<>();
+        Map<Field, FieldSpec> option0 = new HashMap<>();
+        option0.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option0.put(fieldB, FieldSpecFactory.fromLegalValuesList(Arrays.asList("1", "2")));
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option0, Collections.emptyList()), 1));
+        Map<Field, FieldSpec> option1 = new HashMap<>();
+        option1.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option1.put(fieldB, FieldSpecFactory.fromLegalValuesList(Arrays.asList("1", "2")));
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option1, Collections.emptyList()), 1));
+
+        assertThat(
+            rowSpecs,
+            sameBeanAs(expectedRowSpecs));
+    }
+
+    @Test
+    void createRowSpecs_whenRootNodeHasNoWeightedDecisions_returnsCorrectlyWeightedRowSpecs() {
+        //Arrange
+        ConstraintNode root = TestConstraintNodeBuilder.constraintNode()
+            .where(fieldB).isNotNull()
+            .withDecision(
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("1"),
+                TestConstraintNodeBuilder.constraintNode()
+                    .where(fieldB).isInSet("2"))
+            .build();
+        DecisionTree tree = new DecisionTree(root, fields);
+
+        //Act
+        Set<WeightedElement<RowSpec>> rowSpecs = rowSpecTreeSolver.createRowSpecs(tree).collect(Collectors.toSet());
+
+        //Assert
+        Set<WeightedElement<RowSpec>> expectedRowSpecs = new HashSet<>();
+        Map<Field, FieldSpec> option0 = new HashMap<>();
+        option0.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option0.put(fieldB, FieldSpecFactory.fromLegalValuesList(Collections.singletonList("1")).withNotNull());
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option0, Collections.emptyList()), 1));
+        Map<Field, FieldSpec> option1 = new HashMap<>();
+        option1.put(fieldA, FieldSpecFactory.fromType(fieldA.getType()));
+        option1.put(fieldB, FieldSpecFactory.fromLegalValuesList(Collections.singletonList("2")).withNotNull());
+        expectedRowSpecs.add(new WeightedElement<>(new RowSpec(fields, option1, Collections.emptyList()), 1));
+
+        assertThat(
+            rowSpecs,
+            sameBeanAs(expectedRowSpecs));
+    }
+
+    private static <T> DistributedList<T> distributedListOfOneItem(T item, double weight)
+    {
+        ArrayList<WeightedElement<T>> list = new ArrayList<>();
+        list.add(new WeightedElement<>(item, weight));
+
+        return new DistributedList<>(list);
     }
 }


### PR DESCRIPTION
### Description
When a profile contains a decision (if constraint) which refers to weighted set values, currently the generator doesn't take the weightings into account.

### Changes
- Update the decision selection logic to apportion a weighting to each branch of a decision
- Use this weighting when randomly selecting a value for the decision, so that values are projected as per their weightings

### Additional notes

### Issue
Resolves #1704
Resolves #1705 
