### PR TITLE
Update gradle-wrapper distribution url to match configured version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Aug 27 14:51:34 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-rc-1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description
Local builds of the project with a fresh install of IntelliJ fail as the gradle wrapper version doesn't match that of the expected version of gradle (running as part of the build). As such the project cannot be built locally.

### Changes
Update the gradle wrapper distribution version to v7 (latest)

### Issue
Resolves #1726 
Relates to #1722